### PR TITLE
Catégorie interne sur les produits + ventes par catégorie (#46)

### DIFF
--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -107,7 +107,7 @@ class Admin::ProductsController < Admin::BaseController
 
   def product_params
     params.require(:product).permit(
-      :name, :short_name, :description, :category, :position, :active, :flour, :channel,
+      :name, :short_name, :description, :category, :internal_category, :position, :active, :flour, :channel,
       product_flours_attributes: [ :id, :flour_id, :percentage, :_destroy ]
     )
   end

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -5,6 +5,7 @@ class Admin::ReportsController < Admin::BaseController
     @end_date = @start_date if @end_date < @start_date
 
     @sales_by_product = Order.sales_by_product_between(@start_date, @end_date)
+    @sales_by_internal_category = Order.sales_by_internal_category_between(@start_date, @end_date)
     @revenue_cents = Order.revenue_between(@start_date, @end_date)
     @top_customers = Order.top_customers_between(@start_date, @end_date, limit: 10)
     @weekday_comparison = Order.sales_by_weekday_between(@start_date, @end_date, [ 2, 5 ])

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -45,6 +45,16 @@ module CatalogHelper
     end
   end
 
+  def product_internal_category_heading(internal_category)
+    case internal_category.to_s
+    when "boulangerie" then "Boulangerie"
+    when "epicerie" then "Épicerie"
+    when "traiteur" then "Traiteur"
+    when "autre" then "Autre"
+    else internal_category.to_s.tr("_", " ").capitalize
+    end
+  end
+
   def product_flour_label(flour)
     return "Aucune" if flour.blank?
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -133,6 +133,33 @@ class Order < ApplicationRecord
         end
     end
 
+    def sales_by_internal_category_between(start_date, end_date)
+      total_quantity = Arel.sql("SUM(order_items.qty)")
+      total_revenue = Arel.sql("SUM(order_items.qty * order_items.unit_price_cents)")
+      orders_count = Arel.sql("COUNT(DISTINCT orders.id)")
+
+      completed
+        .in_bake_day_range(start_date, end_date)
+        .joins(order_items: { product_variant: :product })
+        .group("products.internal_category")
+        .order(total_revenue.desc)
+        .pluck(
+          "products.internal_category",
+          orders_count,
+          total_quantity,
+          total_revenue
+        ).map do |internal_category, orders_count, total_quantity, total_cents|
+          {
+            # `pluck` renvoie déjà le nom de l'enum (ex. "boulangerie") ; on
+            # retombe sur la conversion depuis l'entier au cas où.
+            internal_category: Product.internal_categories.key(internal_category) || internal_category.to_s,
+            orders_count: orders_count.to_i,
+            total_quantity: total_quantity.to_i,
+            total_cents: total_cents.to_i
+          }
+        end
+    end
+
     def top_customers_between(start_date, end_date, limit: 10)
       orders_count = Arel.sql("COUNT(DISTINCT orders.id)")
       total_revenue = Arel.sql("SUM(orders.total_cents)")

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,6 +2,9 @@ class Product < ApplicationRecord
   has_soft_deletion
 
   enum :category, { breads: 0, dough_balls: 1 }
+  # Catégorie interne (usage comptable/reporting) : distingue la production
+  # maison (boulangerie) des reventes (épicerie, traiteur, etc.).
+  enum :internal_category, { boulangerie: 0, epicerie: 1, traiteur: 2, autre: 3 }, prefix: true
 
   has_many :product_variants, dependent: :destroy
   has_many :product_availabilities, through: :product_variants
@@ -14,6 +17,7 @@ class Product < ApplicationRecord
 
   validates :name, presence: true
   validates :category, presence: true
+  validates :internal_category, presence: true
   validates :position, presence: true, numericality: { only_integer: true }
   validates :channel, presence: true, inclusion: { in: %w[store admin] }
 

--- a/app/views/admin/products/edit.html.slim
+++ b/app/views/admin/products/edit.html.slim
@@ -2,6 +2,7 @@
 - content_for :layout, "admin"
 
 - category_options = Product.categories.keys.map { |key| [product_category_heading(key), key] }
+- internal_category_options = Product.internal_categories.keys.map { |key| [product_internal_category_heading(key), key] }
 
 .mb-6.flex.justify-between.items-center
   h1.text-2xl.font-bold.text-gray-900 Modifier le produit
@@ -51,6 +52,12 @@
             .text-sm.text-gray-500.text-center.py-4 data-product-flours-target="empty" Aucune farine
         script type="application/json" data-product-flours-target="floursData"
           = raw Flour.not_deleted.ordered.map { |f| { id: f.id, name: f.name } }.to_json
+
+  .grid.grid-cols-1.md:grid-cols-2.gap-6
+    .space-y-2
+      = f.label :internal_category, "Catégorie interne", class: "block text-sm font-medium text-gray-700"
+      p.text-xs.text-gray-500 Usage interne (comptabilité, reporting). Distingue la production maison des reventes.
+      = f.select :internal_category, options_for_select(internal_category_options, @product.internal_category), {}, class: admin_input_class
 
   .space-y-2
     = f.label :description, "Description", class: "block text-sm font-medium text-gray-700"

--- a/app/views/admin/products/new.html.slim
+++ b/app/views/admin/products/new.html.slim
@@ -2,6 +2,7 @@
 - content_for :layout, "admin"
 
 - category_options = Product.categories.keys.map { |key| [product_category_heading(key), key] }
+- internal_category_options = Product.internal_categories.keys.map { |key| [product_internal_category_heading(key), key] }
 
 .mb-6.flex.justify-between.items-center
   h1.text-2xl.font-bold.text-gray-900 Nouveau produit
@@ -51,6 +52,12 @@
             .text-sm.text-gray-500.text-center.py-4 data-product-flours-target="empty" Aucune farine
         script type="application/json" data-product-flours-target="floursData"
           = raw Flour.not_deleted.ordered.map { |f| { id: f.id, name: f.name } }.to_json
+
+  .grid.grid-cols-1.md:grid-cols-2.gap-6
+    .space-y-2
+      = f.label :internal_category, "Catégorie interne", class: "block text-sm font-medium text-gray-700"
+      p.text-xs.text-gray-500 Usage interne (comptabilité, reporting). Distingue la production maison des reventes.
+      = f.select :internal_category, options_for_select(internal_category_options, @product.internal_category), {}, class: admin_input_class
 
   .space-y-2
     = f.label :description, "Description", class: "block text-sm font-medium text-gray-700"

--- a/app/views/admin/products/show.html.slim
+++ b/app/views/admin/products/show.html.slim
@@ -18,6 +18,9 @@
       label.block.text-sm.font-medium.text-gray-700 Catégorie
       p.text-sm.text-gray-900 = product_category_heading(@product.category)
     .space-y-2
+      label.block.text-sm.font-medium.text-gray-700 Catégorie interne
+      p.text-sm.text-gray-900 = product_internal_category_heading(@product.internal_category)
+    .space-y-2
       label.block.text-sm.font-medium.text-gray-700 Position
       p.text-sm.text-gray-900 = @product.position
     .space-y-2

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -95,6 +95,41 @@
   </section>
 </div>
 
+<section class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-6">
+  <h2 class="text-lg font-medium text-gray-900 mb-1">Ventes par catégorie interne</h2>
+  <p class="text-sm text-gray-500 mb-4">Distingue la production maison des reventes (épicerie, traiteur…).</p>
+  <% if @sales_by_internal_category.any? %>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200 text-sm">
+        <thead class="bg-gray-50 text-left">
+          <tr>
+            <th class="px-4 py-2 font-medium text-gray-500 uppercase tracking-wide">Catégorie</th>
+            <th class="px-4 py-2 font-medium text-gray-500 uppercase tracking-wide text-right">Commandes</th>
+            <th class="px-4 py-2 font-medium text-gray-500 uppercase tracking-wide text-right">Quantité</th>
+            <th class="px-4 py-2 font-medium text-gray-500 uppercase tracking-wide text-right">CA</th>
+            <th class="px-4 py-2 font-medium text-gray-500 uppercase tracking-wide text-right">Part</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200">
+          <% @sales_by_internal_category.each do |entry| %>
+            <tr>
+              <td class="px-4 py-2 text-gray-900"><%= product_internal_category_heading(entry[:internal_category]) %></td>
+              <td class="px-4 py-2 text-right text-gray-600"><%= entry[:orders_count] %></td>
+              <td class="px-4 py-2 text-right text-gray-600"><%= entry[:total_quantity] %></td>
+              <td class="px-4 py-2 text-right text-gray-900"><%= reports_currency(entry[:total_cents]) %></td>
+              <td class="px-4 py-2 text-right text-gray-600">
+                <%= revenue_share(entry[:total_cents], @revenue_cents) %> %
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <p class="text-sm text-gray-500">Aucune vente enregistrée sur cette période.</p>
+  <% end %>
+</section>
+
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
   <section class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
     <h2 class="text-lg font-medium text-gray-900 mb-4">Comparaison mardi vs vendredi</h2>

--- a/db/migrate/20260605120000_add_internal_category_to_products.rb
+++ b/db/migrate/20260605120000_add_internal_category_to_products.rb
@@ -1,0 +1,6 @@
+class AddInternalCategoryToProducts < ActiveRecord::Migration[8.0]
+  def change
+    add_column :products, :internal_category, :integer, default: 0, null: false
+    add_index :products, :internal_category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_04_130000) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_05_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -296,9 +296,11 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_04_130000) do
     t.string "flour"
     t.string "channel", default: "store", null: false
     t.datetime "deleted_at"
