### PR TITLE
Checkout : paiement en ligne (Bancontact) coché par défaut

### DIFF
--- a/app/views/checkout/new.html.erb
+++ b/app/views/checkout/new.html.erb
@@ -155,11 +155,11 @@
         <label class="block text-sm font-medium text-gray-700 mb-3">Méthode de paiement</label>
         <div class="space-y-3">
           <label class="flex items-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-blue-500 transition payment-method-option" data-payment-method="cash">
-            <input type="radio" name="payment_method" value="cash" class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300" checked>
+            <input type="radio" name="payment_method" value="cash" class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300">
             <span class="ml-3 font-medium text-gray-700">Payer ma commande en liquide au retrait</span>
           </label>
           <label class="flex items-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-blue-500 transition payment-method-option" data-payment-method="online">
-            <input type="radio" name="payment_method" value="online" class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300">
+            <input type="radio" name="payment_method" value="online" class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300" checked>
             <span class="ml-3 font-medium text-gray-700">Payer en ligne avec Bancontact ou autre</span>
           </label>
         </div>
@@ -207,7 +207,7 @@
   let paymentElement;
   let elements;
   let stripeInitialized = false;
-  let currentPaymentMethod = 'cash'; // Par défaut, paiement cash
+  let currentPaymentMethod = 'online'; // Par défaut, paiement en ligne (Bancontact)
 
   // Initialiser l'état de la méthode de paiement
   function initializePaymentMethodState() {

--- a/spec/requests/checkout_spec.rb
+++ b/spec/requests/checkout_spec.rb
@@ -69,4 +69,18 @@ RSpec.describe 'Checkout — réservation au paiement', type: :request do
       expect(response).to have_http_status(:unprocessable_content)
     end
   end
+
+  describe 'GET /checkout/new — méthode de paiement par défaut' do
+    it 'sélectionne « en ligne » par défaut et non « liquide »' do
+      get '/checkout/new'
+
+      expect(response).to have_http_status(:ok)
+
+      online_radio = response.body[%r{<input[^>]*value="online"[^>]*>}]
+      cash_radio = response.body[%r{<input[^>]*value="cash"[^>]*>}]
+
+      expect(online_radio).to include('checked')
+      expect(cash_radio).not_to include('checked')
+    end
+  end
 end


### PR DESCRIPTION
Closes #81

## Résumé
Sur la page de paiement de l'e-shop (`app/views/checkout/new.html.erb`), le mode de paiement par défaut passe de « liquide au retrait » (`cash`) à « en ligne avec Bancontact ou autre » (`online`), pour pousser l'encaissement en ligne.

Trois changements, conformes aux pistes techniques de l'issue :
- Radio `value="cash"` : retrait de l'attribut `checked`.
- Radio `value="online"` : ajout de l'attribut `checked`.
- Initialisation JS `let currentPaymentMethod = 'online'` (au lieu de `'cash'`) + commentaire ajusté.

Aucune modification serveur n'est nécessaire : `CheckoutController` lit toujours `params[:payment_method]`. La mécanique JS existante (`initializePaymentMethodState`, `initStripe`) gère déjà le cas `online` : la section Stripe s'affiche d'emblée et le bouton vert « Confirmer la commande » (cash) est masqué. Le client reste libre de basculer manuellement sur « liquide » (non-régression assurée par `handlePaymentMethodChange`).

## Testé
- Nouveau spec de requête (`spec/requests/checkout_spec.rb`) : `GET /checkout/new` rend le radio « online » avec `checked` et le radio « cash » sans `checked`.
- Suite complète : `bundle exec rspec` → **327 exemples, 0 échec**.
- `bin/rubocop` → **aucune offense**.
- `brakeman` → **0 avertissement de sécurité, 0 erreur**.

## NON testé
- Comportement front-end réel dans le navigateur (affichage Stripe d'emblée, bascule manuelle vers « liquide », confirmation effective d'une commande dans les deux modes) : non vérifié manuellement faute d'environnement navigateur/Stripe dans ce run. La logique JS sous-jacente est inchangée et déjà en place.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SB5ZtXzT6BGLYwR67sXX2i)_