### PR TITLE
Ajout d'une date de paiement (paid_at) sur les commandes

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -129,6 +129,11 @@ class Admin::OrdersController < Admin::BaseController
 
     @order.transition_to!(new_status)
 
+    # Lors d'un passage à « payée » (typiquement un paiement hors-ligne d'un
+    # client pro), enregistrer la date de paiement saisie par l'admin
+    # (sinon la date du jour).
+    @order.update!(paid_at: paid_at_from_params) if new_status.to_s == "paid"
+
     # Send ready SMS only when marking ready on the day of the bake.
     # If the bake day is in the past, the admin simply forgot to mark it ready earlier
     # and notifying the customer now would be confusing.
@@ -155,6 +160,17 @@ class Admin::OrdersController < Admin::BaseController
 
   def set_order
     @order = Order.find(params[:id])
+  end
+
+  # Date de paiement saisie via l'input date (format YYYY-MM-DD), interprétée
+  # dans le fuseau horaire de l'application. À défaut, la date/heure courante.
+  def paid_at_from_params
+    raw = params[:paid_at]
+    return Time.current if raw.blank?
+
+    Time.zone.parse(raw.to_s) || Time.current
+  rescue ArgumentError
+    Time.current
   end
 
   def load_form_dependencies

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -149,6 +149,9 @@ class WebhooksController < ApplicationController
         Rails.logger.info("Order #{order.id} already in status '#{order.status}', skipping transition to paid")
       end
 
+      # Renseigner la date d'encaissement si elle n'a pas encore été fixée.
+      order.update!(paid_at: Time.current) if order.read_attribute(:paid_at).blank?
+
       # Create payment record
       payment = Payment.find_or_create_by!(order: order) do |p|
         p.stripe_payment_intent_id = payment_intent_id

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -75,8 +75,12 @@ class Order < ApplicationRecord
       wallet_transactions.any? { |transaction| transaction.transaction_type == "order_refund" }
   end
 
+  # Date d'encaissement du paiement.
+  # La valeur stockée (saisie manuelle pour les paiements hors-ligne, ou
+  # renseignée automatiquement via le webhook Stripe) prime ; à défaut on la
+  # déduit de la trace de paiement (paiement Stripe ou débit du portefeuille).
   def paid_at
-    payment&.created_at || wallet_order_debit&.created_at
+    read_attribute(:paid_at) || payment&.created_at || wallet_order_debit&.created_at
   end
 
   def can_transition_to?(new_status)

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -73,6 +73,8 @@
           <dd class="mt-1 text-sm text-gray-600">
             <%= order_payment_method_label(@order.payment_method) %><% if @order.paid_at %> · le <%= @order.paid_at.strftime("%d/%m/%Y") %><% end %>
           </dd>
+        <% elsif @order.paid_at %>
+          <dd class="mt-1 text-sm text-gray-600">Payé le <%= @order.paid_at.strftime("%d/%m/%Y") %></dd>
         <% end %>
       </div>
     </dl>
@@ -83,10 +85,15 @@
 
     <div class="space-y-3">
       <% if @order.unpaid? && @order.can_transition_to?(:paid) %>
-        <%= form_with url: update_status_admin_order_path(@order), method: :patch, local: true do |f| %>
+        <%= form_with url: update_status_admin_order_path(@order), method: :patch, local: true, class: "space-y-2" do |f| %>
           <%= f.hidden_field :status, value: :paid %>
+          <div>
+            <label for="paid_at" class="block text-sm font-medium text-gray-700 mb-1">Date de paiement</label>
+            <input type="date" name="paid_at" id="paid_at" value="<%= Date.current.iso8601 %>"
+                   class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" />
+          </div>
           <%= f.submit "Marquer comme payée",
-              class: "w-full px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700",
+              class: "w-full px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 cursor-pointer",
               data: { confirm: "Marquer cette commande comme payée ?" } %>
         <% end %>
       <% end %>

--- a/db/migrate/20260603120000_add_paid_at_to_orders.rb
+++ b/db/migrate/20260603120000_add_paid_at_to_orders.rb
@@ -1,0 +1,5 @@
+class AddPaidAtToOrders < ActiveRecord::Migration[8.0]
+  def change
+    add_column :orders, :paid_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_21_090001) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_03_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -195,6 +195,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_21_090001) do
     t.datetime "updated_at", null: false
     t.boolean "requires_invoice", default: false, null: false
     t.integer "source", default: 0, null: false
+    t.datetime "paid_at"
     t.index ["bake_day_id"], name: "index_orders_on_bake_day_id"
     t.index ["customer_id"], name: "index_orders_on_customer_id"
     t.index ["order_number"], name: "index_orders_on_order_number"

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -74,7 +74,22 @@ RSpec.describe Order, type: :model do
     end
 
     it 'is nil without any payment trace' do