+    t.integer "internal_category", default: 0, null: false
     t.index ["category", "position", "name"], name: "index_products_on_category_and_position_and_name"
     t.index ["category"], name: "index_products_on_category"
     t.index ["deleted_at"], name: "index_products_on_deleted_at"
+    t.index ["internal_category"], name: "index_products_on_internal_category"
   end
 
   create_table "sms_messages", force: :cascade do |t|

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -5,6 +5,19 @@ FactoryBot.define do
     sequence(:position) { |n| n }
     active { true }
     channel { 'store' }
+    internal_category { :boulangerie }
+
+    trait :epicerie do
+      internal_category { :epicerie }
+    end
+
+    trait :traiteur do
+      internal_category { :traiteur }
+    end
+
+    trait :autre do
+      internal_category { :autre }
+    end
 
     trait :bread do
       category { :breads }

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -92,4 +92,46 @@ RSpec.describe Order, type: :model do
       expect(order.reload.paid_at).to be_within(1.second).of(stored)
     end
   end
+
+  describe '.sales_by_internal_category_between' do
+    let(:bake_day) { create(:bake_day, baked_on: Date.new(2026, 5, 12)) }
+    let(:start_date) { Date.new(2026, 5, 1) }
+    let(:end_date) { Date.new(2026, 5, 31) }
+
+    let(:bakery_variant) do
+      create(:product_variant, product: create(:product, internal_category: :boulangerie))
+    end
+    let(:grocery_variant) do
+      create(:product_variant, product: create(:product, :epicerie))
+    end
+
+    it 'agrège le CA, les quantités et le nombre de commandes par catégorie interne' do
+      order1 = create(:order, :paid, bake_day: bake_day)
+      create(:order_item, order: order1, product_variant: bakery_variant, qty: 2, unit_price_cents: 500)
+      create(:order_item, order: order1, product_variant: grocery_variant, qty: 1, unit_price_cents: 300)
+
+      order2 = create(:order, :ready, bake_day: bake_day)
+      create(:order_item, order: order2, product_variant: bakery_variant, qty: 3, unit_price_cents: 500)
+
+      result = described_class.sales_by_internal_category_between(start_date, end_date)
+      bakery = result.find { |entry| entry[:internal_category] == 'boulangerie' }
+      grocery = result.find { |entry| entry[:internal_category] == 'epicerie' }
+
+      expect(bakery[:total_cents]).to eq(2500) # (2 * 500) + (3 * 500)
+      expect(bakery[:total_quantity]).to eq(5)
+      expect(bakery[:orders_count]).to eq(2)
+
+      expect(grocery[:total_cents]).to eq(300)
+      expect(grocery[:total_quantity]).to eq(1)
+      expect(grocery[:orders_count]).to eq(1)
+    end
+
+    it 'exclut les commandes non finalisées (annulées, impayées, planifiées)' do
+      cancelled = create(:order, :cancelled, bake_day: bake_day)
+      create(:order_item, order: cancelled, product_variant: bakery_variant, qty: 4, unit_price_cents: 500)
+
+      result = described_class.sales_by_internal_category_between(start_date, end_date)
+      expect(result).to be_empty
+    end
+  end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Product, type: :model do
+  describe "internal_category" do
+    it "défaut à boulangerie" do
+      product = Product.new(name: "Pain", category: :breads, position: 1)
+      expect(product.internal_category).to eq("boulangerie")
+    end
+
+    it "expose les catégories internes attendues" do
+      expect(Product.internal_categories.keys).to eq(%w[boulangerie epicerie traiteur autre])
+    end
+
+    it "permet de choisir une catégorie de revente" do
+      product = create(:product, :epicerie)
+      expect(product.reload.internal_category).to eq("epicerie")
+      expect(product.internal_category_epicerie?).to be(true)
+    end
+  end
+end

