### PR TITLE
Afficher la commission Stripe par commande (#47)

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -6,6 +6,8 @@ class Admin::ReportsController < Admin::BaseController
 
     @sales_by_product = Order.sales_by_product_between(@start_date, @end_date)
     @revenue_cents = Order.revenue_between(@start_date, @end_date)
+    @stripe_fees_cents = Order.stripe_fees_between(@start_date, @end_date)
+    @net_revenue_cents = @revenue_cents - @stripe_fees_cents
     @top_customers = Order.top_customers_between(@start_date, @end_date, limit: 10)
     @weekday_comparison = Order.sales_by_weekday_between(@start_date, @end_date, [ 2, 5 ])
     @monthly_sales = Order.sales_by_month_between(@start_date, @end_date)

--- a/app/controllers/api/v1/resource_catalog.rb
+++ b/app/controllers/api/v1/resource_catalog.rb
@@ -97,7 +97,9 @@ module Api
           description: "Paiements Stripe rattachés aux commandes. Contient les identifiants PaymentIntent Stripe.",
           fields: {
             id: "integer", order_id: "integer", stripe_payment_intent_id: "string",
-            status: "enum: succeeded|failed|refunded", created_at: "datetime", updated_at: "datetime"
+            status: "enum: succeeded|failed|refunded",
+            stripe_fee_cents: "integer|null", stripe_fee_euros: "number|null",
+            created_at: "datetime", updated_at: "datetime"
           }
         },
         {

--- a/app/jobs/backfill_stripe_fees_job.rb
+++ b/app/jobs/backfill_stripe_fees_job.rb
@@ -1,0 +1,14 @@
+# Récupère rétroactivement la commission Stripe des paiements existants qui
+# n'ont pas encore de `stripe_fee_cents`.
+#
+# Job one-shot, à lancer manuellement après le déploiement :
+#   BackfillStripeFeesJob.perform_later
+class BackfillStripeFeesJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Payment.succeeded.where(stripe_fee_cents: nil).find_each do |payment|
+      StripeFeeService.fetch_for(payment)
+    end
+  end
+end

--- a/app/jobs/fetch_stripe_fee_job.rb
+++ b/app/jobs/fetch_stripe_fee_job.rb
@@ -1,0 +1,14 @@
+# Récupère et enregistre la commission Stripe d'un paiement, en arrière-plan.
+#
+# Appelé après l'encaissement d'une commande (webhook / page success) pour ne
+# pas ralentir la requête, et pour tolérer le délai éventuel de mise à
+# disposition de la balance transaction côté Stripe.
+class FetchStripeFeeJob < ApplicationJob
+  queue_as :default
+
+  discard_on ActiveJob::DeserializationError
+
+  def perform(payment)
+    StripeFeeService.fetch_for(payment)
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -111,6 +111,16 @@ class Order < ApplicationRecord
       completed.in_bake_day_range(start_date, end_date).sum(:total_cents)
     end
 
+    # Total des commissions Stripe (en cents) prélevées sur les commandes
+    # finalisées payées via Stripe sur la période. Les paiements hors Stripe
+    # (portefeuille, encaissement manuel) n'ont pas de commission.
+    def stripe_fees_between(start_date, end_date)
+      completed
+        .in_bake_day_range(start_date, end_date)
+        .joins(:payment)
+        .sum("payments.stripe_fee_cents")
+    end
+
     def sales_by_product_between(start_date, end_date)
       total_quantity = Arel.sql("SUM(order_items.qty)")
       total_revenue = Arel.sql("SUM(order_items.qty * order_items.unit_price_cents)")

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -19,4 +19,16 @@ class Payment < ApplicationRecord
   def succeeded?
     status == "succeeded"
   end
+
+  # Commission Stripe en euros (nil tant qu'elle n'a pas été récupérée).
+  def stripe_fee_euros
+    return nil if stripe_fee_cents.nil?
+
+    (stripe_fee_cents / 100.0).round(2)
+  end
+
+  # Frais Stripe déjà récupérés depuis l'API ?
+  def stripe_fee_recorded?
+    !stripe_fee_cents.nil?
+  end
 end

--- a/app/serializers/api/v1/payment_serializer.rb
+++ b/app/serializers/api/v1/payment_serializer.rb
@@ -9,6 +9,8 @@ module Api
           order_id: object.order_id,
           stripe_payment_intent_id: object.stripe_payment_intent_id,
           status: object.status,
+          stripe_fee_cents: object.stripe_fee_cents,
+          stripe_fee_euros: object.stripe_fee_euros,
           created_at: iso(object.created_at),
           updated_at: iso(object.updated_at),
           _links: {

--- a/app/services/order_payment_finalizer.rb
+++ b/app/services/order_payment_finalizer.rb
@@ -20,9 +20,13 @@ class OrderPaymentFinalizer
       p.status = :succeeded
     end
 
-    # N'envoyer la confirmation qu'au premier enregistrement du paiement
-    # (idempotent face à la course webhook / page success / job).
-    OrderNotificationService.send_confirmation(@order) if payment.previously_new_record?
+    # N'envoyer la confirmation et ne récupérer la commission Stripe qu'au
+    # premier enregistrement du paiement (idempotent face à la course webhook /
+    # page success / job).
+    if payment.previously_new_record?
+      OrderNotificationService.send_confirmation(@order)
+      FetchStripeFeeJob.perform_later(payment)
+    end
 
     @order
   end

--- a/app/services/stripe_fee_service.rb
+++ b/app/services/stripe_fee_service.rb
@@ -1,0 +1,41 @@
+# Récupère la commission Stripe (frais) d'un paiement et la stocke sur le
+# Payment (`stripe_fee_cents`).
+#
+# La commission n'est pas portée par le PaymentIntent : il faut passer par la
+# Charge associée, puis par sa BalanceTransaction qui expose le champ `fee`.
+#
+# Idempotent : si la commission est déjà enregistrée, on ne refait pas d'appel
+# API. Sûr d'être appelé plusieurs fois (webhook, job de backfill).
+class StripeFeeService
+  def self.fetch_for(payment)
+    new(payment).fetch
+  end
+
+  def initialize(payment)
+    @payment = payment
+  end
+
+  # Renvoie la commission en cents (Integer) si elle a pu être récupérée, sinon nil.
+  def fetch
+    return @payment.stripe_fee_cents if @payment.stripe_fee_recorded?
+    return nil if @payment.stripe_payment_intent_id.blank?
+
+    charge = latest_charge
+    return nil if charge.nil? || charge.balance_transaction.blank?
+
+    balance_transaction = Stripe::BalanceTransaction.retrieve(charge.balance_transaction)
+    fee_cents = balance_transaction.fee
+    @payment.update!(stripe_fee_cents: fee_cents)
+    fee_cents
+  rescue Stripe::StripeError => e
+    Rails.logger.error("StripeFeeService: erreur Stripe pour paiement #{@payment.id} (PI #{@payment.stripe_payment_intent_id}): #{e.message}")
+    Sentry.capture_exception(e) if defined?(Sentry)
+    nil
+  end
+
+  private
+
+  def latest_charge
+    Stripe::Charge.list(payment_intent: @payment.stripe_payment_intent_id, limit: 1).data.first
+  end
+end

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -76,6 +76,16 @@
         <% elsif @order.paid_at %>
           <dd class="mt-1 text-sm text-gray-600">Payé le <%= @order.paid_at.strftime("%d/%m/%Y") %></dd>
         <% end %>
+        <% if @order.payment.present? %>
+          <dd class="mt-1 text-sm text-gray-600">
+            Commission Stripe :
+            <% if @order.payment.stripe_fee_recorded? %>
+              <span class="font-medium text-gray-900"><%= number_to_currency(@order.payment.stripe_fee_euros, unit: "€", separator: ",", delimiter: "") %></span>
+            <% else %>
+              <span class="italic text-gray-500">en attente</span>
+            <% end %>
+          </dd>
+        <% end %>
       </div>
     </dl>
   </div>

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -33,6 +33,29 @@
   </div>
 </div>
 
+<section class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-6">
+  <h2 class="text-lg font-medium text-gray-900 mb-1">Commissions Stripe &amp; CA net</h2>
+  <p class="text-sm text-gray-500 mb-4">
+    Commissions prélevées par Stripe sur les commandes payées en ligne. Les paiements par portefeuille ou hors ligne n'engendrent pas de commission.
+  </p>
+  <dl class="grid grid-cols-1 sm:grid-cols-3 gap-6">
+    <div>
+      <dt class="text-sm font-medium text-gray-500 uppercase tracking-wide">CA brut</dt>
+      <dd class="mt-2 text-2xl font-bold text-gray-900"><%= reports_currency(@revenue_cents) %></dd>
+    </div>
+    <div>
+      <dt class="text-sm font-medium text-gray-500 uppercase tracking-wide">Commissions Stripe</dt>
+      <dd class="mt-2 text-2xl font-bold text-red-600">- <%= reports_currency(@stripe_fees_cents) %></dd>
+      <dd class="mt-1 text-sm text-gray-500"><%= revenue_share(@stripe_fees_cents, @revenue_cents) %> % du CA brut</dd>
+    </div>
+    <div>
+      <dt class="text-sm font-medium text-gray-500 uppercase tracking-wide">CA net</dt>
+      <dd class="mt-2 text-2xl font-bold text-gray-900"><%= reports_currency(@net_revenue_cents) %></dd>
+      <dd class="mt-1 text-sm text-gray-500">Après commissions Stripe</dd>
+    </div>
+  </dl>
+</section>
+
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
   <section class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
     <h2 class="text-lg font-medium text-gray-900 mb-4">Ventes par produit</h2>

--- a/db/migrate/20260606011030_add_stripe_fee_cents_to_payments.rb
+++ b/db/migrate/20260606011030_add_stripe_fee_cents_to_payments.rb
@@ -1,0 +1,9 @@
+class AddStripeFeeCentsToPayments < ActiveRecord::Migration[8.0]
+  def change
+    # Commission Stripe (frais) du PaymentIntent, en cents. Nullable : renseignée
+    # de façon asynchrone après l'encaissement (la balance transaction Stripe
+    # n'est pas toujours disponible immédiatement) et absente pour les paiements
+    # hors Stripe (portefeuille, encaissement manuel).
+    add_column :payments, :stripe_fee_cents, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_04_130000) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_06_011030) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -212,6 +212,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_04_130000) do
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "stripe_fee_cents"
     t.index ["order_id"], name: "index_payments_on_order_id", unique: true
     t.index ["status"], name: "index_payments_on_status"
     t.index ["stripe_payment_intent_id"], name: "index_payments_on_stripe_payment_intent_id", unique: true