-      expect(create(:order).paid_at).to be_nil
+      expect(create(:order, paid_at: nil).paid_at).to be_nil
+    end
+
+    it 'uses the stored value for offline payments without any trace' do
+      paid_on = Time.zone.local(2026, 5, 12, 10, 0)
+      order = create(:order, :unpaid, paid_at: paid_on)
+
+      expect(order.paid_at).to be_within(1.second).of(paid_on)
+    end
+
+    it 'prefers the stored value over the derived payment timestamp' do
+      stored = Time.zone.local(2026, 5, 1, 9, 0)
+      order = create(:order, paid_at: stored)
+      create(:payment, order: order)
+
+      expect(order.reload.paid_at).to be_within(1.second).of(stored)
     end
   end
 end

--- a/spec/requests/admin/orders_spec.rb
+++ b/spec/requests/admin/orders_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe "Admin::Orders", type: :request do
+  let(:order) { create(:order, :unpaid, :with_items) }
+
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('ADMIN_PASSWORD').and_return('secret')
+    post admin_login_path, params: { password: 'secret' }
+  end
+
+  describe "PATCH /admin/orders/:id/update_status (marquer payée)" do
+    it "transitions the order to paid and stores the supplied payment date" do
+      patch update_status_admin_order_path(order),
+            params: { status: 'paid', paid_at: '2026-05-12' }
+
+      order.reload
+      expect(order.status).to eq('paid')
+      expect(order.read_attribute(:paid_at)).to eq(Time.zone.local(2026, 5, 12))
+    end
+
+    it "defaults the payment date to now when none is supplied" do
+      patch update_status_admin_order_path(order), params: { status: 'paid' }
+
+      expect(order.reload.read_attribute(:paid_at)).to be_within(1.minute).of(Time.current)
+    end
+
+    it "does not set a payment date for other transitions" do
+      paid_order = create(:order, :paid, :with_items)
+
+      patch update_status_admin_order_path(paid_order), params: { status: 'ready' }
+
+      expect(paid_order.reload.read_attribute(:paid_at)).to be_nil
+    end
+  end
+
+  describe "GET /admin/orders/:id (show)" do
+    it "displays the manually recorded payment date for an offline payment" do
+      order.update!(status: :paid, paid_at: Time.zone.local(2026, 5, 12))
+
+      get admin_order_path(order)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Payé le 12/05/2026")
+    end
+  end
+end

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -43,6 +43,13 @@ RSpec.describe 'Stripe webhook', type: :request do
         .to change { Order.where(payment_intent_id: pi_id).count }.from(0).to(1)
       expect(Order.find_by(payment_intent_id: pi_id).status).to eq('paid')
     end
+
+    it 'records the payment date on the order' do
+      event = fabricate_event(type: 'payment_intent.succeeded', metadata: succeeded_metadata)
+      deliver(event)
+
+      expect(Order.find_by(payment_intent_id: pi_id).read_attribute(:paid_at)).to be_present
+    end
   end
 
   describe 'idempotency on event id (ISC-19)' do


### PR DESCRIPTION
Closes #43

## Résumé
Permet d'enregistrer la **date d'encaissement** d'une commande, en particulier pour les clients pro qui paient hors-ligne (virement) après livraison.

- **Migration** : colonne `paid_at` (datetime, nullable) sur `orders`.
- **`Order#paid_at`** : la valeur stockée prime ; à défaut, elle est déduite de la trace de paiement (paiement Stripe ou débit du portefeuille). Rétro-compatible avec les commandes existantes.
- **Webhook Stripe** : `paid_at` est renseigné automatiquement au passage à `paid`.
- **Admin** : input date dans l'action « Marquer comme payée » (par défaut la date du jour) + affichage de la date de paiement pour les paiements hors-ligne dans la vue commande.
- Le serializer API expose déjà `paid_at` (type inchangé `datetime|null`).

## Testé
- `spec/models/order_spec.rb` : précédence de la valeur stockée, valeur stockée pour un paiement hors-ligne sans trace, repli sur la trace Stripe/portefeuille, nil sans paiement.
- `spec/requests/admin/orders_spec.rb` (nouveau) : passage à payée avec date fournie, défaut à maintenant, pas de date pour les autres transitions, affichage de la date dans la vue.
- `spec/requests/webhooks_spec.rb` : `paid_at` renseigné par le webhook.
- Suite complète : **261 exemples, 0 échec**.
- **Rubocop** : 0 offense. **Brakeman** : 0 alerte de sécurité.

## NON testé
- Pas de test système/Capybara de l'interaction réelle avec l'input date dans le navigateur (couvert au niveau request uniquement).
- Pas de vérification de bout en bout contre l'API Stripe réelle (le webhook est piloté via un événement fabriqué, comme les specs existantes).

---
_Generated by [Claude Code](https://claude.ai/code/session_012Qsb4vdpfC4s6h39ELYUPs)_