### PR TITLE
Reporting des remboursements (admin)

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -8,7 +8,12 @@ class Admin::ReportsController < Admin::BaseController
     @sales_by_internal_category = Order.sales_by_internal_category_between(@start_date, @end_date)
     @revenue_cents = Order.revenue_between(@start_date, @end_date)
     @stripe_fees_cents = Order.stripe_fees_between(@start_date, @end_date)
-    @net_revenue_cents = @revenue_cents - @stripe_fees_cents
+    @refunds = Order.refunds_summary_between(@start_date, @end_date)
+    # Stripe conserve sa commission sur les commandes remboursées : on la
+    # déduit donc aussi du CA net, en plus des commissions sur les ventes.
+    @refund_stripe_fees_cents = @refunds[:stripe_fee_cents]
+    @total_stripe_fees_cents = @stripe_fees_cents + @refund_stripe_fees_cents
+    @net_revenue_cents = @revenue_cents - @total_stripe_fees_cents
     @top_customers = Order.top_customers_between(@start_date, @end_date, limit: 10)
     @weekday_comparison = Order.sales_by_weekday_between(@start_date, @end_date, [ 2, 5 ])
     @monthly_sales = Order.sales_by_month_between(@start_date, @end_date)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -121,6 +121,50 @@ class Order < ApplicationRecord
         .sum("payments.stripe_fee_cents")
     end
 
+    # Remboursements (Stripe + portefeuille) effectués sur la période, ventilés
+    # par jour de cuisson de la commande remboursée — même axe temporel que le CA.
+    # Les commandes remboursées (statut `cancelled`) sont déjà exclues du CA via
+    # le scope `completed`.
+    def refunds_summary_between(start_date, end_date)
+      stripe = stripe_refunds_between(start_date, end_date)
+      wallet = wallet_refunds_between(start_date, end_date)
+
+      {
+        stripe: stripe,
+        wallet: wallet,
+        count: stripe[:count] + wallet[:count],
+        amount_cents: stripe[:amount_cents] + wallet[:amount_cents],
+        # Stripe ne rembourse pas sa commission lors d'un remboursement : elle
+        # reste donc à la charge de la boulangerie et grève le CA net.
+        stripe_fee_cents: stripe[:stripe_fee_cents]
+      }
+    end
+
+    # Remboursements Stripe : commandes dont le paiement a été remboursé.
+    def stripe_refunds_between(start_date, end_date)
+      scope = in_bake_day_range(start_date, end_date)
+                .joins(:payment)
+                .merge(Payment.refunded)
+
+      {
+        count: scope.distinct.count(:id),
+        amount_cents: scope.sum(:total_cents),
+        stripe_fee_cents: scope.sum("payments.stripe_fee_cents")
+      }
+    end
+
+    # Remboursements portefeuille : transactions de type `order_refund`.
+    def wallet_refunds_between(start_date, end_date)
+      scope = WalletTransaction.order_refund
+                .joins(order: :bake_day)
+                .where(bake_days: { baked_on: start_date..end_date })
+
+      {
+        count: scope.count,
+        amount_cents: scope.sum(:amount_cents)
+      }
+    end
+
     def sales_by_product_between(start_date, end_date)
       total_quantity = Arel.sql("SUM(order_items.qty)")
       total_revenue = Arel.sql("SUM(order_items.qty * order_items.unit_price_cents)")

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -45,13 +45,53 @@
     </div>
     <div>
       <dt class="text-sm font-medium text-gray-500 uppercase tracking-wide">Commissions Stripe</dt>
-      <dd class="mt-2 text-2xl font-bold text-red-600">- <%= reports_currency(@stripe_fees_cents) %></dd>
-      <dd class="mt-1 text-sm text-gray-500"><%= revenue_share(@stripe_fees_cents, @revenue_cents) %> % du CA brut</dd>
+      <dd class="mt-2 text-2xl font-bold text-red-600">- <%= reports_currency(@total_stripe_fees_cents) %></dd>
+      <dd class="mt-1 text-sm text-gray-500"><%= revenue_share(@total_stripe_fees_cents, @revenue_cents) %> % du CA brut</dd>
+      <% if @refund_stripe_fees_cents.positive? %>
+        <dd class="mt-1 text-sm text-gray-500">
+          dont <%= reports_currency(@refund_stripe_fees_cents) %> non remboursés sur remboursements
+        </dd>
+      <% end %>
     </div>
     <div>
       <dt class="text-sm font-medium text-gray-500 uppercase tracking-wide">CA net</dt>
       <dd class="mt-2 text-2xl font-bold text-gray-900"><%= reports_currency(@net_revenue_cents) %></dd>
