### PR TITLE
Remove unused 'pending' order status

### DIFF
--- a/app/helpers/admin/bake_days_helper.rb
+++ b/app/helpers/admin/bake_days_helper.rb
@@ -8,7 +8,6 @@ module Admin::BakeDaysHelper
 
   def status_pill_classes(status)
     {
-      "pending" => "bg-yellow-100 text-yellow-800",
       "unpaid" => "bg-orange-100 text-orange-800",
       "paid" => "bg-blue-100 text-blue-800",
       "ready" => "bg-emerald-100 text-emerald-800",

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,6 @@
 module ApplicationHelper
   def order_status_label(status)
     labels = {
-      "pending" => "En attente",
       "unpaid" => "Non payée",
       "paid" => "Payée",
       "ready" => "Prête",

--- a/app/javascript/controllers/order_modal_controller.js
+++ b/app/javascript/controllers/order_modal_controller.js
@@ -125,7 +125,7 @@ export default class extends Controller {
 
     // Déterminer la couleur du statut
     const statusColors = {
-      'pending': 'bg-yellow-100 text-yellow-800',
+      'unpaid': 'bg-orange-100 text-orange-800',
       'paid': 'bg-blue-100 text-blue-800',
       'ready': 'bg-green-100 text-green-800',
       'picked_up': 'bg-gray-100 text-gray-800',
@@ -134,7 +134,6 @@ export default class extends Controller {
     }
 
     const statusLabels = {
-      'pending': 'En attente',
       'unpaid': 'Non payée',
       'paid': 'Payée',
       'ready': 'Prête',

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,6 +1,5 @@
 class Order < ApplicationRecord
   enum :status, {
-    pending: 0,
     paid: 1,
     ready: 2,
     picked_up: 3,
@@ -47,8 +46,6 @@ class Order < ApplicationRecord
 
   def can_transition_to?(new_status)
     case status.to_sym
-    when :pending
-      new_status.to_sym == :paid
     when :paid, :unpaid
       [:ready, :cancelled].include?(new_status.to_sym)
     when :ready

--- a/app/presenters/admin/bake_day_dashboard.rb
+++ b/app/presenters/admin/bake_day_dashboard.rb
@@ -85,7 +85,7 @@ module Admin
         items_count: order_items.sum(&:qty),
         revenue_cents: total_cents,
         variants_count: variant_stats.size,
-        open_orders: orders.count { |order| order.pending? || order.unpaid? },
+        open_orders: orders.count { |order| order.unpaid? },
         ready_orders: orders.count { |order| order.ready? || order.picked_up? }
       }
     end

--- a/app/services/order_creation_service.rb
+++ b/app/services/order_creation_service.rb
@@ -13,7 +13,7 @@ class OrderCreationService
   def call
     return false unless valid?
 
-    initial_status = @payment_method == 'cash' ? :unpaid : :pending
+    initial_status = @payment_method == 'cash' ? :unpaid : :paid
 
     @order = Order.create!(
       customer: @customer,

--- a/app/views/admin/bake_days/show.html.slim
+++ b/app/views/admin/bake_days/show.html.slim
@@ -274,7 +274,7 @@
           .flex.flex-wrap.items-center.gap-2(data-filter-group)
             button.rounded-full.border.border-indigo-600.bg-indigo-600.px-3.py-1.5.text-xs.font-semibold.text-white type="button" data-filter="all" data-action="dashboard-filter#change"
               | Toutes
-            - ['pending', 'unpaid', 'paid', 'ready', 'picked_up', 'cancelled', 'no_show'].each do |order_status|
+            - ['unpaid', 'paid', 'ready', 'picked_up', 'cancelled', 'no_show'].each do |order_status|
               button.rounded-full.border.border-slate-300.px-3.py-1.5.text-md.font-semibold.text-slate-600.hover:border-indigo-300.hover:text-indigo-600 type="button" data-filter=order_status data-action="dashboard-filter#change"
                 = order_status_label(order_status)
           .divide-y.divide-slate-100.overflow-hidden.rounded-2xl.border.border-slate-100

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -127,13 +127,12 @@
               <td class="px-6 py-4 whitespace-nowrap">
                 <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
                   <%= case order.status
-                      when 'pending' then 'bg-yellow-100 text-yellow-800'
+                      when 'unpaid' then 'bg-orange-100 text-orange-800'
                       when 'paid' then 'bg-blue-100 text-blue-800'
                       when 'ready' then 'bg-green-100 text-green-800'
                       when 'picked_up' then 'bg-gray-100 text-gray-800'
                       when 'no_show' then 'bg-red-100 text-red-800'
                       when 'cancelled' then 'bg-red-100 text-red-800'
-                      when 'unpaid' then 'bg-orange-100 text-orange-800'
                       else 'bg-gray-100 text-gray-800'
                       end %>">
                   <%= order_status_label(order.status) %>

--- a/app/views/admin/orders/edit.html.erb
+++ b/app/views/admin/orders/edit.html.erb
@@ -160,7 +160,6 @@
           <legend class="block text-sm font-medium text-gray-700">Statut de la commande</legend>
           <div class="mt-2 grid grid-cols-2 gap-3">
             <% status_options = {
-              pending: "En attente",
               unpaid: "Non payée",
               paid: "Payée",
               ready: "Prête",

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -22,7 +22,7 @@
         <%= form_with url: admin_orders_path, method: :get, local: true, class: "flex space-x-2" do |f| %>
           <%= f.select :status, options_for_select([
             ['Tous', ''],
-            ['En attente', 'pending'],
+            ['Non payées', 'unpaid'],
             ['Payées', 'paid'],
             ['Prêtes', 'ready'],
             ['Récupérées', 'picked_up'],
@@ -69,7 +69,7 @@
           <td class="px-6 py-4 whitespace-nowrap">
             <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
               <%= case order.status
-                  when 'pending' then 'bg-yellow-100 text-yellow-800'
+                  when 'unpaid' then 'bg-orange-100 text-orange-800'
                   when 'paid' then 'bg-blue-100 text-blue-800'
                   when 'ready' then 'bg-green-100 text-green-800'
                   when 'picked_up' then 'bg-gray-100 text-gray-800'

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -16,7 +16,7 @@
         <dd class="mt-1">
           <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
             <%= case @order.status
-                when 'pending' then 'bg-yellow-100 text-yellow-800'
+                when 'unpaid' then 'bg-orange-100 text-orange-800'
                 when 'paid' then 'bg-blue-100 text-blue-800'
                 when 'ready' then 'bg-green-100 text-green-800'
                 when 'picked_up' then 'bg-gray-100 text-gray-800'

--- a/app/views/customers/account/show.html.erb
+++ b/app/views/customers/account/show.html.erb
@@ -70,7 +70,7 @@
                   <p class="font-medium text-gray-900"><%= number_to_currency(order.total_euros, unit: "€", separator: ",", delimiter: "") %></p>
                   <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
                     <%= case order.status
-                        when 'pending' then 'bg-yellow-100 text-yellow-800'
+                        when 'unpaid' then 'bg-orange-100 text-orange-800'
                         when 'paid' then 'bg-blue-100 text-blue-800'
                         when 'ready' then 'bg-green-100 text-green-800'
                         when 'picked_up' then 'bg-gray-100 text-gray-800'

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -13,7 +13,7 @@
       <h2 class="text-lg font-medium text-gray-900 mb-4">Statut</h2>
       <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium
         <%= case @order.status
-            when 'pending' then 'bg-yellow-100 text-yellow-800'
+            when 'unpaid' then 'bg-orange-100 text-orange-800'
             when 'paid' then 'bg-blue-100 text-blue-800'
             when 'ready' then 'bg-green-100 text-green-800'
             when 'picked_up' then 'bg-gray-100 text-gray-800'

--- a/prd.md
+++ b/prd.md
@@ -106,7 +106,7 @@ Tranches de Vie is a single-tenant web application for one artisan bakery that b
 - bake_days(id, baked_on date unique, cut_off_at timestamptz)
 - customers(id, phone_e164 unique, first_name, last_name nullable, email nullable)
 - phone_verifications(id, phone_e164, code, expires_at)
-- orders(id, customer_id FK, bake_day_id FK, status enum[pending,paid,ready,picked_up,no_show,cancelled], total_cents, public_token unique)
+- orders(id, customer_id FK, bake_day_id FK, status enum[unpaid,paid,ready,picked_up,no_show,cancelled], total_cents, public_token unique)
 - order_items(id, order_id FK, product_variant_id FK, qty int, unit_price_cents)
 - payments(id, order_id FK unique, stripe_payment_intent_id unique, status enum[succeeded,failed,refunded])
 - sms_messages(id, direction enum[outbound,inbound], to_e164, from_e164, baked_on nullable, body, kind enum[confirmation,ready,refund,other], external_id)
@@ -134,11 +134,12 @@ Tranches de Vie is a single-tenant web application for one artisan bakery that b
 
 # 6. Status Transitions (allowed)
 
-- `pending` → `paid` (successful Stripe webhook)
-- `paid` → `ready` (admin action) → sends “ready” SMS
+- `unpaid` → `ready` (admin action) → sends "ready" SMS
+- `paid` → `ready` (admin action) → sends "ready" SMS
 - `ready` → `picked_up` (admin action)
 - `ready` → `no_show` (admin action)
-- `paid` → `cancelled` (full refund before cut‑off) → sends “refund” SMS
+- `unpaid` → `cancelled` (admin action before cut‑off)
+- `paid` → `cancelled` (full refund before cut‑off) → sends "refund" SMS
 - Forbidden: reverse transitions except manual admin correction via console (out of UI flow)
 
 # 7. Refund (before cut‑off)


### PR DESCRIPTION
The 'pending' status was not being used in practice. Orders now start
with 'paid' (for online payments) or 'unpaid' (for cash payments).

Changes:
- Remove 'pending' from Order enum and status transitions
- Update all views, helpers, and JavaScript to remove 'pending' references
- Update OrderCreationService to use 'paid' instead of 'pending'
- Update BakeDayDashboard open_orders counter
- Update prd.md documentation