### PR TITLE
Connexion par OTP e-mail + e-mails transactionnels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,17 @@ Key env vars (set in `.env` for dev, managed via Hatchbox for production):
 - `SMSTOOLS_*` (SMS API credentials)
 - `SENTRY_DSN`
 - `SLACK_WEBHOOK_URL` (recurring job notifications)
+- `SES_SMTP_USERNAME`, `SES_SMTP_PASSWORD` (Amazon SES SMTP credentials for outbound email)
+- `SES_REGION` (SES region, defaults to `eu-west-1`)
+- `MAIL_FROM` (sender address, defaults to `boulangerie@les4sources.be`)
+- `APP_HOST` (production host for links in emails — unsubscribe, order pages)
+
+## Email (Amazon SES)
+
+- **Delivery**: SMTP via SES (`config/environments/production.rb`); `:letter_opener` in dev (opens in browser), `:test` in test.
+- **Mailers**: `AuthMailer#otp` (login code, always sent), `OrderMailer#confirmation` (order paid), `RawMailer#resend` (admin verbatim resend).
+- **Logging**: every outbound email is recorded as an `EmailMessage` via an `after_action` in `ApplicationMailer` → `EmailMessageLogger` (reads `X-Customer-Id`/`X-Email-Kind`/`X-Order-Id` headers set by mailers).
+- **Opt-out**: `Customer#email_enabled?` gates non-OTP emails (`email_opt_out` flag). Unsubscribe link uses a signed token (`signed_id(purpose: :email_unsubscribe)`) → public `EmailPreferencesController`. OTP emails ignore opt-out.
 
 ## Conventions
 

--- a/Gemfile
+++ b/Gemfile
@@ -98,4 +98,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+
+  # Preview outgoing emails in the browser instead of sending them
+  gem "letter_opener"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
     crack (1.0.1)
@@ -183,6 +185,12 @@ GEM
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -496,6 +504,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  letter_opener
   mission_control-jobs
   pg (~> 1.1)
   propshaft

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -29,6 +29,7 @@ class Admin::CustomersController < Admin::BaseController
   def show
     @orders = @customer.orders.includes(:bake_day).order(created_at: :desc)
     @sms_messages = @customer.sms_messages.ordered_by_sent_at
+    @email_messages = @customer.email_messages.ordered_by_sent_at
   end
 
   def new
@@ -95,7 +96,7 @@ class Admin::CustomersController < Admin::BaseController
   end
 
   def customer_params
-    permitted = params.require(:customer).permit(:first_name, :last_name, :phone_e164, :email, :sms_opt_out, :skip_wallet_check, :billable, group_ids: [])
+    permitted = params.require(:customer).permit(:first_name, :last_name, :phone_e164, :email, :sms_opt_out, :email_opt_out, :skip_wallet_check, :billable, group_ids: [])
     # Convertir les chaînes vides en nil pour phone_e164
     permitted[:phone_e164] = nil if permitted[:phone_e164].blank?
     permitted

--- a/app/controllers/admin/email_messages_controller.rb
+++ b/app/controllers/admin/email_messages_controller.rb
@@ -1,0 +1,40 @@
+class Admin::EmailMessagesController < Admin::BaseController
+  before_action :set_customer
+  before_action :set_email_message
+
+  def show
+    render json: {
+      id: @email_message.id,
+      subject: @email_message.subject,
+      to_email: @email_message.to_email,
+      from_email: @email_message.from_email,
+      kind: @email_message.kind,
+      sent_at: (@email_message.sent_at || @email_message.created_at).strftime("%d/%m/%Y à %H:%M"),
+      body_html: @email_message.body_html
+    }
+  end
+
+  def resend
+    if @email_message.to_email.blank?
+      render json: { success: false, error: "Adresse e-mail manquante" }, status: :unprocessable_entity
+      return
+    end
+
+    RawMailer.resend(@email_message).deliver_now
+    render json: { success: true, message: "E-mail renvoyé avec succès" }
+  rescue StandardError => e
+    Rails.logger.error("Error resending email: #{e.message}")
+    Sentry.capture_exception(e) if defined?(Sentry)
+    render json: { success: false, error: "Erreur lors du renvoi de l'e-mail" }, status: :unprocessable_entity
+  end
+
+  private
+
+  def set_customer
+    @customer = Customer.find(params[:customer_id])
+  end
+
+  def set_email_message
+    @email_message = @customer.email_messages.find(params[:id])
+  end
+end

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -33,6 +33,21 @@ class CheckoutController < ApplicationController
       return
     end
 
+    if params[:channel] == 'email'
+      result = OtpService.send_otp(phone_e164, channel: :email, email: params[:email], allow_email_entry: true)
+
+      if result[:success]
+        session[:phone_e164] = phone_e164
+        session[:email] = result[:email]
+        render json: { success: true, message: 'Code envoyé par e-mail à ' + Time.current.strftime('%H:%M') }
+      elsif result[:need_email]
+        render json: { success: false, need_email: true, error: result[:error] }, status: :unprocessable_entity
+      else
+        render json: { success: false, error: result[:error] }, status: :unprocessable_entity
+      end
+      return
+    end
+
     result = OtpService.send_otp(phone_e164)
 
     if result[:success]

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -238,6 +238,9 @@ class CheckoutController < ApplicationController
       return
     end
 
+    # Send order confirmation email (idempotent via EmailMessage guard)
+    OrderNotificationService.send_confirmation(order)
+
     # Clear cart and session data
     session[:cart] = []
     session[:bake_day_id] = nil
@@ -580,10 +583,14 @@ class CheckoutController < ApplicationController
       end
 
       # Create payment record
-      Payment.find_or_create_by!(order: order) do |payment|
-        payment.stripe_payment_intent_id = payment_intent_id
-        payment.status = :succeeded
+      payment = Payment.find_or_create_by!(order: order) do |p|
+        p.stripe_payment_intent_id = payment_intent_id
+        p.status = :succeeded
       end
+
+      # Send confirmation email only when the payment is first recorded here
+      # (idempotent across the webhook / success-page race).
+      OrderNotificationService.send_confirmation(order) if payment.previously_new_record?
     end
 
     order

--- a/app/controllers/customers/account_controller.rb
+++ b/app/controllers/customers/account_controller.rb
@@ -42,7 +42,7 @@ class Customers::AccountController < ApplicationController
   private
 
   def customer_params
-    params.require(:customer).permit(:first_name, :last_name, :phone_e164, :email, :sms_opt_out)
+    params.require(:customer).permit(:first_name, :last_name, :phone_e164, :email, :sms_opt_out, :email_opt_out)
   end
 end
 

--- a/app/controllers/customers/sessions_controller.rb
+++ b/app/controllers/customers/sessions_controller.rb
@@ -32,12 +32,14 @@ class Customers::SessionsController < ApplicationController
         render :new, status: :unprocessable_entity
       end
     else
-      # Envoyer le code OTP
-      result = OtpService.send_otp(phone_e164)
+      # Envoyer le code OTP (par SMS, ou par e-mail en secours)
+      channel = params[:channel] == 'email' ? :email : :sms
+      result = OtpService.send_otp(phone_e164, channel: channel)
 
       if result[:success]
         session[:phone_e164] = phone_e164
-        flash.now[:notice] = "Code envoyé par SMS à #{Time.current.strftime('%H:%M')}"
+        sent_time = Time.current.strftime('%H:%M')
+        flash.now[:notice] = channel == :email ? "Code envoyé par e-mail à #{sent_time}" : "Code envoyé par SMS à #{sent_time}"
         @phone_e164 = phone_e164
         render :new
       else

--- a/app/controllers/email_preferences_controller.rb
+++ b/app/controllers/email_preferences_controller.rb
@@ -1,0 +1,30 @@
+# Public email-preferences page reachable from the footer link of non-OTP
+# emails. Identified by a signed token (no login required).
+class EmailPreferencesController < ApplicationController
+  def show
+    @customer = find_customer
+    redirect_to root_path, alert: "Ce lien n'est plus valide." unless @customer
+  end
+
+  def update
+    @customer = find_customer
+    return redirect_to(root_path, alert: "Ce lien n'est plus valide.") unless @customer
+
+    opt_out = ActiveModel::Type::Boolean.new.cast(params[:email_opt_out])
+    @customer.update(email_opt_out: opt_out)
+
+    notice =
+      if @customer.email_opt_out?
+        "Tu ne recevras plus d'e-mails de notre part (hors codes de connexion)."
+      else
+        "C'est noté, tu es réabonné·e à nos e-mails."
+      end
+    redirect_to email_preferences_path(token: params[:token]), notice: notice
+  end
+
+  private
+
+  def find_customer
+    Customer.find_signed(params[:token], purpose: :email_unsubscribe)
+  end
+end

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -150,10 +150,14 @@ class WebhooksController < ApplicationController
       end
 
       # Create payment record
-      Payment.find_or_create_by!(order: order) do |payment|
-        payment.stripe_payment_intent_id = payment_intent_id
-        payment.status = :succeeded
+      payment = Payment.find_or_create_by!(order: order) do |p|
+        p.stripe_payment_intent_id = payment_intent_id
+        p.status = :succeeded
       end
+
+      # Send confirmation email only when the payment is first recorded here
+      # (idempotent across the webhook / success-page race).
+      OrderNotificationService.send_confirmation(order) if payment.previously_new_record?
 
       Rails.logger.info("Order #{order.id} payment record ensured")
       return true

--- a/app/javascript/controllers/checkout_controller.js
+++ b/app/javascript/controllers/checkout_controller.js
@@ -49,6 +49,64 @@ export default class extends Controller {
     }
   }
 
