### PR TITLE
Security: Protect Mission Control Jobs + Remove Telerivet webhook

### DIFF
--- a/config/initializers/mission_control.rb
+++ b/config/initializers/mission_control.rb
@@ -1,0 +1,12 @@
+# Mission Control Jobs configuration
+# Protect the admin interface with HTTP Basic Auth
+
+Rails.application.config.after_initialize do
+  MissionControl::Jobs.http_basic_auth_enabled = true
+  MissionControl::Jobs.http_basic_auth_user = ENV.fetch('ADMIN_USER', 'admin')
+  MissionControl::Jobs.http_basic_auth_password = ENV['ADMIN_PASSWORD']
+
+  if Rails.env.production? && ENV['ADMIN_PASSWORD'].blank?
+    Rails.logger.warn "⚠️  ADMIN_PASSWORD is not set. Mission Control Jobs will be inaccessible."
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,6 @@ Rails.application.routes.draw do
 
   # Webhooks
   post "/webhooks/stripe", to: "webhooks#stripe"
-  post "/webhooks/telerivet", to: "webhooks#telerivet"
 
   # Admin routes
   namespace :admin do


### PR DESCRIPTION
## Changements

### 🔐 Protection Mission Control Jobs
- Ajout de HTTP Basic Auth sur `/admin/jobs`
- Utilise les variables d'environnement `ADMIN_USER` et `ADMIN_PASSWORD`
- Empêche l'accès non autorisé à la gestion des jobs

### 🗑️ Suppression webhook Telerivet
- Suppression de la route `POST /webhooks/telerivet`
- Suppression de l'action `telerivet` du WebhooksController
- Ce webhook n'était plus utilisé et représentait une surface d'attaque

## Déploiement
Après merge, s'assurer que `ADMIN_PASSWORD` est défini en production (déjà utilisé pour l'auth admin existante).