### PR TITLE
claude/accounting-github-issues-zGlHW

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -95,7 +95,7 @@ class Admin::CustomersController < Admin::BaseController
   end
 
   def customer_params
-    permitted = params.require(:customer).permit(:first_name, :last_name, :phone_e164, :email, :sms_opt_out, :skip_wallet_check, group_ids: [])
+    permitted = params.require(:customer).permit(:first_name, :last_name, :phone_e164, :email, :sms_opt_out, :skip_wallet_check, :billable, group_ids: [])
     # Convertir les chaînes vides en nil pour phone_e164
     permitted[:phone_e164] = nil if permitted[:phone_e164].blank?
     permitted

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -89,7 +89,7 @@ class Admin::OrdersController < Admin::BaseController
     @selected_quantities = normalize_variant_quantities(raw_quantities)
     @final_total_input = permitted_params.delete(:final_total_euros)
 
-    @order = Order.new(permitted_params)
+    @order = Order.new(permitted_params.merge(source: :admin))
     subtotal_cents = calculate_total_from_quantities(@selected_quantities)
     
     # Calculer la remise si un client est sélectionné

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,4 +13,14 @@ module ApplicationHelper
 
     labels[status.to_s] || status.to_s.tr("_", " ").capitalize
   end
+
+  def order_source_label(source)
+    labels = {
+      "checkout" => "Client (en ligne)",
+      "calendar" => "Client (calendrier)",
+      "admin" => "Admin"
+    }
+
+    labels[source.to_s] || source.to_s.capitalize
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -10,7 +10,7 @@ class Order < ApplicationRecord
     planned: 7
   }
 
-  enum :source, { checkout: 0, calendar: 1 }
+  enum :source, { checkout: 0, calendar: 1, admin: 2 }
 
   belongs_to :customer
   belongs_to :bake_day
@@ -56,8 +56,10 @@ class Order < ApplicationRecord
       new_status.to_sym == :paid
     when :planned
       [:paid, :cancelled].include?(new_status.to_sym)
-    when :paid, :unpaid
+    when :paid
       [:ready, :cancelled].include?(new_status.to_sym)
+    when :unpaid
+      [:paid, :ready, :cancelled].include?(new_status.to_sym)
     when :ready
       [:picked_up, :no_show].include?(new_status.to_sym)
     else

--- a/app/views/admin/bake_days/show.html.slim
+++ b/app/views/admin/bake_days/show.html.slim
@@ -76,7 +76,7 @@
   - kpi_cards = [ \
       { label: "Commandes confirmées", value: kpis[:orders_count], meta: "#{pluralize(kpis[:open_orders], 'commande')} en attente" },
       { label: "Articles à produire", value: kpis[:items_count], meta: "Total des unités à préparer" },
-      { label: "Revenus attendus", value: number_to_currency(kpis[:revenue_cents] / 100.0, unit: '€', separator: ',', delimiter: ' '), meta: "Montant TTC prévu" },
+      { label: "Chiffre d'affaires", value: number_to_currency(kpis[:revenue_cents] / 100.0, unit: '€', separator: ',', delimiter: ' '), meta: "Montant TTC" },
       { label: "Variantes concernées", value: kpis[:variants_count], meta: "Produits à vérifier en stock" } \
     ]
 

--- a/app/views/admin/customers/edit.html.erb
+++ b/app/views/admin/customers/edit.html.erb
@@ -79,6 +79,14 @@
 
     <div class="mt-6">
       <div class="flex items-center">
+        <%= f.check_box :billable, class: "h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded" %>
+        <%= f.label :billable, "Facturable", class: "ml-2 block text-sm text-gray-900" %>
+      </div>
+      <p class="mt-1 text-sm text-gray-500">Cochez pour les points de dépôt et clients pro qui reçoivent une facture mensuelle.</p>
+    </div>
+
+    <div class="mt-6">
+      <div class="flex items-center">
         <%= f.check_box :skip_wallet_check, class: "h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded" %>
         <%= f.label :skip_wallet_check, "Client interne (pas de vérification de solde)", class: "ml-2 block text-sm text-gray-900" %>
       </div>

--- a/app/views/admin/customers/new.html.erb
+++ b/app/views/admin/customers/new.html.erb
@@ -71,6 +71,14 @@
 
     <div class="mt-6">
       <div class="flex items-center">