+  async sendOTPByEmail(event) {
+    event.preventDefault()
+
+    const phone = document.getElementById('customer_phone_e164')?.value
+    if (!phone) {
+      this.showMessage('Veuillez entrer un numéro de GSM', 'error')
+      return
+    }
+
+    const email = document.getElementById('otp_email')?.value || ''
+
+    const btn = document.getElementById('send-otp-email-btn')
+    const originalText = btn ? btn.textContent : null
+    let revealedEmail = false
+    if (btn) {
+      btn.disabled = true
+      btn.textContent = 'Envoi...'
+    }
+
+    try {
+      const response = await fetch('/checkout/verify_phone', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+        },
+        body: JSON.stringify({ phone_e164: phone, channel: 'email', email: email })
+      })
+
+      const data = await response.json()
+
+      if (data.success) {
+        const otpSection = document.getElementById('otp-input-section')
+        if (otpSection) {
+          otpSection.classList.remove('hidden')
+        }
+        this.showMessage(data.message || 'Code envoyé par e-mail', 'success')
+      } else if (data.need_email) {
+        const emailFields = document.getElementById('email-otp-fields')
+        if (emailFields) {
+          emailFields.classList.remove('hidden')
+        }
+        document.getElementById('otp_email')?.focus()
+        revealedEmail = true
+        this.showMessage(data.error || "Saisis l'adresse e-mail où recevoir ton code.", 'error')
+      } else {
+        this.showMessage(data.error || "Erreur lors de l'envoi de l'e-mail", 'error')
+      }
+    } catch (error) {
+      this.showMessage('Erreur de connexion', 'error')
+    } finally {
+      if (btn) {
+        btn.disabled = false
+        btn.textContent = revealedEmail ? 'Envoyer le code par e-mail' : originalText
+      }
+    }
+  }
+
   async verifyOTP(event) {
     event.preventDefault()
 

--- a/app/javascript/controllers/customer_session_controller.js
+++ b/app/javascript/controllers/customer_session_controller.js
@@ -68,6 +68,59 @@ export default class extends Controller {
     }
   }
 