--- a/spec/requests/admin/reports_spec.rb
+++ b/spec/requests/admin/reports_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+# Admin : reporting des ventes, dont la ventilation par catégorie interne (ISC-46).
+RSpec.describe "Admin::Reports", type: :request do
+  around do |ex|
+    original = ENV["ADMIN_PASSWORD"]
+    ENV["ADMIN_PASSWORD"] = "test-admin-pw"
+    ex.run
+    ENV["ADMIN_PASSWORD"] = original
+  end
+
+  def login_admin
+    post admin_login_path, params: { password: "test-admin-pw" }
+  end
+
+  it "exige une authentification" do
+    get admin_reports_path
+    expect(response).to redirect_to(admin_login_path)
+  end
+
+  context "when authenticated" do
+    before { login_admin }
+
+    let(:bake_day) { create(:bake_day, baked_on: Date.new(2026, 5, 12)) }
+    let(:bakery_variant) do
+      create(:product_variant, product: create(:product, internal_category: :boulangerie))
+    end
+    let(:grocery_variant) do
+      create(:product_variant, product: create(:product, :epicerie))
+    end
+
+    it "affiche la ventilation des ventes par catégorie interne" do
+      order = create(:order, :paid, bake_day: bake_day)
+      create(:order_item, order: order, product_variant: bakery_variant, qty: 2, unit_price_cents: 500)
+      create(:order_item, order: order, product_variant: grocery_variant, qty: 1, unit_price_cents: 300)
+
+      get admin_reports_path(start_date: "2026-05-01", end_date: "2026-05-31")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Ventes par catégorie interne")
+      expect(response.body).to include("Boulangerie")
+      expect(response.body).to include("Épicerie")
+    end
+
+    it "fonctionne sans aucune vente sur la période" do
+      get admin_reports_path(start_date: "2026-05-01", end_date: "2026-05-31")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Ventes par catégorie interne")
+    end
+  end
+end