--- a/spec/jobs/fetch_stripe_fee_job_spec.rb
+++ b/spec/jobs/fetch_stripe_fee_job_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe FetchStripeFeeJob, type: :job do
+  it 'delegates fee retrieval to StripeFeeService' do
+    payment = create(:payment)
+    expect(StripeFeeService).to receive(:fetch_for).with(payment)
+
+    described_class.perform_now(payment)
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -58,6 +58,45 @@ RSpec.describe Order, type: :model do
     end
   end
 
+  describe '.stripe_fees_between' do
+    let(:bake_day) { create(:bake_day, baked_on: Date.new(2026, 5, 12)) }
+
+    it 'sums the Stripe fees of completed orders paid via Stripe in range' do
+      order_a = create(:order, :paid, bake_day: bake_day, total_cents: 2000)
+      order_b = create(:order, :ready, bake_day: bake_day, total_cents: 3000)
+      create(:payment, order: order_a, stripe_fee_cents: 50)
+      create(:payment, order: order_b, stripe_fee_cents: 75)
+
+      expect(Order.stripe_fees_between(Date.new(2026, 5, 1), Date.new(2026, 5, 31))).to eq(125)
+    end
+
+    it 'ignores fees not yet recorded (nil) and orders without a Stripe payment' do
+      order_with_fee = create(:order, :paid, bake_day: bake_day)
+      create(:payment, order: order_with_fee, stripe_fee_cents: 40)
+
+      order_pending_fee = create(:order, :paid, bake_day: bake_day)
+      create(:payment, order: order_pending_fee, stripe_fee_cents: nil)
+
+      create(:order, :paid, bake_day: bake_day) # paiement portefeuille / hors ligne : pas de Payment
+
+      expect(Order.stripe_fees_between(Date.new(2026, 5, 1), Date.new(2026, 5, 31))).to eq(40)
+    end
+
+    it 'excludes orders outside the bake day range' do
+      out_of_range = create(:order, :paid, bake_day: create(:bake_day, baked_on: Date.new(2026, 4, 1)))
+      create(:payment, order: out_of_range, stripe_fee_cents: 99)
+
+      expect(Order.stripe_fees_between(Date.new(2026, 5, 1), Date.new(2026, 5, 31))).to eq(0)
+    end
+
+    it 'excludes non-completed orders' do
+      cancelled = create(:order, :cancelled, bake_day: bake_day)
+      create(:payment, :refunded, order: cancelled, stripe_fee_cents: 60)
+
+      expect(Order.stripe_fees_between(Date.new(2026, 5, 1), Date.new(2026, 5, 31))).to eq(0)
+    end
+  end
+
   describe '#paid_at' do
     it 'uses the Stripe payment timestamp' do
       order = create(:order)

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Payment, type: :model do
+  describe '#stripe_fee_euros' do
+    it 'converts the fee from cents to euros' do
+      expect(build(:payment, stripe_fee_cents: 123).stripe_fee_euros).to eq(1.23)
+    end
+
+    it 'is nil when the fee has not been recorded yet' do
+      expect(build(:payment, stripe_fee_cents: nil).stripe_fee_euros).to be_nil
+    end
+  end
+
+  describe '#stripe_fee_recorded?' do
+    it 'is true once a fee (even zero) is stored' do
+      expect(build(:payment, stripe_fee_cents: 0).stripe_fee_recorded?).to be(true)
+      expect(build(:payment, stripe_fee_cents: 50).stripe_fee_recorded?).to be(true)
+    end
+
+    it 'is false when no fee is stored' do
+      expect(build(:payment, stripe_fee_cents: nil).stripe_fee_recorded?).to be(false)
+    end
+  end
+end