-      <dd class="mt-1 text-sm text-gray-500">Après commissions Stripe</dd>
+      <dd class="mt-1 text-sm text-gray-500">Après commissions Stripe (ventes et remboursements)</dd>
+    </div>
+  </dl>
+</section>
+
+<section class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-6">
+  <h2 class="text-lg font-medium text-gray-900 mb-1">Remboursements</h2>
+  <p class="text-sm text-gray-500 mb-4">
+    Remboursements Stripe (commandes annulées remboursées) et remboursements vers le portefeuille
+    sur la période, ventilés par jour de cuisson de la commande. Les commandes remboursées sont
+    exclues du chiffre d'affaires.
+  </p>
+  <dl class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+    <div>
+      <dt class="text-sm font-medium text-gray-500 uppercase tracking-wide">Remboursements</dt>
+      <dd class="mt-2 text-2xl font-bold text-gray-900"><%= @refunds[:count] %></dd>
+      <dd class="mt-1 text-sm text-gray-500">
+        <%= @refunds[:stripe][:count] %> Stripe · <%= @refunds[:wallet][:count] %> portefeuille
+      </dd>
+    </div>
+    <div>
+      <dt class="text-sm font-medium text-gray-500 uppercase tracking-wide">Montant total remboursé</dt>
+      <dd class="mt-2 text-2xl font-bold text-gray-900"><%= reports_currency(@refunds[:amount_cents]) %></dd>
+      <dd class="mt-1 text-sm text-gray-500">Stripe + portefeuille</dd>
+    </div>
+    <div>
+      <dt class="text-sm font-medium text-gray-500 uppercase tracking-wide">Remboursé via Stripe</dt>
+      <dd class="mt-2 text-2xl font-bold text-gray-900"><%= reports_currency(@refunds[:stripe][:amount_cents]) %></dd>
+      <dd class="mt-1 text-sm text-red-600">
+        commission non récupérée : <%= reports_currency(@refunds[:stripe][:stripe_fee_cents]) %>
+      </dd>
+    </div>
+    <div>
+      <dt class="text-sm font-medium text-gray-500 uppercase tracking-wide">Remboursé sur portefeuille</dt>
+      <dd class="mt-2 text-2xl font-bold text-gray-900"><%= reports_currency(@refunds[:wallet][:amount_cents]) %></dd>
+      <dd class="mt-1 text-sm text-gray-500">Crédité au portefeuille client</dd>
     </div>
   </dl>
 </section>

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -97,6 +97,64 @@ RSpec.describe Order, type: :model do
     end
   end
 
+  describe '.revenue_between' do
+    let(:bake_day) { create(:bake_day, baked_on: Date.new(2026, 5, 12)) }
+
+    it 'exclut les commandes remboursées (annulées) du chiffre d\'affaires' do
+      create(:order, :paid, bake_day: bake_day, total_cents: 2000)
+
+      refunded = create(:order, :cancelled, bake_day: bake_day, total_cents: 3000)
+      create(:payment, :refunded, order: refunded, stripe_fee_cents: 60)
+
+      expect(Order.revenue_between(Date.new(2026, 5, 1), Date.new(2026, 5, 31))).to eq(2000)
+    end
+  end
+
+  describe '.refunds_summary_between' do
+    let(:range_start) { Date.new(2026, 5, 1) }
+    let(:range_end) { Date.new(2026, 5, 31) }
+    let(:bake_day) { create(:bake_day, baked_on: Date.new(2026, 5, 12)) }
+
+    it 'agrège les remboursements Stripe et portefeuille de la période' do
+      stripe_refund = create(:order, :cancelled, bake_day: bake_day, total_cents: 2000)
+      create(:payment, :refunded, order: stripe_refund, stripe_fee_cents: 60)
+
+      wallet_order = create(:order, :cancelled, bake_day: bake_day, total_cents: 1500)
+      create(:wallet_transaction, :order_refund, order: wallet_order, amount_cents: 1500)
+
+      summary = Order.refunds_summary_between(range_start, range_end)
+
+      expect(summary[:count]).to eq(2)
+      expect(summary[:amount_cents]).to eq(3500)
+      expect(summary[:stripe_fee_cents]).to eq(60)
+      expect(summary[:stripe][:count]).to eq(1)
+      expect(summary[:stripe][:amount_cents]).to eq(2000)
+      expect(summary[:wallet][:count]).to eq(1)
+      expect(summary[:wallet][:amount_cents]).to eq(1500)
+    end
+
+    it 'exclut les remboursements dont le jour de cuisson est hors période' do
+      out = create(:order, :cancelled, bake_day: create(:bake_day, baked_on: Date.new(2026, 4, 1)), total_cents: 2000)
+      create(:payment, :refunded, order: out, stripe_fee_cents: 60)
+
+      summary = Order.refunds_summary_between(range_start, range_end)
+
+      expect(summary[:count]).to eq(0)
+      expect(summary[:amount_cents]).to eq(0)
+      expect(summary[:stripe_fee_cents]).to eq(0)
+    end
+
+    it 'ignore les paiements non remboursés' do
+      paid = create(:order, :paid, bake_day: bake_day, total_cents: 2000)
+      create(:payment, order: paid, stripe_fee_cents: 50)
+
+      summary = Order.refunds_summary_between(range_start, range_end)
+
+      expect(summary[:stripe][:count]).to eq(0)
+      expect(summary[:stripe][:amount_cents]).to eq(0)
+    end
+  end
+
   describe '#paid_at' do
     it 'uses the Stripe payment timestamp' do
       order = create(:order)

