### PR TITLE
Vue facturation mensuelle pour les clients pro (#45)

### DIFF
--- a/app/controllers/admin/billing_controller.rb
+++ b/app/controllers/admin/billing_controller.rb
@@ -1,0 +1,59 @@
+require "csv"
+
+# Facturation mensuelle des clients professionnels (clients `billable`).
+# Récapitule, pour un mois donné, les commandes par client pro avec le détail,
+# le total et le statut de paiement. Filtrable par mois et par client.
+class Admin::BillingController < Admin::BaseController
+  def index
+    @month = parsed_month(params[:month]) || Date.current.beginning_of_month
+    @customer = Customer.billable.find_by(id: params[:customer_id])
+    @billable_customers = Customer.billable.order(:first_name, :last_name)
+
+    @report = BillingReportService.new(month: @month, customer: @customer).call
+
+    respond_to do |format|
+      format.html
+      format.csv do
+        send_data billing_csv(@report),
+          filename: "facturation-#{@month.strftime('%Y-%m')}.csv",
+          type: "text/csv"
+      end
+    end
+  end
+
+  private
+
+  def parsed_month(value)
+    return nil if value.blank?
+
+    Date.strptime(value, "%Y-%m").beginning_of_month
+  rescue ArgumentError, TypeError
+    nil
+  end
+
+  def billing_csv(report)
+    CSV.generate(headers: true) do |csv|
+      csv << [ "Client", "Date de cuisson", "N° commande", "Articles", "Montant (€)", "Statut paiement", "Date de paiement" ]
+
+      report.customers.each do |billing|
+        billing.orders.each do |order|
+          csv << [
+            billing.customer.full_name,
+            I18n.l(order.bake_day.baked_on),
+            order.order_number,
+            csv_items(order),
+            format("%.2f", order.total_cents / 100.0),
+            order.payment_received? ? "Payé" : "Impayé",
+            order.payment_received? && order.paid_at ? I18n.l(order.paid_at.to_date) : ""
+          ]
+        end
+      end
+    end
+  end
+
+  def csv_items(order)
+    order.order_items.map do |item|
+      "#{item.qty}x #{item.product_variant.name}"
+    end.join(", ")
+  end
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -15,6 +15,8 @@ class Customer < ApplicationRecord
 
   scope :with_sms_enabled, -> { where(sms_opt_out: false) }
   scope :with_email_enabled, -> { where.not(email: [ nil, "" ]).where(email_opt_out: false) }
+  # Clients professionnels (épiceries, points de dépôt) facturés mensuellement.
+  scope :billable, -> { where(billable: true) }
 
   def sms_enabled?
     phone_e164.present? && !sms_opt_out?

--- a/app/services/billing_report_service.rb
+++ b/app/services/billing_report_service.rb
@@ -1,0 +1,91 @@
+# Construit le récapitulatif de facturation mensuelle des clients professionnels
+# (clients `billable` : épiceries, points de dépôt, facturés au mois).
+#
+# Pour un mois donné, regroupe par client les commandes dont le jour de cuisson
+# tombe dans le mois, avec le détail des articles, le total, le statut de
+# paiement et la date de paiement éventuelle.
+#
+# Usage :
+#   report = BillingReportService.new(month: Date.new(2026, 5, 1)).call
+#   report.customers      # => [ CustomerBilling, ... ]
+#   report.grand_total_cents
+class BillingReportService
+  # Statuts de commande pris en compte dans la facturation. On exclut les
+  # commandes annulées, planifiées (non confirmées) et en attente de paiement
+  # en ligne (pending). `unpaid` est inclus : ce sont précisément les commandes
+  # à facturer (impayées).
+  BILLABLE_STATUSES = %w[unpaid paid ready picked_up no_show].freeze
+
+  CustomerBilling = Struct.new(
+    :customer,
+    :orders,
+    :total_cents,
+    :paid_total_cents,
+    :unpaid_total_cents,
+    keyword_init: true
+  )
+
+  Report = Struct.new(
+    :month,
+    :customers,
+    :grand_total_cents,
+    :paid_total_cents,
+    :unpaid_total_cents,
+    keyword_init: true
+  )
+
+  def initialize(month:, customer: nil)
+    @month = month.beginning_of_month
+    @customer = customer
+  end
+
+  def call
+    customer_billings = build_customer_billings
+
+    Report.new(
+      month: @month,
+      customers: customer_billings,
+      grand_total_cents: customer_billings.sum(&:total_cents),
+      paid_total_cents: customer_billings.sum(&:paid_total_cents),
+      unpaid_total_cents: customer_billings.sum(&:unpaid_total_cents)
+    )
+  end
+
+  private
+
+  def build_customer_billings
+    orders_by_customer = scoped_orders.group_by(&:customer_id)
+
+    billable_customers.filter_map do |customer|
+      orders = orders_by_customer[customer.id]
+      next if orders.blank?
+
+      orders = orders.sort_by { |order| order.bake_day.baked_on }
+      paid_cents = orders.select(&:payment_received?).sum(&:total_cents)
+
+      CustomerBilling.new(
+        customer: customer,
+        orders: orders,
+        total_cents: orders.sum(&:total_cents),
+        paid_total_cents: paid_cents,
+        unpaid_total_cents: orders.sum(&:total_cents) - paid_cents
+      )
+    end
+  end
+
+  def billable_customers
+    scope = Customer.billable.order(:first_name, :last_name)
+    scope = scope.where(id: @customer.id) if @customer
+    scope
+  end
+
+  def scoped_orders
+    scope = Order
+      .where(status: BILLABLE_STATUSES)
+      .in_bake_day_range(@month, @month.end_of_month)
+      .includes(:bake_day, :payment, order_items: { product_variant: :product })
+
+    scope = scope.where(customer_id: @customer.id) if @customer
+    scope
+  end
+end

--- a/app/views/admin/billing/index.html.erb
+++ b/app/views/admin/billing/index.html.erb
@@ -1,0 +1,134 @@
+<% content_for :title, "Facturation mensuelle" %>
+<% content_for :layout, "admin" %>
+
+<div class="mb-6 flex flex-col md:flex-row md:items-center md:justify-between md:space-x-6 space-y-4 md:space-y-0">
+  <div>
+    <h1 class="text-2xl font-bold text-gray-900">Facturation mensuelle</h1>
+    <p class="text-sm text-gray-600">
+      Clients professionnels — <%= month_label(@month) %>
+    </p>
+  </div>
+  <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+    <%= form_with url: admin_billing_path, method: :get, local: true, class: "flex flex-col md:flex-row md:items-end md:space-x-4 space-y-4 md:space-y-0" do |f| %>
+      <div class="flex flex-col">
+        <%= f.label :month, "Mois", class: "text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.month_field :month, value: @month.strftime("%Y-%m"), class: "rounded-md border border-gray-300 px-3 py-2 text-sm" %>
+      </div>
+      <div class="flex flex-col">
+        <%= f.label :customer_id, "Client", class: "text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.select :customer_id,
+              options_from_collection_for_select(@billable_customers, :id, :full_name, @customer&.id),
+              { include_blank: "Tous les clients" },
+              class: "rounded-md border border-gray-300 px-3 py-2 text-sm" %>
+      </div>
+      <div>
+        <%= f.submit "Filtrer", class: "w-full md:w-auto rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 cursor-pointer" %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<div class="mb-6 flex flex-col md:flex-row md:items-center md:justify-between md:space-x-6 space-y-4 md:space-y-0">
+  <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 flex-1">
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+      <h2 class="text-xs font-medium text-gray-500 uppercase tracking-wide">Total à facturer</h2>
+      <p class="mt-1 text-2xl font-bold text-gray-900"><%= reports_currency(@report.grand_total_cents) %></p>
+    </div>
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+      <h2 class="text-xs font-medium text-gray-500 uppercase tracking-wide">Déjà payé</h2>
+      <p class="mt-1 text-2xl font-bold text-green-700"><%= reports_currency(@report.paid_total_cents) %></p>
+    </div>
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+      <h2 class="text-xs font-medium text-gray-500 uppercase tracking-wide">Impayé</h2>
+      <p class="mt-1 text-2xl font-bold text-red-700"><%= reports_currency(@report.unpaid_total_cents) %></p>
+    </div>
+  </div>
+  <div>
+    <%= link_to "Export CSV", admin_billing_path(format: :csv, month: @month.strftime("%Y-%m"), customer_id: @customer&.id),
+          class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50" %>
+  </div>
+</div>
+
+<% if @report.customers.any? %>
+  <div class="space-y-6">
+    <% @report.customers.each do |billing| %>
+      <section class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4 gap-2">
+          <div>
+            <h2 class="text-lg font-medium text-gray-900">
+              <%= link_to billing.customer.full_name, admin_customer_path(billing.customer), class: "hover:underline" %>
+            </h2>
+            <p class="text-sm text-gray-500">
+              <%= pluralize(billing.orders.size, "commande") %> —
+              Total <span class="font-medium text-gray-900"><%= reports_currency(billing.total_cents) %></span>
+              <% if billing.unpaid_total_cents.positive? %>
+                · <span class="text-red-700">Impayé <%= reports_currency(billing.unpaid_total_cents) %></span>
+              <% end %>
+            </p>
+          </div>
+          <div>
+            <%# Génération de facture PDF : voir issue #38 (hors périmètre de cette page). %>
+            <button type="button" disabled
+              class="inline-flex items-center rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm font-medium text-gray-400 cursor-not-allowed"
+              title="Génération de facture PDF à venir (#38)">
+              Facture PDF (à venir)
+            </button>
+          </div>
+        </div>
+
+        <div class="overflow-x-auto">
+          <table class="min-w-full divide-y divide-gray-200 text-sm">
+            <thead class="bg-gray-50 text-left">
+              <tr>
+                <th class="px-4 py-2 font-medium text-gray-500 uppercase tracking-wide">Date de cuisson</th>
+                <th class="px-4 py-2 font-medium text-gray-500 uppercase tracking-wide">Articles</th>
+                <th class="px-4 py-2 font-medium text-gray-500 uppercase tracking-wide text-right">Montant</th>
+                <th class="px-4 py-2 font-medium text-gray-500 uppercase tracking-wide">Paiement</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200">
+              <% billing.orders.each do |order| %>
+                <tr>
+                  <td class="px-4 py-2 text-gray-900 whitespace-nowrap">
+                    <%= link_to l(order.bake_day.baked_on), admin_order_path(order), class: "hover:underline" %>
+                  </td>
+                  <td class="px-4 py-2 text-gray-600">
+                    <ul class="space-y-0.5">
+                      <% order.order_items.each do |item| %>
+                        <li><%= item.qty %>x <%= item.product_variant.name %></li>
+                      <% end %>
+                    </ul>
+                  </td>
+                  <td class="px-4 py-2 text-right text-gray-900 whitespace-nowrap"><%= reports_currency(order.total_cents) %></td>
+                  <td class="px-4 py-2 whitespace-nowrap">
+                    <% if order.payment_received? %>
+                      <span class="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800">Payé</span>
+                      <% if order.paid_at %>
+                        <span class="block text-xs text-gray-500 mt-0.5">le <%= l(order.paid_at.to_date) %></span>
+                      <% end %>
+                    <% else %>
+                      <span class="inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800">Impayé</span>
+                    <% end %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+            <tfoot class="bg-gray-50">
+              <tr>
+                <td class="px-4 py-2 font-medium text-gray-700" colspan="2">Total du mois</td>
+                <td class="px-4 py-2 text-right font-bold text-gray-900"><%= reports_currency(billing.total_cents) %></td>
+                <td class="px-4 py-2"></td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </section>
+    <% end %>
+  </div>
+<% else %>
+  <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+    <p class="text-sm text-gray-500">
+      Aucune commande à facturer pour les clients professionnels sur ce mois.
+    </p>
+  </div>
+<% end %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -31,6 +31,7 @@
               <%= link_to "Jours de cuisson", admin_bake_days_path, class: admin_nav_link_class("bake_days") %>
               <%= link_to "Mangeurs", admin_customers_path, class: admin_nav_link_class("customers") %>
               <%= link_to "Produits", admin_products_path, class: admin_nav_link_class("products") %>
+              <%= link_to "Facturation", admin_billing_path, class: admin_nav_link_class("billing") %>
               <%= link_to admin_reports_path, class: admin_nav_link_class("reports"), title: "Reporting", aria: { label: "Reporting" } do %>
                 <span class="md:hidden">Reporting</span>
                 <svg class="hidden md:block w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -79,6 +80,7 @@
             <%= link_to "Jours de cuisson", admin_bake_days_path, class: admin_mobile_nav_link_class("bake_days"), data: { action: "click->mobile-menu#close" } %>
             <%= link_to "Mangeurs", admin_customers_path, class: admin_mobile_nav_link_class("customers"), data: { action: "click->mobile-menu#close" } %>
             <%= link_to "Produits", admin_products_path, class: admin_mobile_nav_link_class("products"), data: { action: "click->mobile-menu#close" } %>
+            <%= link_to "Facturation", admin_billing_path, class: admin_mobile_nav_link_class("billing"), data: { action: "click->mobile-menu#close" } %>
             <%= link_to "Reporting", admin_reports_path, class: admin_mobile_nav_link_class("reports"), data: { action: "click->mobile-menu#close" } %>
             <%= link_to "Paramètres", admin_settings_path, class: admin_mobile_nav_link_class("settings"), data: { action: "click->mobile-menu#close" } %>
             <div class="mt-4 border-t border-gray-200 pt-4">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,6 +115,7 @@ Rails.application.routes.draw do
     delete "logout", to: "sessions#destroy"
 
     resources :reports, only: [ :index ]
+    get "billing", to: "billing#index", as: :billing
 
     resources :orders, only: [ :index, :show, :new, :create, :edit, :update ] do
       member do

--- a/spec/requests/admin/billing_spec.rb
+++ b/spec/requests/admin/billing_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+# Admin : vue de facturation mensuelle des clients professionnels (ISC-45).
+RSpec.describe "Admin::Billing", type: :request do
+  around do |ex|
+    original = ENV["ADMIN_PASSWORD"]
+    ENV["ADMIN_PASSWORD"] = "test-admin-pw"
+    ex.run
+    ENV["ADMIN_PASSWORD"] = original
+  end
+
+  def login_admin
+    post admin_login_path, params: { password: "test-admin-pw" }
+  end
+
+  it "exige une authentification" do
+    get admin_billing_path
+    expect(response).to redirect_to(admin_login_path)
+  end
+
+  context "when authenticated" do
+    before { login_admin }
+
+    let(:month) { Date.new(2026, 5, 1) }
+    let(:bake_day) { create(:bake_day, baked_on: Date.new(2026, 5, 12)) }
+    let!(:pro) { create(:customer, billable: true, first_name: "Épicerie", last_name: "Durand") }
+    let!(:order) do
+      create(:order, :unpaid, customer: pro, bake_day: bake_day, total_cents: 1500).tap do |o|
+        create(:order_item, order: o, qty: 3)
+      end
+    end
+
+    it "affiche le récapitulatif du mois pour les clients facturables" do
+      get admin_billing_path(month: "2026-05")
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Épicerie Durand")
+      expect(response.body).to include("Impayé")
+    end
+
+    it "exporte le récapitulatif en CSV" do
+      get admin_billing_path(month: "2026-05", format: :csv)
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/csv")
+      expect(response.body).to include("Client")
+      expect(response.body).to include("Épicerie Durand")
+    end
+
+    it "tolère un mois invalide en retombant sur le mois courant" do
+      get admin_billing_path(month: "pas-une-date")
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/services/billing_report_service_spec.rb
+++ b/spec/services/billing_report_service_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe BillingReportService do
+  let(:month) { Date.new(2026, 5, 1) }
+  let(:bake_day_in_month) { create(:bake_day, baked_on: Date.new(2026, 5, 12)) }
+  let(:bake_day_other_month) { create(:bake_day, baked_on: Date.new(2026, 6, 12)) }
+
+  def report(customer: nil)
+    described_class.new(month: month, customer: customer).call
+  end
+
+  it "regroupe les commandes des clients facturables pour le mois donné" do
+    pro = create(:customer, billable: true, first_name: "Épicerie", last_name: "Durand")
+    create(:order, :paid, customer: pro, bake_day: bake_day_in_month, total_cents: 2000)
+    create(:order, :unpaid, customer: pro, bake_day: bake_day_in_month, total_cents: 1500)
+
+    result = report
+    expect(result.customers.size).to eq(1)
+
+    billing = result.customers.first
+    expect(billing.customer).to eq(pro)
+    expect(billing.orders.size).to eq(2)
+    expect(billing.total_cents).to eq(3500)
+    expect(billing.paid_total_cents).to eq(2000)
+    expect(billing.unpaid_total_cents).to eq(1500)
+  end
+
+  it "agrège les totaux globaux du rapport" do
+    pro = create(:customer, billable: true)
+    create(:order, :paid, customer: pro, bake_day: bake_day_in_month, total_cents: 2000)
+    create(:order, :unpaid, customer: pro, bake_day: bake_day_in_month, total_cents: 1500)
+
+    result = report
+    expect(result.grand_total_cents).to eq(3500)
+    expect(result.paid_total_cents).to eq(2000)
+    expect(result.unpaid_total_cents).to eq(1500)
+  end
+
+  it "exclut les clients non facturables" do
+    regular = create(:customer, billable: false)
+    create(:order, :paid, customer: regular, bake_day: bake_day_in_month, total_cents: 2000)
+
+    expect(report.customers).to be_empty
+  end
+
+  it "exclut les commandes hors du mois demandé" do
+    pro = create(:customer, billable: true)
+    create(:order, :paid, customer: pro, bake_day: bake_day_other_month, total_cents: 2000)
+
+    expect(report.customers).to be_empty
+  end
+
+  it "exclut les statuts non facturables (annulée, planifiée, en attente)" do
+    pro = create(:customer, billable: true)
+    create(:order, :cancelled, customer: pro, bake_day: bake_day_in_month, total_cents: 2000)
+    create(:order, :planned, customer: pro, bake_day: bake_day_in_month, total_cents: 2000)
+    create(:order, :pending, customer: pro, bake_day: bake_day_in_month, total_cents: 2000)
+
+    expect(report.customers).to be_empty
+  end
+
+  it "ne renvoie que le client demandé lorsqu'un filtre client est fourni" do
+    pro_a = create(:customer, billable: true)
+    pro_b = create(:customer, billable: true)
+    create(:order, :paid, customer: pro_a, bake_day: bake_day_in_month, total_cents: 2000)
+    create(:order, :paid, customer: pro_b, bake_day: bake_day_in_month, total_cents: 3000)
+
+    result = report(customer: pro_a)
+    expect(result.customers.size).to eq(1)
+    expect(result.customers.first.customer).to eq(pro_a)
+    expect(result.grand_total_cents).to eq(2000)
+  end
+
+  it "trie les commandes d'un client par date de cuisson" do
+    pro = create(:customer, billable: true)
+    later = create(:bake_day, baked_on: Date.new(2026, 5, 26))
+    earlier = create(:bake_day, baked_on: Date.new(2026, 5, 5))
+    create(:order, :paid, customer: pro, bake_day: later, total_cents: 1000)
+    create(:order, :paid, customer: pro, bake_day: earlier, total_cents: 1000)
+
+    baked_dates = report.customers.first.orders.map { |o| o.bake_day.baked_on }
+    expect(baked_dates).to eq([ earlier.baked_on, later.baked_on ])
+  end
+end


### PR DESCRIPTION
Closes #45

## Résumé
Ajoute une vue admin de facturation mensuelle pour les clients professionnels (clients `billable` : épiceries, points de dépôt facturés au mois).

- **Nouvelle page** `/admin/billing` (lien ajouté à la navigation admin desktop + mobile)
- **Filtrable** par mois (sélecteur `month`) et par client pro
- **Pour chaque client pro** : liste des commandes du mois (date de cuisson, articles, montant), total du mois, statut de paiement (payé / impayé) et date de paiement
- **Cartes de synthèse** : total à facturer, déjà payé, impayé
- **Export CSV** (une ligne par commande, prêt pour la compta)
- Logique métier isolée dans `BillingReportService` (regroupement par client, filtres, totaux payé/impayé)

### Choix / périmètre
- Statuts pris en compte : `unpaid, paid, ready, picked_up, no_show` (exclut `cancelled`, `planned`, `pending`). `unpaid` est inclus car ce sont précisément les commandes à facturer.
- Les commandes sont rattachées au mois via la **date de cuisson** (`bake_day.baked_on`).
- Prérequis déjà présents sur `main` : champ `billable` (#42) et `paid_at` (#43/#60).
- **Hors périmètre** : la génération de **facture PDF** relève de l'issue #38 — un bouton désactivé « Facture PDF (à venir) » marque l'emplacement sans l'implémenter.

## Testé
- `bundle exec rspec` → **272 examples, 0 failures** (dont les nouveaux specs)
  - `spec/services/billing_report_service_spec.rb` : regroupement par client, exclusion des non-facturables, exclusion hors mois, exclusion des statuts non facturables, filtre client, totaux payé/impayé, tri par date de cuisson
  - `spec/requests/admin/billing_spec.rb` : gate d'auth, rendu HTML, export CSV, mois invalide → mois courant
- `bin/rubocop` → no offenses (263 fichiers)
- `brakeman` → 0 security warnings, 0 errors

## NON testé
- Rendu visuel réel / responsive de la page dans un navigateur (vérification manuelle non effectuée).
- Le contenu/format CSV n'a été vérifié que via la requête de test (en-têtes + présence du client), pas ouvert dans un tableur réel.
- Pas de test du sélecteur de mois natif (`<input type="month">`) côté navigateur.
- Génération PDF : volontairement non implémentée (#38).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZmnYjspBYS5FACQjdWp2J)_