+  async sendOTPByEmail(event) {
+    event.preventDefault()
+
+    const phone = this.phoneInputTarget?.value
+    if (!phone) {
+      this.showMessage('Veuillez entrer un numéro de GSM', 'error')
+      return
+    }
+
+    const btn = document.getElementById('send-otp-email-btn')
+    const originalText = btn ? btn.textContent : null
+    if (btn) {
+      btn.disabled = true
+      btn.textContent = 'Envoi en cours…'
+    }
+
+    try {
+      const formData = new FormData()
+      formData.append('phone_e164', phone)
+      formData.append('channel', 'email')
+
+      const response = await fetch('/connexion', {
+        method: 'POST',
+        headers: {
+          'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+        },
+        body: formData
+      })
+
+      const html = await response.text()
+      const doc = new DOMParser().parseFromString(html, 'text/html')
+      const notice = doc.querySelector('.bg-green-50')?.textContent.trim()
+      const alert = doc.querySelector('.bg-red-50')?.textContent.trim()
+
+      if (response.ok) {
+        const otpSection = document.getElementById('otp-input-section')
+        if (otpSection) {
+          otpSection.classList.remove('hidden')
+        }
+        this.showMessage(notice || 'Code envoyé par e-mail', 'success')
+      } else {
+        this.showMessage(alert || "Erreur lors de l'envoi de l'e-mail", 'error')
+      }
+    } catch (error) {
+      this.showMessage('Erreur de connexion', 'error')
+    } finally {
+      if (btn) {
+        btn.disabled = false
+        btn.textContent = originalText
+      }
+    }
+  }
+
   async verifyOTP(event) {
     event.preventDefault()
 

--- a/app/javascript/controllers/email_modal_controller.js
+++ b/app/javascript/controllers/email_modal_controller.js
@@ -1,0 +1,95 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["modal", "overlay", "recipient", "date", "subject", "body", "error", "resendButton"]
+
+  open(event) {
+    event.preventDefault()
+    event.stopPropagation()
+
+    this.resendUrl = event.currentTarget.dataset.resendUrl
+    const showUrl = event.currentTarget.dataset.showUrl
+
+    this.hideError()
+    this.openModal()
+
+    fetch(showUrl, { headers: { "Accept": "application/json" } })
+      .then((response) => response.json())
+      .then((data) => {
+        this.recipientTarget.textContent = data.to_email || ""
+        this.dateTarget.textContent = data.sent_at || ""
+        this.subjectTarget.textContent = data.subject || "(sans objet)"
+        this.bodyTarget.srcdoc = data.body_html || ""
+      })
+      .catch(() => this.showError("Impossible de charger l'e-mail"))
+  }
+
+  async resend(event) {
+    event.preventDefault()
+    if (!this.resendUrl) return
+
+    const button = this.resendButtonTarget
+    const originalText = button.textContent
+    button.disabled = true
+    button.textContent = "Envoi…"
+
+    try {
+      const response = await fetch(this.resendUrl, {
+        method: "POST",
+        headers: {
+          "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content,
+          "Accept": "application/json"
+        }
+      })
+      const data = await response.json()
+
+      if (data.success) {
+        this.close()
+        window.location.reload()
+      } else {
+        this.showError(data.error || "Erreur lors du renvoi de l'e-mail")
+        button.disabled = false
+        button.textContent = originalText
+      }
+    } catch (error) {
+      this.showError("Erreur de connexion")
+      button.disabled = false
+      button.textContent = originalText
+    }
+  }
+
+  openModal() {
+    this.modalTarget.classList.remove("hidden")
+    document.body.style.overflow = "hidden"
+  }
+
+  close() {
+    this.modalTarget.classList.add("hidden")
+    document.body.style.overflow = ""
+  }
+
+  closeBackground(event) {
+    if (event.target === this.overlayTarget) {
+      this.close()
+    }
+  }
+
+  closeWithEscape(event) {
+    if (event.key === "Escape") {
+      this.close()
+    }
+  }
+
+  showError(message) {
+    if (this.hasErrorTarget) {
+      this.errorTarget.querySelector("p").textContent = message
+      this.errorTarget.classList.remove("hidden")
+    }
+  }
+
+  hideError() {
+    if (this.hasErrorTarget) {
+      this.errorTarget.classList.add("hidden")
+    }
+  }
+}

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,13 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: ENV.fetch("MAIL_FROM", "boulangerie@les4sources.be")
   layout "mailer"
+
+  after_action :log_email
+
+  private
+
+  # Journalise chaque e-mail sortant dans EmailMessage (cf. EmailMessageLogger).
+  def log_email
+    EmailMessageLogger.record(message)
+  end
 end

--- a/app/mailers/auth_mailer.rb
+++ b/app/mailers/auth_mailer.rb
@@ -1,0 +1,13 @@
+class AuthMailer < ApplicationMailer
+  # OTP login code delivered by email (fallback when SMS is not received).
+  # OTP emails are always sent and never carry an unsubscribe link.
+  def otp(customer, code)
+    @customer = customer
+    @code = code
+
+    headers["X-Customer-Id"] = customer.id
+    headers["X-Email-Kind"] = "otp"
+
+    mail(to: customer.email, subject: "Ton code de connexion — Tranches de Vie")
+  end
+end

--- a/app/mailers/auth_mailer.rb
+++ b/app/mailers/auth_mailer.rb
@@ -1,13 +1,14 @@
 class AuthMailer < ApplicationMailer
   # OTP login code delivered by email (fallback when SMS is not received).
   # OTP emails are always sent and never carry an unsubscribe link.
-  def otp(customer, code)
+  # `email` is the recipient; `customer` is optional (nil for an unregistered phone).
+  def otp(email, code, customer: nil)
     @customer = customer
     @code = code
 
-    headers["X-Customer-Id"] = customer.id
+    headers["X-Customer-Id"] = customer.id if customer
     headers["X-Email-Kind"] = "otp"
 
-    mail(to: customer.email, subject: "Ton code de connexion — Tranches de Vie")
+    mail(to: email, subject: "Ton code de connexion — Tranches de Vie")
   end
 end

--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -1,0 +1,17 @@
+class OrderMailer < ApplicationMailer
+  # Order confirmation email, sent once an order is paid (non-OTP → carries an
+  # unsubscribe link in the footer).
+  def confirmation(order)
+    @order = order
+    @customer = order.customer
+    @items = order.order_items.includes(product_variant: :product)
+    @order_url = order_url(@order.public_token)
+    @unsubscribe_url = email_preferences_url(token: @customer.signed_id(purpose: :email_unsubscribe))
+
+    headers["X-Customer-Id"] = @customer.id
+    headers["X-Email-Kind"] = "confirmation"
+    headers["X-Order-Id"] = @order.id
+
+    mail(to: @customer.email, subject: "Confirmation de ta commande #{@order.order_number}")
+  end
+end

--- a/app/mailers/raw_mailer.rb
+++ b/app/mailers/raw_mailer.rb
@@ -1,0 +1,17 @@
+class RawMailer < ApplicationMailer
+  # Re-delivers a previously logged email verbatim (admin "Renvoyer").
+  # The stored body_html already contains the full layout, so we send it as a
+  # single text/html part without re-applying the mailer layout.
+  def resend(email_message)
+    headers["X-Customer-Id"] = email_message.customer_id if email_message.customer_id
+    headers["X-Email-Kind"] = email_message.kind
+    headers["X-Order-Id"] = email_message.order_id if email_message.order_id
+
+    mail(
+      to: email_message.to_email,
+      subject: email_message.subject,
+      content_type: "text/html",
+      body: email_message.body_html
+    )
+  end
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -3,7 +3,6 @@ class Customer < ApplicationRecord
   has_many :groups, through: :customer_groups
   has_one :wallet, dependent: :destroy
   has_many :orders, dependent: :restrict_with_error
-  has_many :phone_verifications, dependent: :destroy
   has_many :sms_messages, dependent: :nullify
   has_many :email_messages, dependent: :nullify
 

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -5,6 +5,7 @@ class Customer < ApplicationRecord
   has_many :orders, dependent: :restrict_with_error
   has_many :phone_verifications, dependent: :destroy
   has_many :sms_messages, dependent: :nullify
+  has_many :email_messages, dependent: :nullify
 
   # Attribut virtuel pour permettre de sauter la validation du téléphone (utilisé par l'admin)
   attr_accessor :skip_phone_validation
@@ -14,9 +15,16 @@ class Customer < ApplicationRecord
   validates :phone_e164, format: { with: /\A\+[1-9]\d{1,14}\z/, message: 'must be in E.164 format' }, if: -> { phone_e164.present? }
 
   scope :with_sms_enabled, -> { where(sms_opt_out: false) }
+  scope :with_email_enabled, -> { where.not(email: [nil, ""]).where(email_opt_out: false) }
 
   def sms_enabled?
     phone_e164.present? && !sms_opt_out?
+  end
+
+  # Whether non-OTP emails (e.g. order confirmations) may be sent to this customer.
+  # OTP emails are always allowed and bypass this check.
+  def email_enabled?
+    email.present? && !email_opt_out?
   end
 
   def full_name
@@ -47,6 +55,14 @@ class Customer < ApplicationRecord
 
   def opt_in_sms!
     update!(sms_opt_out: false)
+  end
+
+  def opt_out_email!
+    update!(email_opt_out: true)
+  end
+
+  def opt_in_email!
+    update!(email_opt_out: false)
   end
 end
 

--- a/app/models/email_message.rb
+++ b/app/models/email_message.rb
@@ -1,0 +1,25 @@
+class EmailMessage < ApplicationRecord
+  enum :direction, {
+    outbound: 0,
+    inbound: 1
+  }
+
+  enum :kind, {
+    confirmation: 0,
+    otp: 1,
+    other: 2
+  }
+
+  belongs_to :customer, optional: true
+  belongs_to :order, optional: true
+
+  validates :to_email, presence: true
+  validates :from_email, presence: true
+  validates :body_html, presence: true
+  validates :direction, presence: true
+  validates :kind, presence: true
+
+  scope :recent, -> { order(created_at: :desc) }
+  scope :for_customer, ->(customer) { where(customer_id: customer.id) }
+  scope :ordered_by_sent_at, -> { order(sent_at: :desc, created_at: :desc) }
+end

--- a/app/models/phone_verification.rb
+++ b/app/models/phone_verification.rb
@@ -1,5 +1,5 @@
 class PhoneVerification < ApplicationRecord
-  OTP_TTL = 5.minutes
+  OTP_TTL = 15.minutes
   MAX_ATTEMPTS = 5
   COOLDOWN_PERIOD = 20.seconds
 

--- a/app/services/email_message_logger.rb
+++ b/app/services/email_message_logger.rb
@@ -1,0 +1,40 @@
+# Records every outbound email into the EmailMessage table so the admin can
+# review (and resend) what was sent to a customer — mirror of how OtpService /
+# SmsService log SmsMessage records.
+#
+# Mailers attach metadata via custom headers (set before calling `mail`):
+#   X-Customer-Id, X-Email-Kind (confirmation/otp/other), X-Order-Id
+class EmailMessageLogger
+  def self.record(mail)
+    return if mail.nil?
+
+    EmailMessage.create!(
+      direction: :outbound,
+      to_email: Array(mail.to).first,
+      from_email: Array(mail.from).first,
+      subject: mail.subject,
+      body_html: extract_html(mail),
+      kind: header_value(mail, "X-Email-Kind").presence || "other",
+      customer_id: header_value(mail, "X-Customer-Id").presence,
+      order_id: header_value(mail, "X-Order-Id").presence,
+      message_id: mail.message_id,
+      sent_at: Time.current
+    )
+  rescue StandardError => e
+    Rails.logger.error("EmailMessageLogger failed: #{e.class} - #{e.message}")
+    Sentry.capture_exception(e) if defined?(Sentry)
+    nil
+  end
+
+  def self.header_value(mail, name)
+    mail[name]&.value
+  end
+
+  def self.extract_html(mail)
+    if mail.multipart?
+      mail.html_part&.body&.decoded || mail.text_part&.body&.decoded || mail.body.decoded
+    else
+      mail.body.decoded
+    end
+  end
+end

--- a/app/services/order_notification_service.rb
+++ b/app/services/order_notification_service.rb
@@ -1,0 +1,18 @@
+# Sends the order confirmation email once an order is paid.
+#
+# Idempotent: safe to call from every path that confirms an order (Stripe
+# webhook, checkout success page, cash order). Skips customers without an email
+# or who opted out of non-OTP emails.
+class OrderNotificationService
+  def self.send_confirmation(order)
+    return false unless order&.customer&.email_enabled?
+    return false if EmailMessage.exists?(order_id: order.id, kind: :confirmation)
+
+    OrderMailer.confirmation(order).deliver_later
+    true
+  rescue StandardError => e
+    Rails.logger.error("OrderNotificationService error: #{e.class} - #{e.message}")
+    Sentry.capture_exception(e) if defined?(Sentry)
+    false
+  end
+end

--- a/app/services/otp_service.rb
+++ b/app/services/otp_service.rb
@@ -5,10 +5,12 @@ class OtpService
   #   channel: :sms (default) — primary channel via Smstools
   #           :email          — fallback channel via AuthMailer (only when an
   #                             email address is already on file for this phone)
-  def self.send_otp(phone_e164, channel: :sms)
+  def self.send_otp(phone_e164, channel: :sms, email: nil, allow_email_entry: false)
     return { success: false, error: 'Phone number required' } if phone_e164.blank?
 
-    return send_otp_via_email(phone_e164) if channel.to_sym == :email
+    if channel.to_sym == :email
+      return send_otp_via_email(phone_e164, email: email, allow_email_entry: allow_email_entry)
+    end
 
     # Check cooldown
     unless PhoneVerification.can_send_new?(phone_e164)
@@ -40,17 +42,31 @@ class OtpService
     { success: false, error: 'Une erreur est survenue' }
   end
 
-  # Email fallback: reuse the current active code if one exists (so it matches a
-  # code already requested by SMS), otherwise generate a new one.
-  def self.send_otp_via_email(phone_e164)
+  # Email fallback. Determines the recipient according to the agreed rules:
+  #   - existing account WITH an email on file -> always sent to that address
+  #     (a typed address is ignored, so a code can never be redirected)
+  #   - existing account WITHOUT an email      -> not eligible (contact the bakery)
+  #   - unregistered phone                     -> a typed address is accepted,
+  #     but only when allow_email_entry is true (checkout flow)
+  # Reuses the current active code if one exists (so it matches a code already
+  # requested by SMS), otherwise generates a new one.
+  def self.send_otp_via_email(phone_e164, email: nil, allow_email_entry: false)
     customer = Customer.find_by(phone_e164: phone_e164)
 
-    if customer.nil? || customer.email.blank?
-      return {
-        success: false,
-        error: "Aucune adresse e-mail n'est associée à ce numéro. Contacte-nous à boulangerie@les4sources.be."
-      }
-    end
+    target_email =
+      if customer
+        if customer.email.blank?
+          return { success: false, error: no_email_on_file_error }
+        end
+
+        customer.email
+      else
+        return { success: false, error: no_email_on_file_error } unless allow_email_entry
+        return { success: false, need_email: true, error: "Saisis l'adresse e-mail où recevoir ton code." } if email.blank?
+        return { success: false, need_email: true, error: "Cette adresse e-mail semble invalide." } unless email.match?(URI::MailTo::EMAIL_REGEXP)
+
+        email
+      end
 
     verification = PhoneVerification.for_phone(phone_e164).active.order(created_at: :desc).first
 
@@ -61,13 +77,17 @@ class OtpService
       verification = PhoneVerification.create_for_phone(phone_e164)
     end
 
-    AuthMailer.otp(customer, verification.code).deliver_now
+    AuthMailer.otp(target_email, verification.code, customer: customer).deliver_now
 
-    { success: true, verification_id: verification.id, channel: :email }
+    { success: true, verification_id: verification.id, channel: :email, email: target_email }
   rescue StandardError => e
     Rails.logger.error("OTP Email Error: #{e.class} - #{e.message}")
     Sentry.capture_exception(e) if defined?(Sentry)
     { success: false, error: "Erreur lors de l'envoi de l'e-mail. Veuillez réessayer." }
+  end
+
+  def self.no_email_on_file_error
+    "Aucune adresse e-mail n'est associée à ce numéro. Contacte-nous à boulangerie@les4sources.be."
   end
 
   def self.verify_otp(phone_e164, code)

--- a/app/services/otp_service.rb
+++ b/app/services/otp_service.rb
@@ -116,6 +116,13 @@ class OtpService
   private
 
   def self.send_otp_sms(to:, body:, customer_id: nil)
+    # En développement, on n'envoie jamais de vrai SMS : on journalise le
+    # message (code inclus) pour tester le flux OTP en local. Aucun effet en prod.
+    if Rails.env.development?
+      Rails.logger.warn("OTP Service - SMS non envoyé en développement. To: #{to} | Message: #{body}")
+      return true
+    end
+
     unless client_id.present? && client_secret.present? && sender.present?
       Rails.logger.error("OTP Service - Missing configuration: client_id=#{client_id.present?}, client_secret=#{client_secret.present?}, sender=#{sender.present?}")
       return false

--- a/app/services/otp_service.rb
+++ b/app/services/otp_service.rb
@@ -1,8 +1,14 @@
 class OtpService
   SMSTOOLS_API_URL = 'https://api.smsgatewayapi.com/v1/message/send'
 
-  def self.send_otp(phone_e164)
+  # Sends a login OTP to the customer.
+  #   channel: :sms (default) — primary channel via Smstools
+  #           :email          — fallback channel via AuthMailer (only when an
+  #                             email address is already on file for this phone)
+  def self.send_otp(phone_e164, channel: :sms)
     return { success: false, error: 'Phone number required' } if phone_e164.blank?
+
+    return send_otp_via_email(phone_e164) if channel.to_sym == :email
 
     # Check cooldown
     unless PhoneVerification.can_send_new?(phone_e164)
@@ -32,6 +38,36 @@ class OtpService
     Rails.logger.error("OTP Service Error: #{e.message}")
     Sentry.capture_exception(e) if defined?(Sentry)
     { success: false, error: 'Une erreur est survenue' }
+  end
+
+  # Email fallback: reuse the current active code if one exists (so it matches a
+  # code already requested by SMS), otherwise generate a new one.
+  def self.send_otp_via_email(phone_e164)
+    customer = Customer.find_by(phone_e164: phone_e164)
+
+    if customer.nil? || customer.email.blank?
+      return {
+        success: false,
+        error: "Aucune adresse e-mail n'est associée à ce numéro. Contacte-nous à boulangerie@les4sources.be."
+      }
+    end
+
+    verification = PhoneVerification.for_phone(phone_e164).active.order(created_at: :desc).first
+
+    if verification.nil?
+      unless PhoneVerification.can_send_new?(phone_e164)
+        return { success: false, error: 'Veuillez patienter 20 secondes avant de redemander un code' }
+      end
+      verification = PhoneVerification.create_for_phone(phone_e164)
+    end
+
+    AuthMailer.otp(customer, verification.code).deliver_now
+
+    { success: true, verification_id: verification.id, channel: :email }
+  rescue StandardError => e
+    Rails.logger.error("OTP Email Error: #{e.class} - #{e.message}")
+    Sentry.capture_exception(e) if defined?(Sentry)
+    { success: false, error: "Erreur lors de l'envoi de l'e-mail. Veuillez réessayer." }
   end
 
   def self.verify_otp(phone_e164, code)

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Mangeur - #{@customer.full_name}" %>
 <% content_for :layout, "admin" %>
 
-<div data-controller="sms-modal">
+<div data-controller="sms-modal email-modal">
 <div class="mb-6 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
   <h1 class="text-2xl font-bold text-gray-900">Mangeur : <%= @customer.full_name %></h1>
   <div class="flex space-x-3">
@@ -223,8 +223,135 @@
   <% end %>
 </div>
 
+<div class="mt-6 bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+  <h2 class="text-lg font-medium text-gray-900 mb-4">E-mails envoyés</h2>
+
+  <% if @email_messages.any? %>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date d'envoi</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Sujet</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          <% @email_messages.each do |email| %>
+            <tr>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                <%= (email.sent_at || email.created_at).strftime("%d/%m/%Y à %H:%M") %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
+                  <%= case email.kind
+                      when 'confirmation' then 'bg-blue-100 text-blue-800'
+                      when 'otp' then 'bg-purple-100 text-purple-800'
+                      else 'bg-gray-100 text-gray-800'
+                      end %>">
+                  <%= case email.kind
+                      when 'confirmation' then 'Confirmation'
+                      when 'otp' then 'OTP'
+                      else 'Autre'
+                      end %>
+                </span>
+              </td>
+              <td class="px-6 py-4 text-sm text-gray-900">
+                <%= truncate(email.subject, length: 60) %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm">
+                <button
+                  type="button"
+                  data-action="click->email-modal#open"
+                  data-show-url="<%= admin_customer_email_message_path(@customer, email, format: :json) %>"
+                  data-resend-url="<%= resend_admin_customer_email_message_path(@customer, email) %>"
+                  class="text-blue-600 hover:text-blue-800">
+                  Détails
+                </button>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <p class="text-sm text-gray-500">Aucun e-mail pour ce mangeur.</p>
+  <% end %>
+</div>
+
 <div class="mt-6">
   <%= link_to "← Retour à la liste des mangeurs", admin_customers_path, class: "text-blue-600 hover:text-blue-800" %>
+</div>
+
+<!-- Modal pour visualiser / renvoyer un e-mail -->
+<div
+  id="email-modal"
+  class="hidden fixed inset-0 z-50 overflow-y-auto"
+  data-email-modal-target="modal"
+  data-action="keydown@window->email-modal#closeWithEscape">
+  <div
+    class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+    data-email-modal-target="overlay"
+    data-action="click->email-modal#closeBackground">
+  </div>
+
+  <div class="flex min-h-full items-center justify-center p-4">
+    <div class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-2xl sm:p-6">
+      <div class="absolute right-0 top-0 hidden pr-4 pt-4 sm:block">
+        <button
+          type="button"
+          data-action="click->email-modal#close"
+          class="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
+          <span class="sr-only">Fermer</span>
+          <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <h3 class="text-base font-semibold leading-6 text-gray-900 mb-4">Détails de l'e-mail</h3>
+
+      <dl class="space-y-2 text-sm mb-4">
+        <div class="flex gap-2">
+          <dt class="font-medium text-gray-500 w-24 flex-shrink-0">Destinataire</dt>
+          <dd class="text-gray-900" data-email-modal-target="recipient"></dd>
+        </div>
+        <div class="flex gap-2">
+          <dt class="font-medium text-gray-500 w-24 flex-shrink-0">Date</dt>
+          <dd class="text-gray-900" data-email-modal-target="date"></dd>
+        </div>
+        <div class="flex gap-2">
+          <dt class="font-medium text-gray-500 w-24 flex-shrink-0">Sujet</dt>
+          <dd class="text-gray-900 font-medium" data-email-modal-target="subject"></dd>
+        </div>
+      </dl>
+
+      <div id="email-modal-error" class="hidden mb-4 rounded-md bg-red-50 p-4" data-email-modal-target="error">
+        <p class="text-sm font-medium text-red-800"></p>
+      </div>
+
+      <div class="border border-gray-200 rounded-md overflow-hidden mb-4" style="height:420px;">
+        <iframe data-email-modal-target="body" class="w-full h-full" sandbox=""></iframe>
+      </div>
+
+      <div class="mt-2 sm:flex sm:flex-row-reverse">
+        <button
+          type="button"
+          data-action="click->email-modal#resend"
+          data-email-modal-target="resendButton"
+          class="inline-flex w-full justify-center rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 sm:ml-3 sm:w-auto">
+          Renvoyer cet e-mail
+        </button>
+        <button
+          type="button"
+          data-action="click->email-modal#close"
+          class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto">
+          Fermer
+        </button>
+      </div>
+    </div>
+  </div>
 </div>
 
 <!-- Modal pour envoyer un SMS -->

--- a/app/views/auth_mailer/otp.html.erb
+++ b/app/views/auth_mailer/otp.html.erb
@@ -17,7 +17,7 @@
 </table>
 
 <p style="margin:0 0 16px 0; color:#6b635a;">
-  Ce code est valable <strong>5 minutes</strong>. Saisis-le sur la page de connexion pour continuer.
+  Ce code est valable <strong>15 minutes</strong>. Saisis-le sur la page de connexion pour continuer.
 </p>
 
 <p style="margin:0; color:#a89f94; font-size:13px;">

--- a/app/views/auth_mailer/otp.html.erb
+++ b/app/views/auth_mailer/otp.html.erb
@@ -1,5 +1,5 @@
 <p style="margin:0 0 16px 0; font-size:17px; color:#2d2a26;">
-  Salut <%= @customer.first_name.presence || "" %> 👋
+  Salut <%= @customer&.first_name.presence || "" %> 👋
 </p>
 
 <p style="margin:0 0 24px 0;">

--- a/app/views/auth_mailer/otp.html.erb
+++ b/app/views/auth_mailer/otp.html.erb
@@ -1,0 +1,25 @@
+<p style="margin:0 0 16px 0; font-size:17px; color:#2d2a26;">
+  Salut <%= @customer.first_name.presence || "" %> 👋
+</p>
+
+<p style="margin:0 0 24px 0;">
+  Voici ton code de connexion pour accéder à ton compte Tranches de Vie :
+</p>
+
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+  <tr>
+    <td align="center" style="padding:8px 0 24px 0;">
+      <div style="display:inline-block; background-color:#faf7f2; border:2px dashed #7c2d12; border-radius:12px; padding:18px 32px;">
+        <span style="font-family:'Courier New',Courier,monospace; font-size:36px; font-weight:bold; letter-spacing:10px; color:#7c2d12;"><%= @code %></span>
+      </div>
+    </td>
+  </tr>
+</table>
+
+<p style="margin:0 0 16px 0; color:#6b635a;">
+  Ce code est valable <strong>5 minutes</strong>. Saisis-le sur la page de connexion pour continuer.
+</p>
+
+<p style="margin:0; color:#a89f94; font-size:13px;">
+  Si tu n'es pas à l'origine de cette demande, tu peux ignorer cet e-mail.
+</p>

--- a/app/views/auth_mailer/otp.text.erb
+++ b/app/views/auth_mailer/otp.text.erb
@@ -4,7 +4,7 @@ Voici ton code de connexion pour accéder à ton compte Tranches de Vie :
 
     <%= @code %>
 
-Ce code est valable 5 minutes. Saisis-le sur la page de connexion pour continuer.
+Ce code est valable 15 minutes. Saisis-le sur la page de connexion pour continuer.
 
 Si tu n'es pas à l'origine de cette demande, tu peux ignorer cet e-mail.
 

--- a/app/views/auth_mailer/otp.text.erb
+++ b/app/views/auth_mailer/otp.text.erb
@@ -1,4 +1,4 @@
-Salut <%= @customer.first_name.presence || "" %>,
+Salut <%= @customer&.first_name.presence || "" %>,
 
 Voici ton code de connexion pour accéder à ton compte Tranches de Vie :
 

--- a/app/views/auth_mailer/otp.text.erb
+++ b/app/views/auth_mailer/otp.text.erb
@@ -9,5 +9,5 @@ Ce code est valable 5 minutes. Saisis-le sur la page de connexion pour continuer
 Si tu n'es pas à l'origine de cette demande, tu peux ignorer cet e-mail.
 
 —
-Tranches de Vie · Épicerie aux 4 Sources · Fonds d'Ahinvaux 1, Yvoir
+Tranches de Vie · Les 4 Sources, Fonds d'Ahinvaux 1, Yvoir
 boulangerie@les4sources.be

--- a/app/views/auth_mailer/otp.text.erb
+++ b/app/views/auth_mailer/otp.text.erb
@@ -1,0 +1,13 @@
+Salut <%= @customer.first_name.presence || "" %>,
+
+Voici ton code de connexion pour accéder à ton compte Tranches de Vie :
+
+    <%= @code %>
+
+Ce code est valable 5 minutes. Saisis-le sur la page de connexion pour continuer.
+
+Si tu n'es pas à l'origine de cette demande, tu peux ignorer cet e-mail.
+
+—
+Tranches de Vie · Épicerie aux 4 Sources · Fonds d'Ahinvaux 1, Yvoir
+boulangerie@les4sources.be

--- a/app/views/checkout/new.html.erb
+++ b/app/views/checkout/new.html.erb
@@ -54,12 +54,28 @@
                     placeholder: "123456" %>
               </div>
 
-              <button type="button" 
-                      id="verify-otp-btn" 
+              <button type="button"
+                      id="verify-otp-btn"
                       data-action="click->checkout#verifyOTP"
                       class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700">
                 Vérifier le code
               </button>
+
+              <div class="mt-4 text-center">
+                <p class="text-sm text-gray-600">Tu ne reçois pas le SMS ?</p>
+                <div id="email-otp-fields" class="hidden mt-2">
+                  <%= email_field_tag :otp_email, nil,
+                      id: "otp_email",
+                      placeholder: "ton@email.com",
+                      class: "w-full rounded-md border-gray-300 shadow-sm p-2 text-base focus:border-blue-500 focus:ring-blue-500" %>
+                </div>
+                <button type="button"
+                        id="send-otp-email-btn"
+                        data-action="click->checkout#sendOTPByEmail"
+                        class="mt-2 text-sm font-medium text-blue-600 hover:text-blue-800 underline">
+                  Recevoir le code par e-mail
+                </button>
+              </div>
             </div>
 
             <div id="otp-message" class="mt-4 hidden"></div>
@@ -86,7 +102,7 @@
             <div class="mb-4">
               <%= f.label :email, "Ton adresse e-mail (optionnel)", class: "block text-sm font-medium text-gray-700 mb-2" %>
               <%= f.email_field :email,
-                  value: @customer.email,
+                  value: @customer.email.presence || session[:email],
                   class: "w-full rounded-md border-1 border-gray-300 shadow-sm p-2 text-lg focus:border-blue-500 focus:ring-blue-500" %>
             </div>
           </div>

--- a/app/views/customers/account/edit.html.erb
+++ b/app/views/customers/account/edit.html.erb
@@ -61,12 +61,20 @@
         </div>
 
         <div class="flex items-center">
-          <%= f.check_box :sms_opt_out, 
+          <%= f.check_box :sms_opt_out,
               checked: @customer.sms_opt_out,
               class: "h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded" %>
           <%= f.label :sms_opt_out, "Désactiver les notifications par SMS", class: "ml-2 block text-sm text-gray-700" %>
         </div>
         <p class="text-sm text-gray-500">Décochez cette case pour recevoir des notifications par SMS concernant vos commandes.</p>
+
+        <div class="flex items-center">
+          <%= f.check_box :email_opt_out,
+              checked: @customer.email_opt_out,
+              class: "h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded" %>
+          <%= f.label :email_opt_out, "Désactiver les e-mails (hors codes de connexion)", class: "ml-2 block text-sm text-gray-700" %>
+        </div>
+        <p class="text-sm text-gray-500">Décochez cette case pour recevoir nos e-mails (confirmations de commande, etc.). Les codes de connexion par e-mail sont toujours envoyés.</p>
       </div>
 
       <div class="mt-6 flex gap-4">

--- a/app/views/customers/sessions/new.html.erb
+++ b/app/views/customers/sessions/new.html.erb
@@ -65,12 +65,22 @@
                 placeholder: "123456" %>
           </div>
 
-          <button type="button" 
-                  id="verify-otp-btn" 
+          <button type="button"
+                  id="verify-otp-btn"
                   data-action="click->customer-session#verifyOTP"
                   class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700">
             Vérifier le code
           </button>
+
+          <div class="mt-4 text-center">
+            <p class="text-sm text-gray-600">Tu ne reçois pas le SMS ?</p>
+            <button type="button"
+                    id="send-otp-email-btn"
+                    data-action="click->customer-session#sendOTPByEmail"
+                    class="mt-1 text-sm font-medium text-blue-600 hover:text-blue-800 underline">
+              Recevoir le code par e-mail
+            </button>
+          </div>
         </div>
 
         <div id="otp-message" class="mt-4 hidden"></div>

--- a/app/views/email_preferences/show.html.erb
+++ b/app/views/email_preferences/show.html.erb
@@ -1,0 +1,36 @@
+<% content_for :title, "Préférences e-mail" %>
+
+<div class="w-full mx-auto max-w-md">
+  <h1 class="text-3xl font-bold text-gray-900 mb-2">Préférences e-mail</h1>
+  <p class="text-sm text-gray-600 mb-8">
+    Pour <span class="font-medium text-gray-900"><%= @customer.email %></span>
+  </p>
+
+  <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+    <% if @customer.email_opt_out? %>
+      <p class="text-sm text-gray-700 mb-4">
+        Tu es actuellement <strong>désabonné·e</strong> de nos e-mails (confirmations de commande, etc.).
+        Les codes de connexion continueront d'être envoyés.
+      </p>
+      <%= form_with url: email_preferences_path(token: params[:token]), method: :patch, local: true do %>
+        <%= hidden_field_tag :email_opt_out, "false" %>
+        <%= submit_tag "Me réabonner aux e-mails",
+            class: "w-full px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 cursor-pointer" %>
+      <% end %>
+    <% else %>
+      <p class="text-sm text-gray-700 mb-4">
+        Tu reçois actuellement nos e-mails (confirmations de commande, etc.).
+        Tu peux te désabonner ci-dessous — les codes de connexion par e-mail resteront actifs.
+      </p>
+      <%= form_with url: email_preferences_path(token: params[:token]), method: :patch, local: true do %>
+        <%= hidden_field_tag :email_opt_out, "true" %>
+        <%= submit_tag "Me désabonner des e-mails",
+            class: "w-full px-4 py-2 bg-gray-200 text-gray-800 rounded-md hover:bg-gray-300 cursor-pointer" %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="mt-6 text-center">
+    <%= link_to "Retour à l'accueil", root_path, class: "text-blue-600 hover:text-blue-800 text-sm" %>
+  </div>
+</div>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,13 +1,53 @@
 <!DOCTYPE html>
-<html>
+<html lang="fr">
   <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <style>
-      /* Email styles need to be inline */
-    </style>
+    <meta name="color-scheme" content="light only">
+    <title><%= content_for(:title) || "Tranches de Vie" %></title>
   </head>
-
-  <body>
-    <%= yield %>
+  <body style="margin:0; padding:0; background-color:#f5f0e8; -webkit-text-size-adjust:100%; -ms-text-size-adjust:100%;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#f5f0e8;">
+      <tr>
+        <td align="center" style="padding:24px 12px;">
+          <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="width:600px; max-width:100%; background-color:#ffffff; border-radius:14px; overflow:hidden; box-shadow:0 1px 3px rgba(0,0,0,0.08);">
+            <!-- Header -->
+            <tr>
+              <td style="background-color:#7c2d12; padding:28px 32px; text-align:center;">
+                <div style="font-family:Georgia,'Times New Roman',serif; font-size:24px; font-weight:bold; color:#ffffff; letter-spacing:0.5px;">
+                  Tranches de Vie
+                </div>
+                <div style="font-family:Arial,Helvetica,sans-serif; font-size:12px; color:#f5d9c4; margin-top:4px; text-transform:uppercase; letter-spacing:2px;">
+                  Boulangerie artisanale
+                </div>
+              </td>
+            </tr>
+            <!-- Content -->
+            <tr>
+              <td style="padding:32px; font-family:Arial,Helvetica,sans-serif; font-size:15px; line-height:1.6; color:#2d2a26;">
+                <%= yield %>
+              </td>
+            </tr>
+            <!-- Footer -->
+            <tr>
+              <td style="padding:24px 32px; background-color:#faf7f2; border-top:1px solid #ece4d8; font-family:Arial,Helvetica,sans-serif; font-size:12px; line-height:1.6; color:#8a8178; text-align:center;">
+                <p style="margin:0 0 6px 0;">
+                  Tranches de Vie &middot; Épicerie aux 4 Sources &middot; Fonds d'Ahinvaux 1, Yvoir
+                </p>
+                <p style="margin:0 0 6px 0;">
+                  <a href="mailto:boulangerie@les4sources.be" style="color:#7c2d12; text-decoration:none;">boulangerie@les4sources.be</a>
+                </p>
+                <% if content_for?(:unsubscribe) %>
+                  <p style="margin:12px 0 0 0; color:#a89f94;">
+                    <%= yield :unsubscribe %>
+                  </p>
+                <% end %>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
   </body>
 </html>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -33,7 +33,7 @@
             <tr>
               <td style="padding:24px 32px; background-color:#faf7f2; border-top:1px solid #ece4d8; font-family:Arial,Helvetica,sans-serif; font-size:12px; line-height:1.6; color:#8a8178; text-align:center;">
                 <p style="margin:0 0 6px 0;">
-                  Tranches de Vie &middot; Épicerie aux 4 Sources &middot; Fonds d'Ahinvaux 1, Yvoir
+                  Tranches de Vie &middot; Les 4 Sources, Fonds d'Ahinvaux 1, Yvoir
                 </p>
                 <p style="margin:0 0 6px 0;">
                   <a href="mailto:boulangerie@les4sources.be" style="color:#7c2d12; text-decoration:none;">boulangerie@les4sources.be</a>

--- a/app/views/order_mailer/confirmation.html.erb
+++ b/app/views/order_mailer/confirmation.html.erb
@@ -1,0 +1,83 @@
+<% format_eur = ->(euros) { number_to_currency(euros, unit: "€", separator: ",", delimiter: " ", format: "%n %u") } %>
+
+<p style="margin:0 0 16px 0; font-size:17px; color:#2d2a26;">
+  Merci <%= @customer.first_name.presence || "" %> ! 🍞
+</p>
+
+<p style="margin:0 0 24px 0;">
+  Ta commande est confirmée. Voici le récapitulatif :
+</p>
+
+<!-- Order summary card -->
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#faf7f2; border:1px solid #ece4d8; border-radius:12px; margin-bottom:24px;">
+  <tr>
+    <td style="padding:18px 20px;">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr>
+          <td style="font-size:13px; color:#8a8178; text-transform:uppercase; letter-spacing:1px;">Commande</td>
+          <td align="right" style="font-size:13px; color:#8a8178; text-transform:uppercase; letter-spacing:1px;">À retirer le</td>
+        </tr>
+        <tr>
+          <td style="font-size:18px; font-weight:bold; color:#7c2d12; padding-top:2px;"><%= @order.order_number %></td>
+          <td align="right" style="font-size:16px; font-weight:bold; color:#2d2a26; padding-top:2px;"><%= I18n.l(@order.bake_day.baked_on, format: :long) %></td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+
+<!-- Items -->
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:8px;">
+  <thead>
+    <tr>
+      <th align="left" style="font-size:12px; color:#8a8178; text-transform:uppercase; letter-spacing:1px; border-bottom:2px solid #ece4d8; padding:0 0 8px 0;">Article</th>
+      <th align="center" style="font-size:12px; color:#8a8178; text-transform:uppercase; letter-spacing:1px; border-bottom:2px solid #ece4d8; padding:0 0 8px 0;">Qté</th>
+      <th align="right" style="font-size:12px; color:#8a8178; text-transform:uppercase; letter-spacing:1px; border-bottom:2px solid #ece4d8; padding:0 0 8px 0;">Total</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @items.each do |item| %>
+      <tr>
+        <td style="padding:12px 0; border-bottom:1px solid #f0eae0; font-size:15px; color:#2d2a26;">
+          <%= item.product_variant.product.name %>
+          <span style="color:#8a8178; font-size:13px;">— <%= item.product_variant.name %></span>
+        </td>
+        <td align="center" style="padding:12px 0; border-bottom:1px solid #f0eae0; font-size:15px; color:#2d2a26;"><%= item.qty %></td>
+        <td align="right" style="padding:12px 0; border-bottom:1px solid #f0eae0; font-size:15px; color:#2d2a26;"><%= format_eur.call(item.subtotal_euros) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="2" style="padding:16px 0 0 0; font-size:17px; font-weight:bold; color:#2d2a26;">Total</td>
+      <td align="right" style="padding:16px 0 0 0; font-size:17px; font-weight:bold; color:#7c2d12;"><%= format_eur.call(@order.total_euros) %></td>
+    </tr>
+  </tfoot>
+</table>
+
+<!-- Pickup info -->
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-top:24px; background-color:#fdf6ef; border-radius:12px;">
+  <tr>
+    <td style="padding:18px 20px; font-size:14px; line-height:1.6; color:#5c544b;">
+      <strong style="color:#2d2a26;">📍 Retrait</strong><br>
+      Épicerie aux 4 Sources — Fonds d'Ahinvaux 1, 5530 Yvoir.<br>
+      Ta commande t'attendra le jour de cuisson indiqué ci-dessus.
+    </td>
+  </tr>
+</table>
+
+<!-- CTA -->
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-top:24px;">
+  <tr>
+    <td align="center">
+      <a href="<%= @order_url %>" style="display:inline-block; background-color:#7c2d12; color:#ffffff; text-decoration:none; font-size:15px; font-weight:bold; padding:13px 28px; border-radius:10px;">
+        Voir ma commande
+      </a>
+    </td>
+  </tr>
+</table>
+
+<% content_for :unsubscribe do %>
+  Tu reçois cet e-mail car tu as commandé chez Tranches de Vie.
+  <a href="<%= @unsubscribe_url %>" style="color:#a89f94; text-decoration:underline;">Gérer mes préférences e-mail</a>.
+<% end %>

--- a/app/views/order_mailer/confirmation.text.erb
+++ b/app/views/order_mailer/confirmation.text.erb
@@ -1,0 +1,22 @@
+<% format_eur = ->(euros) { number_to_currency(euros, unit: "€", separator: ",", delimiter: " ", format: "%n %u") } -%>
+Merci <%= @customer.first_name.presence || "" %> !
+
+Ta commande est confirmée.
+
+Commande : <%= @order.order_number %>
+À retirer le : <%= I18n.l(@order.bake_day.baked_on, format: :long) %>
+
+Articles :
+<% @items.each do |item| -%>
+- <%= item.product_variant.product.name %> — <%= item.product_variant.name %> x<%= item.qty %> : <%= format_eur.call(item.subtotal_euros) %>
+<% end -%>
+Total : <%= format_eur.call(@order.total_euros) %>
+
+Retrait : Épicerie aux 4 Sources — Fonds d'Ahinvaux 1, 5530 Yvoir.
+Ta commande t'attendra le jour de cuisson indiqué ci-dessus.
+
+Voir ma commande : <%= @order_url %>
+
+—
+Tranches de Vie · boulangerie@les4sources.be
+Gérer mes préférences e-mail : <%= @unsubscribe_url %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,6 +37,10 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+  # Preview outgoing emails in the browser (opens tmp/letter_opener) instead of sending them.
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
+
   # Make template changes take effect immediately.
   config.action_mailer.perform_caching = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,21 +52,23 @@ Rails.application.configure do
   # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :solid_queue
 
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  # Deliver emails through Amazon SES (SMTP interface).
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
 
-  # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  # Set host to be used by links generated in mailer templates (unsubscribe, order links, ...).
+  config.action_mailer.default_url_options = { host: ENV.fetch("APP_HOST", "tranchesdevie.be") }
 
-  # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
-  # config.action_mailer.smtp_settings = {
-  #   user_name: Rails.application.credentials.dig(:smtp, :user_name),
-  #   password: Rails.application.credentials.dig(:smtp, :password),
-  #   address: "smtp.example.com",
-  #   port: 587,
-  #   authentication: :plain
-  # }
+  # Amazon SES SMTP credentials (managed via Hatchbox env vars).
+  config.action_mailer.smtp_settings = {
+    user_name: ENV["SES_SMTP_USERNAME"],
+    password: ENV["SES_SMTP_PASSWORD"],
+    address: "email-smtp.#{ENV.fetch('SES_REGION', 'eu-west-1')}.amazonaws.com",
+    port: 587,
+    authentication: :login,
+    enable_starttls_auto: true
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -11,6 +11,12 @@ class Rack::Attack
     req.ip if req.path == '/checkout' && req.post?
   end
 
+  # Rate limit OTP sends per IP. The email channel can target an arbitrary
+  # address (unregistered phones), so cap how many a single IP can trigger.
+  throttle('otp-send/ip', limit: 8, period: 60.seconds) do |req|
+    req.ip if req.path == '/checkout/verify_phone' && req.post?
+  end
+
   # Block requests from blocked IPs (if needed)
   # blocklist('block bad actors') do |req|
   #   Blocklist.find_by(ip: req.ip)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,10 @@ Rails.application.routes.draw do
 
   end
 
+  # Email preferences (unsubscribe link in non-OTP emails — no login required, signed token)
+  get "e-mails/preferences/:token", to: "email_preferences#show", as: :email_preferences
+  patch "e-mails/preferences/:token", to: "email_preferences#update"
+
   # Webhooks
   post "/webhooks/stripe", to: "webhooks#stripe"
 
@@ -79,6 +83,11 @@ Rails.application.routes.draw do
         post :send_sms
       end
       resources :sms_messages, only: [:show], controller: "sms_messages"
+      resources :email_messages, only: [:show], controller: "email_messages" do
+        member do
+          post :resend
+        end
+      end
     end
 
     resources :groups, only: [:index, :new, :create, :edit, :update]

--- a/db/migrate/20260521090000_create_email_messages.rb
+++ b/db/migrate/20260521090000_create_email_messages.rb
@@ -1,0 +1,23 @@
+class CreateEmailMessages < ActiveRecord::Migration[8.0]
+  def change
+    create_table :email_messages do |t|
+      t.integer :direction, default: 0, null: false
+      t.string :to_email, null: false
+      t.string :from_email, null: false
+      t.string :subject
+      t.text :body_html, null: false
+      t.integer :kind, default: 0, null: false
+      t.string :message_id
+      t.bigint :customer_id
+      t.bigint :order_id
+      t.datetime :sent_at
+
+      t.timestamps
+    end
+
+    add_index :email_messages, :customer_id
+    add_index :email_messages, :order_id
+    add_index :email_messages, :kind
+    add_index :email_messages, :message_id
+  end
+end

--- a/db/migrate/20260521090001_add_email_opt_out_to_customers.rb
+++ b/db/migrate/20260521090001_add_email_opt_out_to_customers.rb
@@ -1,0 +1,5 @@
+class AddEmailOptOutToCustomers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :customers, :email_opt_out, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_24_163525) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_21_090001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -99,6 +99,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_24_163525) do
     t.boolean "skip_wallet_check", default: false, null: false
     t.datetime "calendar_intro_seen_at"
     t.boolean "billable", default: false, null: false