### PR DESCRIPTION
Closes #46

## Résumé
Ajoute une **catégorie interne** aux produits pour distinguer la production maison des reventes (épicerie, traiteur…), et un reporting des ventes ventilé par cette catégorie.

- **Modèle** : nouveau champ `internal_category` sur `Product` (enum `boulangerie` / `epicerie` / `traiteur` / `autre`, défaut `boulangerie`, `null: false`). Migration + index.
- **Admin produit** : sélecteur « Catégorie interne » dans les formulaires `new`/`edit`, et affichage sur la fiche produit (`show`).
- **Reporting** (`/admin/reports`) : nouvelle section « Ventes par catégorie interne » → CA, nombre de commandes, quantités et part du CA, par catégorie.
- **Agrégation** : `Order.sales_by_internal_category_between` (service de calcul dans le modèle, cohérent avec les autres méthodes de reporting existantes ; ne compte que les commandes finalisées `paid`/`ready`/`picked_up`).
- **i18n** : libellés FR via le helper `product_internal_category_heading`.

## Testé (vert localement)
- `bundle exec rspec` → **305 exemples, 0 échec**
  - `spec/models/product_spec.rb` (enum, défaut, sélection)
  - `spec/models/order_spec.rb` → `.sales_by_internal_category_between` (agrégation CA/quantités/commandes, exclusion des commandes non finalisées)
  - `spec/requests/admin/reports_spec.rb` (auth + rendu de la section par catégorie)
- `bin/rubocop` → **aucune offense**
- Brakeman → **0 avertissement** (lancé directement ; le wrapper `bin/brakeman` ajoute `--ensure-latest` qui s'interrompt car la version épinglée 7.1.0 n'est pas la dernière — artefact d'environnement, sans rapport avec le code)

## NON inclus (volontairement — dépend d'autres issues ouvertes)
Deux points de l'issue #46 dépendent de travaux non encore réalisés et sont donc **laissés de côté** :
1. **CA net après commission Stripe** : nécessite le stockage des frais Stripe (`stripe_fee_cents`) introduit par **#47/#48**, qui n'existe pas encore. Le reporting affiche pour l'instant le **CA brut** par catégorie.
2. **Inclusion dans le mail annuel du 01/01** : le mailer annuel de **#51** n'existe pas encore dans le code.

À reconnecter une fois #47/#48 et #51 mergés.

## NON testé
- Rendu visuel réel dans le navigateur (vérifié uniquement via specs de requête sur le HTML généré).


---
_Generated by [Claude Code](https://claude.ai/code/session_01DNGb7A3i6zMWw8jRrtfuzq)_