--- a/spec/requests/admin/reports_spec.rb
+++ b/spec/requests/admin/reports_spec.rb
@@ -44,6 +44,26 @@ RSpec.describe "Admin::Reports", type: :request do
       expect(response.body).to include("2,50")
     end
 
+    it "affiche la section remboursements et déduit la commission Stripe non remboursée du CA net" do
+      sale = create(:order, :paid, bake_day: bake_day, total_cents: 10_000)
+      create(:payment, order: sale, stripe_fee_cents: 250)
+
+      stripe_refund = create(:order, :cancelled, bake_day: bake_day, total_cents: 3_000)
+      create(:payment, :refunded, order: stripe_refund, stripe_fee_cents: 90)
+
+      wallet_order = create(:order, :cancelled, bake_day: bake_day, total_cents: 1_500)
+      create(:wallet_transaction, :order_refund, order: wallet_order, amount_cents: 1_500)
+
+      get admin_reports_path(start_date: "2026-05-01", end_date: "2026-05-31")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Remboursements")
+      # Montant total remboursé = 3000 + 1500 = 4500 cents → 45,00 €
+      expect(response.body).to include("45,00")
+      # CA net = 10000 - 250 (commission ventes) - 90 (commission remboursement) = 9660 → 96,60 €
+      expect(response.body).to include("96,60")
+    end
+
     it "affiche la ventilation des ventes par catégorie interne" do
       order = create(:order, :paid, bake_day: bake_day)
       create(:order_item, order: order, product_variant: bakery_variant, qty: 2, unit_price_cents: 500)


### PR DESCRIPTION
Closes #48

## Résumé
Ajoute le suivi comptable des remboursements dans la page `/admin/reports`.

- **Section « Remboursements »** : nombre de remboursements (ventilé Stripe / portefeuille), montant total remboursé, montant remboursé via Stripe avec la **commission Stripe non récupérée**, et montant crédité aux portefeuilles clients.
- **CA net ajusté** : la commission Stripe sur les commandes remboursées (que Stripe conserve) est désormais déduite du CA net, en plus des commissions sur les ventes. Le libellé de la section « Commissions Stripe & CA net » a été clarifié en conséquence.
- **CA correct** : les commandes remboursées (statut `cancelled`) étaient déjà exclues du chiffre d'affaires via le scope `completed` ; un test le verrouille explicitement.

Axe temporel : comme le reste du reporting, les remboursements sont ventilés par **jour de cuisson** de la commande remboursée (`bake_days.baked_on` dans la période sélectionnée).

### Détail technique
- `Order.refunds_summary_between` (+ `stripe_refunds_between`, `wallet_refunds_between`) — agrégations cohérentes avec `revenue_between` / `stripe_fees_between` existantes.
- `Admin::ReportsController#index` expose `@refunds`, `@refund_stripe_fees_cents`, `@total_stripe_fees_cents` et recalcule `@net_revenue_cents`.
- Vue : nouvelle section + ajustement de la section commissions.

## Testé
- `bundle exec rspec` (via `bin/rspec`) : **326 exemples, 0 échec**, dont :
  - `spec/models/order_spec.rb` : `.refunds_summary_between` (agrégation Stripe + portefeuille, hors période, paiements non remboursés) et `.revenue_between` (exclusion des commandes remboursées).
  - `spec/requests/admin/reports_spec.rb` : affichage de la section remboursements + CA net déduisant la commission Stripe non remboursée.
- `bin/rubocop` : **aucune offense** (280 fichiers).
- Brakeman : **0 alerte de sécurité** (lancé directement ; le binstub `bin/brakeman` s'interrompt avec `--ensure-latest` car la version 7.1.0 installée n'est pas la dernière — problème d'environnement, pas du code).

## NON testé
- Aucune vérification visuelle dans un navigateur (rendu Tailwind de la nouvelle section).
- Pas testé sur des **remboursements Stripe partiels** : `RefundService` ne fait que des remboursements complets, donc `total_cents` = montant remboursé. Si des remboursements partiels apparaissent un jour, le montant affiché serait à revoir.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbJXvBT7xwBdNrkwYMhMbq)_