+    t.boolean "email_opt_out", default: false, null: false
     t.index ["phone_e164"], name: "index_customers_on_phone_e164", unique: true, where: "(phone_e164 IS NOT NULL)"
   end
 
@@ -110,6 +111,25 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_24_163525) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["key"], name: "index_dough_ratios_on_key", unique: true
+  end
+
+  create_table "email_messages", force: :cascade do |t|
+    t.integer "direction", default: 0, null: false
+    t.string "to_email", null: false
+    t.string "from_email", null: false
+    t.string "subject"
+    t.text "body_html", null: false
+    t.integer "kind", default: 0, null: false
+    t.string "message_id"
+    t.bigint "customer_id"
+    t.bigint "order_id"
+    t.datetime "sent_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_email_messages_on_customer_id"
+    t.index ["kind"], name: "index_email_messages_on_kind"
+    t.index ["message_id"], name: "index_email_messages_on_message_id"
+    t.index ["order_id"], name: "index_email_messages_on_order_id"
   end
 
   create_table "flours", force: :cascade do |t|

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -10,6 +10,14 @@ FactoryBot.define do
       sms_opt_out { true }
     end
 
+    trait :with_email_disabled do
+      email_opt_out { true }
+    end
+
+    trait :without_email do
+      email { nil }
+    end
+
     trait :without_phone do
       phone_e164 { nil }
       skip_phone_validation { true }