--- a/spec/requests/admin/reports_spec.rb
+++ b/spec/requests/admin/reports_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+# Admin : reporting — commission Stripe par commande + CA net (#47).
+RSpec.describe "Admin::Reports", type: :request do
+  around do |ex|
+    original = ENV["ADMIN_PASSWORD"]
+    ENV["ADMIN_PASSWORD"] = "test-admin-pw"
+    ex.run
+    ENV["ADMIN_PASSWORD"] = original
+  end
+
+  def login_admin
+    post admin_login_path, params: { password: "test-admin-pw" }
+  end
+
+  it "exige une authentification" do
+    get admin_reports_path
+    expect(response).to redirect_to(admin_login_path)
+  end
+
+  context "when authenticated" do
+    before { login_admin }
+
+    let(:bake_day) { create(:bake_day, baked_on: Date.new(2026, 5, 12)) }
+
+    it "affiche le CA net et le total des commissions Stripe" do
+      order = create(:order, :paid, bake_day: bake_day, total_cents: 10_000)
+      create(:payment, order: order, stripe_fee_cents: 250)
+
+      get admin_reports_path(start_date: "2026-05-01", end_date: "2026-05-31")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Commissions Stripe")
+      expect(response.body).to include("CA net")
+      # CA net = 10000 - 250 = 9750 cents → 97,50 €
+      expect(response.body).to include("97,50")
+      expect(response.body).to include("2,50")
+    end
+  end
+end

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe 'Stripe webhook', type: :request do
     allow(OrderNotificationService).to receive(:send_confirmation)
   end
 