+        <%= f.check_box :billable, class: "h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded" %>
+        <%= f.label :billable, "Facturable", class: "ml-2 block text-sm text-gray-900" %>
+      </div>
+      <p class="mt-1 text-sm text-gray-500">Cochez pour les points de dépôt et clients pro qui reçoivent une facture mensuelle.</p>
+    </div>
+
+    <div class="mt-6">
+      <div class="flex items-center">
         <%= f.check_box :skip_wallet_check, class: "h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded" %>
         <%= f.label :skip_wallet_check, "Client interne (pas de vérification de solde)", class: "ml-2 block text-sm text-gray-900" %>
       </div>

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -63,6 +63,17 @@
         <dd class="mt-1 text-sm text-gray-900"><%= @customer.created_at.strftime("%d/%m/%Y à %H:%M") %></dd>
       </div>
 
+      <% if @customer.billable? %>
+        <div>
+          <dt class="text-sm font-medium text-gray-500">Facturation</dt>
+          <dd class="mt-1">
+            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800">
+              Facturable
+            </span>
+          </dd>
+        </div>
+      <% end %>
+
       <div>
         <dt class="text-sm font-medium text-gray-500">Groupes</dt>
         <dd class="mt-1 text-sm text-gray-900">

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -30,6 +30,11 @@
       </div>
 
       <div>
+        <dt class="text-sm font-medium text-gray-500">Origine</dt>
+        <dd class="mt-1 text-sm text-gray-900"><%= order_source_label(@order.source) %></dd>
+      </div>
+
+      <div>
         <dt class="text-sm font-medium text-gray-500">Client</dt>
         <dd class="mt-1 text-sm text-gray-900"><%= link_to @order.customer.full_name, admin_customer_path(@order.customer), class: "text-blue-600 hover:text-blue-800 hover:underline" %></dd>
         <% if @order.customer.phone_e164.present? %>
@@ -59,10 +64,19 @@
     <h2 class="text-lg font-medium text-gray-900 mb-4">Actions</h2>
 
     <div class="space-y-3">
+      <% if @order.unpaid? && @order.can_transition_to?(:paid) %>
+        <%= form_with url: update_status_admin_order_path(@order), method: :patch, local: true do |f| %>
+          <%= f.hidden_field :status, value: :paid %>
+          <%= f.submit "Marquer comme payée",
+              class: "w-full px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700",
+              data: { confirm: "Marquer cette commande comme payée ?" } %>
+        <% end %>
+      <% end %>
+
       <% if @order.can_transition_to?(:ready) %>
         <%= form_with url: update_status_admin_order_path(@order), method: :patch, local: true do |f| %>
           <%= f.hidden_field :status, value: :ready %>
-          <%= f.submit "Marquer comme prête", 
+          <%= f.submit "Marquer comme prête",
               class: "w-full px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700",
               data: { confirm: "Envoyer le SMS 'prête' au client ?" } %>
         <% end %>

--- a/db/migrate/20260416120000_add_billable_to_customers.rb
+++ b/db/migrate/20260416120000_add_billable_to_customers.rb
@@ -1,0 +1,5 @@
+class AddBillableToCustomers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :customers, :billable, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_27_071748) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_16_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -97,6 +97,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_27_071748) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "skip_wallet_check", default: false, null: false
+    t.boolean "billable", default: false, null: false
     t.index ["phone_e164"], name: "index_customers_on_phone_e164", unique: true, where: "(phone_e164 IS NOT NULL)"
   end
 


### PR DESCRIPTION
- Renommer "Revenus attendus" → "Chiffre d'affaires" dans le dashboard
- Ajouter source `admin` (enum) aux commandes, auto-assignée via le panel admin
- Afficher l'origine de la commande (client en ligne / calendrier / admin)
- Permettre la transition unpaid → paid pour marquer les commandes comme payées
- Ajouter le bouton "Marquer comme payée" dans la vue admin
- Ajouter le champ `billable` (facturable) aux clients avec checkbox admin
- Afficher le badge "Facturable" sur la fiche client

Closes #39, closes #40, closes #42, closes #55

https://claude.ai/code/session_01QnGvUA9ybYu1ukwQfDpQLt