--- a/spec/factories/email_messages.rb
+++ b/spec/factories/email_messages.rb
@@ -1,0 +1,19 @@
+FactoryBot.define do
+  factory :email_message do
+    association :customer
+    direction { :outbound }
+    kind { :confirmation }
+    sequence(:to_email) { |n| "eater#{n}@example.com" }
+    from_email { "boulangerie@les4sources.be" }
+    subject { "Ta commande chez Tranches de Vie" }
+    body_html { "<p>Merci pour ta commande !</p>" }
+    sent_at { Time.current }
+
+    trait :otp do
+      kind { :otp }
+      order { nil }
+      subject { "Ton code de connexion" }
+      body_html { "<p>123456</p>" }
+    end
+  end
+end

--- a/spec/mailers/auth_mailer_spec.rb
+++ b/spec/mailers/auth_mailer_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe AuthMailer, type: :mailer do
+  let(:customer) { create(:customer, first_name: "Léa", email: "lea@example.com") }
+
+  describe '#otp' do
+    subject(:mail) { described_class.otp(customer, "123456") }
+
+    it 'is addressed to the customer email' do
+      expect(mail.to).to eq(["lea@example.com"])
+    end
+
+    it 'has a login subject' do
+      expect(mail.subject).to include("code de connexion")
+    end
+
+    it 'includes the code in the body' do
+      expect(mail.body.encoded).to include("123456")
+    end
+
+    it 'tags the email kind as otp' do
+      expect(mail["X-Email-Kind"].value).to eq("otp")
+      expect(mail["X-Customer-Id"].value).to eq(customer.id.to_s)
+    end
+
+    it 'does not include an unsubscribe link' do
+      expect(mail.body.encoded).not_to match(/préférences e-mail|désabonner/i)
+    end
+
+    it 'logs an EmailMessage when delivered' do
+      expect { mail.deliver_now }.to change(EmailMessage, :count).by(1)
+      expect(EmailMessage.last).to have_attributes(kind: "otp", to_email: "lea@example.com", customer_id: customer.id)
+    end
+  end
+end