+  # Bascule sur l'adapter ActiveJob `:test` uniquement pour les exemples qui
+  # vérifient l'enfilement d'un job (matchers `have_enqueued_job`).
+  around(:each, :active_job_test) do |example|
+    original_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+    example.run
+    ActiveJob::Base.queue_adapter = original_adapter
+  end
+
   let(:bake_day) { create(:bake_day, :can_order) }
   let(:customer) { create(:customer) }
   let(:pi_id) { "pi_test_#{SecureRandom.hex(6)}" }
@@ -50,6 +59,11 @@ RSpec.describe 'Stripe webhook', type: :request do
 
       expect { deliver(event) }.not_to change(Order, :count)
       expect(response).to have_http_status(:ok)
+    end
+
+    it 'enqueues the Stripe fee retrieval for the new payment', :active_job_test do
+      expect { deliver(fabricate_event(type: 'payment_intent.succeeded')) }
+        .to have_enqueued_job(FetchStripeFeeJob)
     end
   end
 

--- a/spec/services/stripe_fee_service_spec.rb
+++ b/spec/services/stripe_fee_service_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe StripeFeeService do
+  let(:payment) { create(:payment, stripe_payment_intent_id: 'pi_test_fee', stripe_fee_cents: nil) }
+
+  def stub_charge(balance_transaction:)
+    charge = double('Stripe::Charge', balance_transaction: balance_transaction)
+    list = double('Stripe::ListObject', data: [ charge ])
+    allow(Stripe::Charge).to receive(:list)
+      .with(payment_intent: 'pi_test_fee', limit: 1)
+      .and_return(list)
+  end
+
+  describe '.fetch_for' do
+    it 'retrieves the fee from the balance transaction and stores it' do
+      stub_charge(balance_transaction: 'txn_123')
+      allow(Stripe::BalanceTransaction).to receive(:retrieve).with('txn_123')
+        .and_return(double('Stripe::BalanceTransaction', fee: 42))
+
+      result = described_class.fetch_for(payment)
+
+      expect(result).to eq(42)
+      expect(payment.reload.stripe_fee_cents).to eq(42)
+    end
+
+    it 'does not call the Stripe API when the fee is already recorded' do
+      payment.update!(stripe_fee_cents: 30)
+      expect(Stripe::Charge).not_to receive(:list)
+
+      expect(described_class.fetch_for(payment)).to eq(30)
+    end
+
+    it 'returns nil and stores nothing when there is no charge yet' do
+      list = double('Stripe::ListObject', data: [])
+      allow(Stripe::Charge).to receive(:list).and_return(list)
+
+      expect(described_class.fetch_for(payment)).to be_nil
+      expect(payment.reload.stripe_fee_cents).to be_nil
+    end
+
+    it 'returns nil when the charge has no balance transaction yet' do
+      stub_charge(balance_transaction: nil)
+
+      expect(described_class.fetch_for(payment)).to be_nil
+      expect(payment.reload.stripe_fee_cents).to be_nil
+    end
+
+    it 'swallows Stripe errors and returns nil' do
+      allow(Stripe::Charge).to receive(:list).and_raise(Stripe::StripeError.new('boom'))
+
+      expect(described_class.fetch_for(payment)).to be_nil
+      expect(payment.reload.stripe_fee_cents).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Closes #47