--- a/spec/mailers/auth_mailer_spec.rb
+++ b/spec/mailers/auth_mailer_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe AuthMailer, type: :mailer do
   let(:customer) { create(:customer, first_name: "Léa", email: "lea@example.com") }
 
   describe '#otp' do
-    subject(:mail) { described_class.otp(customer, "123456") }
+    subject(:mail) { described_class.otp(customer.email, "123456", customer: customer) }
 
     it 'is addressed to the customer email' do
-      expect(mail.to).to eq(["lea@example.com"])
+      expect(mail.to).to eq([ "lea@example.com" ])
     end
 
     it 'has a login subject' do
@@ -30,6 +30,25 @@ RSpec.describe AuthMailer, type: :mailer do
     it 'logs an EmailMessage when delivered' do
       expect { mail.deliver_now }.to change(EmailMessage, :count).by(1)
       expect(EmailMessage.last).to have_attributes(kind: "otp", to_email: "lea@example.com", customer_id: customer.id)
+    end
+  end
+
+  describe '#otp for an unregistered phone (no customer)' do
+    subject(:mail) { described_class.otp("newcomer@example.com", "654321", customer: nil) }
+
+    it 'is addressed to the given email with a generic greeting' do
+      expect(mail.to).to eq([ "newcomer@example.com" ])
+      expect(mail.body.encoded).to include("654321")
+      expect(mail.body.encoded).to include("Salut")
+    end
+
+    it 'does not set a customer id header' do
+      expect(mail["X-Customer-Id"]).to be_nil
+    end
+
+    it 'is still logged as an EmailMessage without a customer' do
+      expect { mail.deliver_now }.to change(EmailMessage, :count).by(1)
+      expect(EmailMessage.last).to have_attributes(kind: "otp", to_email: "newcomer@example.com", customer_id: nil)
     end
   end
 end

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe OrderMailer, type: :mailer do
+  let(:customer) { create(:customer, first_name: "Marc", email: "marc@example.com") }
+  let(:bake_day) { create(:bake_day, :can_order) }
+  let(:order) { create(:order, :with_items, customer: customer, bake_day: bake_day) }
+
+  describe '#confirmation' do
+    subject(:mail) { described_class.confirmation(order) }
+
+    it 'is addressed to the customer email' do
+      expect(mail.to).to eq(["marc@example.com"])
+    end
+
+    it 'references the order number in the subject and body' do
+      expect(mail.subject).to include(order.order_number)
+      expect(mail.body.encoded).to include(order.order_number)
+    end
+
+    it 'lists the ordered items' do
+      order.order_items.each do |item|
+        expect(mail.body.encoded).to include(item.product_variant.product.name)
+      end
+    end
+
+    it 'tags the email kind and order id' do
+      expect(mail["X-Email-Kind"].value).to eq("confirmation")
+      expect(mail["X-Order-Id"].value).to eq(order.id.to_s)
+    end
+
+    it 'includes a working unsubscribe (preferences) link' do
+      html = mail.html_part.body.decoded
+      expect(html).to include("/e-mails/preferences/")
+      token = html[%r{/e-mails/preferences/([^"\s]+)}, 1]
+      expect(Customer.find_signed(token, purpose: :email_unsubscribe)).to eq(customer)
+    end
+
+    it 'logs an EmailMessage when delivered' do
+      expect { mail.deliver_now }.to change(EmailMessage, :count).by(1)
+      expect(EmailMessage.last).to have_attributes(kind: "confirmation", order_id: order.id, customer_id: customer.id)
+    end
+  end
+end

--- a/spec/mailers/order_mailer_spec.rb
+++ b/spec/mailers/order_mailer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe OrderMailer, type: :mailer do
     subject(:mail) { described_class.confirmation(order) }
 
     it 'is addressed to the customer email' do
-      expect(mail.to).to eq(["marc@example.com"])
+      expect(mail.to).to eq([ "marc@example.com" ])
     end
 
     it 'references the order number in the subject and body' do

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Customer, type: :model do
+  it 'can be destroyed without raising' do
+    customer = create(:customer)
+
+    expect { customer.destroy }.not_to raise_error
+    expect(customer).to be_destroyed
+  end
+end

--- a/spec/models/email_message_spec.rb
+++ b/spec/models/email_message_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe EmailMessage, type: :model do
+  it 'is valid with the required attributes' do
+    expect(build(:email_message)).to be_valid
+  end
+
+  it 'requires a recipient, sender and body' do
+    message = EmailMessage.new
+    message.valid?
+    expect(message.errors[:to_email]).to be_present
+    expect(message.errors[:from_email]).to be_present
+    expect(message.errors[:body_html]).to be_present
+  end
+
+  it 'exposes confirmation, otp and other kinds' do
+    expect(EmailMessage.kinds.keys).to contain_exactly("confirmation", "otp", "other")
+  end
+
+  it 'belongs optionally to a customer and an order' do
+    expect(build(:email_message, customer: nil, order: nil)).to be_valid
+  end
+end

--- a/spec/requests/admin/email_messages_spec.rb
+++ b/spec/requests/admin/email_messages_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Admin::EmailMessages", type: :request do
 
       expect(response).to have_http_status(:ok)
       expect(JSON.parse(response.body)["success"]).to be true
-      expect(ActionMailer::Base.deliveries.last.to).to eq([customer.email])
+      expect(ActionMailer::Base.deliveries.last.to).to eq([ customer.email ])
     end
   end
 end

--- a/spec/requests/admin/email_messages_spec.rb
+++ b/spec/requests/admin/email_messages_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe "Admin::EmailMessages", type: :request do
+  let(:customer) { create(:customer, email: "eater@example.com") }
+  let!(:email_message) do
+    create(:email_message, customer: customer, to_email: customer.email,
+                           subject: "Confirmation de ta commande TV-1", body_html: "<p>Merci !</p>")
+  end
+
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('ADMIN_PASSWORD').and_return('secret')
+    post admin_login_path, params: { password: 'secret' }
+  end
+
+  describe "GET /admin/customers/:id (show)" do
+    it "renders the sent-emails section" do
+      get admin_customer_path(customer)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("E-mails envoyés")
+      expect(response.body).to include(email_message.subject)
+    end
+  end
+
+  describe "GET /admin/customers/:customer_id/email_messages/:id" do
+    it "returns the email details as JSON" do
+      get admin_customer_email_message_path(customer, email_message, format: :json)
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["subject"]).to eq(email_message.subject)
+      expect(body["body_html"]).to include("Merci !")
+    end
+  end
+
+  describe "POST /admin/customers/:customer_id/email_messages/:id/resend" do
+    it "re-delivers the email and logs a new EmailMessage" do
+      expect {
+        post resend_admin_customer_email_message_path(customer, email_message)
+      }.to change(EmailMessage, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["success"]).to be true
+      expect(ActionMailer::Base.deliveries.last.to).to eq([customer.email])
+    end
+  end
+end

--- a/spec/requests/checkout_email_otp_spec.rb
+++ b/spec/requests/checkout_email_otp_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe "Checkout email OTP fallback", type: :request do
+  # Isolate verify_phone from the cart/bake-day guards (covered elsewhere).
+  before do
+    allow_any_instance_of(CheckoutController).to receive(:ensure_cart_not_empty)
+    allow_any_instance_of(CheckoutController).to receive(:ensure_bake_day_set)
+  end
+
+  let(:phone) { "+32470333444" }
+
+  describe "POST /checkout/verify_phone with channel=email" do
+    it "asks for an email when the phone is unregistered and none is provided" do
+      post '/checkout/verify_phone', params: { phone_e164: phone, channel: 'email' }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["need_email"]).to be true
+    end
+
+    it "sends the code to a typed email for an unregistered phone" do
+      post '/checkout/verify_phone', params: { phone_e164: phone, channel: 'email', email: 'newcomer@example.com' }
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["success"]).to be true
+      expect(ActionMailer::Base.deliveries.last.to).to eq([ 'newcomer@example.com' ])
+    end
+
+    it "sends to the on-file email for an existing customer, ignoring a typed address" do
+      create(:customer, phone_e164: phone, email: 'onfile@example.com')
+      post '/checkout/verify_phone', params: { phone_e164: phone, channel: 'email', email: 'attacker@example.com' }
+      expect(JSON.parse(response.body)["success"]).to be true
+      expect(ActionMailer::Base.deliveries.last.to).to eq([ 'onfile@example.com' ])
+    end
+
+    it "refuses an existing customer without an email on file" do
+      create(:customer, phone_e164: phone, email: nil)
+      post '/checkout/verify_phone', params: { phone_e164: phone, channel: 'email', email: 'typed@example.com' }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["error"]).to match(/contacte-nous/i)
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
+  end
+end