## Résumé
Récupère et affiche la **commission Stripe (frais)** prélevée sur chaque commande payée en ligne, pour le reporting et la comptabilité.

- **Modèle** : nouveau champ `stripe_fee_cents` (nullable) sur `Payment` + helpers `stripe_fee_euros` / `stripe_fee_recorded?`. Migration + mise à jour du schema.
- **Service** : `StripeFeeService` récupère la commission via `Stripe::Charge.list(payment_intent:)` → `Stripe::BalanceTransaction.retrieve(...).fee` et la stocke. Idempotent, tolérant aux erreurs Stripe.
- **Récupération asynchrone** : `FetchStripeFeeJob` enfilé au premier enregistrement du paiement (`OrderPaymentFinalizer`) — n'alourdit pas le webhook et tolère le délai de mise à dispo de la balance transaction.
- **Backfill** : `BackfillStripeFeesJob` (one-shot) pour récupérer rétroactivement la commission des paiements existants (`BackfillStripeFeesJob.perform_later`).
- **Reporting** (`/admin/reports`) : nouvelle section « Commissions Stripe & CA net » → CA brut, total des commissions (+ part du CA), CA net. Agrégation via `Order.stripe_fees_between` (cohérente avec les autres méthodes de reporting ; ne compte que les commandes finalisées payées via Stripe).
- **Fiche commande admin** : affichage de la commission Stripe (ou « en attente » si pas encore récupérée).
- **API agent** (lecture seule) : exposition de `stripe_fee_cents` / `stripe_fee_euros` (serializer Payment + catalogue de ressources, donc OpenAPI/guide synchronisés).

## Testé (vert localement)
- `bin/rspec` → **314 exemples, 0 échec**
  - `spec/models/payment_spec.rb` (helpers commission)
  - `spec/models/order_spec.rb` → `.stripe_fees_between` (somme, exclusion nil / hors Stripe / hors période / non finalisées)
  - `spec/services/stripe_fee_service_spec.rb` (récupération, idempotence, charge/balance absente, erreurs Stripe)
  - `spec/jobs/fetch_stripe_fee_job_spec.rb` (délégation au service)
  - `spec/requests/webhooks_spec.rb` (enfilement du job à l'encaissement)
  - `spec/requests/admin/reports_spec.rb` (rendu CA net + commissions + auth)
- `bin/rubocop` → **aucune offense** (278 fichiers)
- Brakeman → **0 avertissement** (lancé via `Gem.bin_path` ; le wrapper `bin/brakeman` ajoute `--ensure-latest` qui s'interrompt car la version épinglée 7.1.0 n'est pas la dernière — artefact d'environnement, sans rapport avec le code)

## NON testé
- Appels réels à l'API Stripe (`Stripe::Charge.list` / `Stripe::BalanceTransaction.retrieve`) : stubbés dans les specs, non vérifiés contre un vrai compte Stripe.
- Rendu visuel réel dans le navigateur (vérifié uniquement via specs de requête sur le HTML généré).
- Exécution du `BackfillStripeFeesJob` sur des données de production.

## Note
Débloque le « CA net après commission Stripe » laissé de côté dans la PR #62 (#46), qui attendait l'introduction de `stripe_fee_cents`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSAc3PCgSXvu6eZYUsD6QF)_