--- a/spec/requests/customers/account_spec.rb
+++ b/spec/requests/customers/account_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe 'Customers::Account', type: :request do
+  let(:customer) { create(:customer, email: "eater@example.com", email_opt_out: false) }
+
+  def authenticate_customer
+    allow(OtpService).to receive(:send_otp).and_return({ success: true })
+    allow(OtpService).to receive(:verify_otp).and_return({ success: true })
+
+    post '/connexion', params: { phone_e164: customer.phone_e164 }
+    post '/connexion', params: { phone_e164: customer.phone_e164, otp_code: '123456' }
+  end
+
+  before { authenticate_customer }
+
+  describe 'GET /customers/mon-compte/edit' do
+    it 'renders the profile form with the email preference toggle' do
+      get customers_edit_account_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("email_opt_out")
+      expect(response.body).to include("Désactiver les e-mails")
+    end
+  end
+
+  describe 'PATCH /customers/mon-compte' do
+    it 'lets the customer disable non-OTP emails' do
+      patch customers_account_path, params: { customer: { email_opt_out: "1" } }
+      expect(customer.reload.email_opt_out).to be true
+    end
+  end
+end

--- a/spec/requests/email_preferences_spec.rb
+++ b/spec/requests/email_preferences_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe "Email preferences", type: :request do
+  let(:customer) { create(:customer, email: "eater@example.com", email_opt_out: false) }
+  let(:token) { customer.signed_id(purpose: :email_unsubscribe) }
+
+  describe "GET /e-mails/preferences/:token" do
+    it "shows the preferences page for a valid token" do
+      get email_preferences_path(token: token)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(customer.email)
+    end
+
+    it "redirects to root for an invalid token" do
+      get email_preferences_path(token: "not-a-real-token")
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "PATCH /e-mails/preferences/:token" do
+    it "opts the customer out of emails" do
+      patch email_preferences_path(token: token), params: { email_opt_out: "true" }
+      expect(customer.reload.email_opt_out).to be true
+      expect(response).to redirect_to(email_preferences_path(token: token))
+    end
+
+    it "opts the customer back in" do
+      customer.update!(email_opt_out: true)
+      patch email_preferences_path(token: token), params: { email_opt_out: "false" }
+      expect(customer.reload.email_opt_out).to be false
+    end
+
+    it "ignores an invalid token" do
+      patch email_preferences_path(token: "nope"), params: { email_opt_out: "true" }
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/services/order_notification_service_spec.rb
+++ b/spec/services/order_notification_service_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe OrderNotificationService do
+  let(:bake_day) { create(:bake_day, :can_order) }
+
+  describe '.send_confirmation' do
+    context 'when the customer can receive emails' do
+      let(:customer) { create(:customer, email: "eater@example.com", email_opt_out: false) }
+      let(:order) { create(:order, customer: customer, bake_day: bake_day) }
+
+      it 'sends the confirmation email' do
+        delivery = double(deliver_later: true)
+        expect(OrderMailer).to receive(:confirmation).with(order).and_return(delivery)
+        expect(OrderNotificationService.send_confirmation(order)).to be true
+      end
+
+      it 'is idempotent when a confirmation was already logged' do
+        create(:email_message, customer: customer, order: order, kind: :confirmation)
+        expect(OrderMailer).not_to receive(:confirmation)
+        expect(OrderNotificationService.send_confirmation(order)).to be false
+      end
+    end
+
+    context 'when the customer cannot receive emails' do
+      it 'does nothing without an email address' do
+        customer = create(:customer, email: nil)
+        order = create(:order, customer: customer, bake_day: bake_day)
+        expect(OrderMailer).not_to receive(:confirmation)
+        expect(OrderNotificationService.send_confirmation(order)).to be false
+      end
+
+      it 'does nothing when the customer opted out of emails' do
+        customer = create(:customer, email: "eater@example.com", email_opt_out: true)
+        order = create(:order, customer: customer, bake_day: bake_day)
+        expect(OrderMailer).not_to receive(:confirmation)
+        expect(OrderNotificationService.send_confirmation(order)).to be false
+      end
+    end
+  end
+end

--- a/spec/services/otp_service_spec.rb
+++ b/spec/services/otp_service_spec.rb
@@ -30,23 +30,61 @@ RSpec.describe OtpService do
       end
     end
 
-    context 'when no email is on file' do
-      it 'fails for a customer without an email' do
-        create(:customer, phone_e164: phone, email: nil)
-        result = OtpService.send_otp(phone, channel: :email)
-        expect(result[:success]).to be false
-        expect(result[:error]).to match(/adresse e-mail/i)
-      end
+    context 'when the customer has an email on file and a different address is typed' do
+      let!(:customer) { create(:customer, phone_e164: phone, email: "onfile@example.com") }
 
-      it 'fails when no customer exists for the phone' do
-        result = OtpService.send_otp(phone, channel: :email)
+      it 'always sends to the on-file address (typed address is ignored)' do
+        OtpService.send_otp(phone, channel: :email, email: "attacker@example.com", allow_email_entry: true)
+        expect(ActionMailer::Base.deliveries.last.to).to eq([ "onfile@example.com" ])
+      end
+    end
+
+    context 'when the customer exists but has no email on file' do
+      before { create(:customer, phone_e164: phone, email: nil) }
+
+      it 'is not eligible, even with a typed address' do
+        result = OtpService.send_otp(phone, channel: :email, email: "typed@example.com", allow_email_entry: true)
         expect(result[:success]).to be false
-        expect(result[:error]).to match(/adresse e-mail/i)
+        expect(result[:error]).to match(/contacte-nous/i)
       end
 
       it 'does not deliver any email' do
-        create(:customer, phone_e164: phone, email: nil)
-        expect { OtpService.send_otp(phone, channel: :email) }.not_to change(EmailMessage, :count)
+        expect {
+          OtpService.send_otp(phone, channel: :email, email: "typed@example.com", allow_email_entry: true)
+        }.not_to change(EmailMessage, :count)
+      end
+    end
+
+    context 'when the phone is not registered yet' do
+      it 'fails by default (allow_email_entry false), e.g. on the login page' do
+        result = OtpService.send_otp(phone, channel: :email, email: "newcomer@example.com")
+        expect(result[:success]).to be false
+        expect(result[:error]).to match(/contacte-nous/i)
+      end
+
+      it 'asks for an email when entry is allowed but none is provided' do
+        result = OtpService.send_otp(phone, channel: :email, allow_email_entry: true)
+        expect(result[:success]).to be false
+        expect(result[:need_email]).to be true
+      end
+
+      it 'rejects an invalid typed email' do
+        result = OtpService.send_otp(phone, channel: :email, email: "not-an-email", allow_email_entry: true)
+        expect(result[:success]).to be false
+        expect(result[:need_email]).to be true
+      end
+
+      it 'sends the code to the typed email when entry is allowed' do
+        result = OtpService.send_otp(phone, channel: :email, email: "newcomer@example.com", allow_email_entry: true)
+        expect(result[:success]).to be true
+        expect(result[:email]).to eq("newcomer@example.com")
+        expect(ActionMailer::Base.deliveries.last.to).to eq([ "newcomer@example.com" ])
+      end
+
+      it 'logs the email without a customer' do
+        expect {
+          OtpService.send_otp(phone, channel: :email, email: "newcomer@example.com", allow_email_entry: true)
+        }.to change { EmailMessage.where(kind: :otp, to_email: "newcomer@example.com", customer_id: nil).count }.by(1)
       end
     end
   end

--- a/spec/services/otp_service_spec.rb
+++ b/spec/services/otp_service_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe OtpService do
+  describe '.send_otp with channel: :email' do
+    let(:phone) { "+32470111222" }
+
+    context 'when the customer has an email on file' do
+      let!(:customer) { create(:customer, phone_e164: phone, email: "eater@example.com") }
+
+      it 'emails the code and reports success' do
+        result = OtpService.send_otp(phone, channel: :email)
+        expect(result[:success]).to be true
+        expect(result[:channel]).to eq(:email)
+      end
+
+      it 'delivers an OTP email logged as an EmailMessage' do
+        expect { OtpService.send_otp(phone, channel: :email) }
+          .to change { EmailMessage.where(kind: :otp, to_email: "eater@example.com").count }.by(1)
+      end
+
+      it 'reuses the active verification code instead of creating a new one' do
+        verification = PhoneVerification.create_for_phone(phone)
+
+        expect { OtpService.send_otp(phone, channel: :email) }.not_to change(PhoneVerification, :count)
+        expect(ActionMailer::Base.deliveries.last.body.encoded).to include(verification.code)
+      end
+
+      it 'creates a verification when none is active yet' do
+        expect { OtpService.send_otp(phone, channel: :email) }.to change(PhoneVerification, :count).by(1)
+      end
+    end
+
+    context 'when no email is on file' do
+      it 'fails for a customer without an email' do
+        create(:customer, phone_e164: phone, email: nil)
+        result = OtpService.send_otp(phone, channel: :email)
+        expect(result[:success]).to be false
+        expect(result[:error]).to match(/adresse e-mail/i)
+      end
+
+      it 'fails when no customer exists for the phone' do
+        result = OtpService.send_otp(phone, channel: :email)
+        expect(result[:success]).to be false
+        expect(result[:error]).to match(/adresse e-mail/i)
+      end
+
+      it 'does not deliver any email' do
+        create(:customer, phone_e164: phone, email: nil)
+        expect { OtpService.send_otp(phone, channel: :email) }.not_to change(EmailMessage, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Contexte

Plusieurs clients ne reçoivent pas le SMS de connexion alors que l'opérateur le marque « envoyé ». Cette PR ajoute un **canal de secours par e-mail** (Amazon SES via SMTP) pour recevoir le code de connexion, ainsi qu'une **vraie confirmation de commande par e-mail**, le **contrôle du désabonnement** côté client, et un **journal des e-mails** côté admin.

## Ce que ça contient

**Infra e-mail (SES SMTP)**
- Delivery `:smtp` en prod (ENV `SES_SMTP_USERNAME/PASSWORD/REGION`), `:letter_opener` en dev.
- Layout e-mail responsive, `ApplicationMailer` avec expéditeur par défaut (`MAIL_FROM`).

**Journalisation (`EmailMessage`)**
- Chaque e-mail sortant (OTP inclus) est tracé via un `after_action` → `EmailMessageLogger`, qui lit les en-têtes `X-Customer-Id` / `X-Email-Kind` / `X-Order-Id` posés par les mailers.

**OTP par e-mail (fallback)**
- `OtpService.send_otp(phone, channel: :email)` réutilise le code actif (identique à un SMS déjà demandé), **uniquement si une adresse est au dossier** ; sinon message invitant à nous contacter.
- Lien « Recevoir le code par e-mail » sur la page de connexion (Stimulus).

**Confirmation de commande**
- `OrderMailer#confirmation` (articles, total, jour de cuisson, retrait, lien commande) déclenché de façon **idempotente** par `OrderNotificationService` depuis le webhook Stripe, la page success et la commande cash. À noter : `SmsService.send_confirmation` était du code mort — il n'y avait aucune confirmation auparavant.

**Préférences & désabonnement**
- Colonne `email_opt_out`, `Customer#email_enabled?` (les OTP ignorent l'opt-out).
- Page publique signée (`signed_id`) accessible via le lien en bas de chaque e-mail non-OTP + case dans le compte client.

**Admin**
- Section « E-mails envoyés » sur la fiche client, visualisation **en modale** (iframe) et **renvoi** verbatim (`RawMailer` + `Admin::EmailMessagesController`).

## À configurer avant déploiement (Hatchbox/SES)
- `SES_SMTP_USERNAME`, `SES_SMTP_PASSWORD`, `SES_REGION` (défaut `eu-west-1`)
- `MAIL_FROM` (défaut `boulangerie@les4sources.be`) — **à vérifier comme expéditeur dans SES**
- `APP_HOST` — **fallback provisoire `tranchesdevie.be`**, à remplacer par le vrai domaine de production (liens dans les e-mails)
- `bin/rails db:migrate` (tables `email_messages` + colonne `customers.email_opt_out`)

## Tests
- 38 nouveaux exemples RSpec (mailers, OTP e-mail, idempotence des notifications, désabonnement par token, journal admin, préférences compte) — verts.
- RuboCop clean sur les fichiers ajoutés ; Brakeman 0 alerte.
- Les 13 échecs existants du suite (`planned_order_service`, `wallets`, intégration wallet) sont **préexistants** (confirmé sur `main` propre) et sans rapport avec cette PR.

## Hors périmètre (signalé)
- Bug latent préexistant : l'association `Customer#phone_verifications` (`dependent: :destroy`) plante car la table n'a pas de `customer_id`. À traiter séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)