### PR TITLE
Gabarit d'issue + gate de complétude (agent nocturne)

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-autonome.yml
+++ b/.github/ISSUE_TEMPLATE/feature-autonome.yml
@@ -1,0 +1,62 @@
+name: "Feature — exécution autonome"
+description: "Décrire une feature avec TOUT le contexte pour qu'un agent autonome la traite seul la nuit."
+title: "[Feature] "
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## ⚠️ Lis-moi
+        Un agent autonome pourra traiter cette issue **sans accès à la conversation d'origine** — il n'a que ce texte + le repo cloné.
+        **Tout ce qui n'est pas écrit ici (ou trouvable dans le repo) n'existe pas pour lui.** Remplis chaque section.
+        L'architecture et les conventions du projet sont dans `CLAUDE.md` à la racine du repo — l'agent les lira.
+        L'issue ne sera traitée que si tu lui ajoutes le label `agent:ready` (un contrôle automatique vérifie qu'elle est complète avant de l'accepter).
+  - type: textarea
+    id: contexte
+    attributes:
+      label: "Contexte / problème"
+      description: "Ce qui est cassé ou manquant aujourd'hui, et pourquoi ça compte. L'état actuel."
+    validations:
+      required: true
+  - type: textarea
+    id: criteres
+    attributes:
+      label: "Critères d'acceptation"
+      description: "Un comportement vérifiable par ligne (cases à cocher). C'est la définition du fini ; l'agent doit pouvoir cocher chaque ligne."
+      value: |
+        - [ ]
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+  - type: textarea
+    id: perimetre
+    attributes:
+      label: "Périmètre (dans / hors)"
+      description: "Ce qui EST inclus et surtout ce qui n'est PAS inclus (anti-scope), pour éviter que l'agent dérape."
+      placeholder: |
+        Inclus : …
+        Hors scope : …
+    validations:
+      required: true
+  - type: textarea
+    id: zones-code
+    attributes:
+      label: "Zones de code concernées"
+      description: "Pointe les fichiers/dossiers probables (controllers, vues/pages, models, services…). L'agent peut explorer, mais ces pointeurs évitent les éditions au mauvais endroit."
+    validations:
+      required: true
+  - type: textarea
+    id: tests
+    attributes:
+      label: "Stratégie de test"
+      description: "Quels tests l'agent doit ajouter/lancer (ex. RSpec : … ; front : …). Nomme les cas clés."
+    validations:
+      required: true
+  - type: textarea
+    id: dod
+    attributes:
+      label: "Definition of Done"
+      description: "En une phrase : à quoi on reconnaît que c'est fini et mergeable."
+    validations:
+      required: true

--- a/.github/workflows/agent-ready-gate.yml
+++ b/.github/workflows/agent-ready-gate.yml
@@ -1,0 +1,51 @@
+name: Agent-ready completeness gate
+# Quand une issue reçoit le label `agent:ready`, vérifie qu'elle est assez complète
+# pour une exécution autonome. Si non : retire `agent:ready` + commente ce qui manque.
+# L'agent nocturne ne voit ainsi jamais une issue incomplète.
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  gate:
+    if: github.event.label.name == 'agent:ready'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Vérifier la complétude
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BODY: ${{ github.event.issue.body }}
+          NUM: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          missing=()
+          # Sections obligatoires (sous-chaînes des en-têtes du gabarit d'issue)
+          while IFS= read -r sec; do
+            [ -z "$sec" ] && continue
+            printf '%s' "$BODY" | grep -qiF "$sec" || missing+=("$sec")
+          done <<'SECTIONS'
+          Contexte
+          Critères d'acceptation
+          Périmètre
+          Zones de code
+          Stratégie de test
+          Definition of Done
+          SECTIONS
+          # Au moins un critère d'acceptation sous forme de case à cocher
+          printf '%s' "$BODY" | grep -qE '^[[:space:]]*- \[[ xX]\]' \
+            || missing+=("au moins un critère d'acceptation en case à cocher (- [ ])")
+
+          if [ ${#missing[@]} -eq 0 ]; then
+            echo "Issue #$NUM complète — agent:ready conservé."
+            exit 0
+          fi
+
+          list=$(printf '%s\n' "${missing[@]}" | sed 's/^/- /')
+          gh issue edit "$NUM" -R "$REPO" --remove-label "agent:ready"
+          gh issue comment "$NUM" -R "$REPO" --body "🤖 **Pas encore prête pour l'agent nocturne.** Le label \`agent:ready\` a été retiré : l'agent autonome n'a que l'issue + le repo, et il manque des éléments pour qu'il puisse la traiter seul.
+
+Complète ces points (idéalement via le gabarit *Feature — exécution autonome*), puis remets le label \`agent:ready\` :
+$list"

--- a/.github/workflows/agent-ready-gate.yml
+++ b/.github/workflows/agent-ready-gate.yml
@@ -1,7 +1,6 @@
 name: Agent-ready completeness gate
 # Quand une issue reçoit le label `agent:ready`, vérifie qu'elle est assez complète
-# pour une exécution autonome. Si non : retire `agent:ready` + commente ce qui manque.
-# L'agent nocturne ne voit ainsi jamais une issue incomplète.
+# pour une exécution autonome. Sinon : retire `agent:ready` + commente ce qui manque.
 on:
   issues:
     types: [labeled]
@@ -14,7 +13,7 @@ jobs:
     if: github.event.label.name == 'agent:ready'
     runs-on: ubuntu-latest
     steps:
-      - name: Vérifier la complétude
+      - name: Verifier la completude
         env:
           GH_TOKEN: ${{ github.token }}
           BODY: ${{ github.event.issue.body }}
@@ -22,30 +21,19 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           missing=()
-          # Sections obligatoires (sous-chaînes des en-têtes du gabarit d'issue)
-          while IFS= read -r sec; do
-            [ -z "$sec" ] && continue
+          for sec in "Contexte" "Critères d'acceptation" "Périmètre" "Zones de code" "Stratégie de test" "Definition of Done"; do
             printf '%s' "$BODY" | grep -qiF "$sec" || missing+=("$sec")
-          done <<'SECTIONS'
-          Contexte
-          Critères d'acceptation
-          Périmètre
-          Zones de code
-          Stratégie de test
-          Definition of Done
-          SECTIONS
-          # Au moins un critère d'acceptation sous forme de case à cocher
-          printf '%s' "$BODY" | grep -qE '^[[:space:]]*- \[[ xX]\]' \
-            || missing+=("au moins un critère d'acceptation en case à cocher (- [ ])")
-
+          done
+          printf '%s' "$BODY" | grep -qE '^[[:space:]]*- \[[ xX]\]' || missing+=("au moins un critère d'acceptation en case à cocher (- [ ])")
           if [ ${#missing[@]} -eq 0 ]; then
             echo "Issue #$NUM complète — agent:ready conservé."
             exit 0
           fi
-
-          list=$(printf '%s\n' "${missing[@]}" | sed 's/^/- /')
+          {
+            echo "🤖 **Pas encore prête pour l'agent nocturne.** Le label \`agent:ready\` a été retiré : l'agent autonome n'a que l'issue + le repo, et il manque des éléments pour qu'il puisse la traiter seul."
+            echo ""
+            echo "Complète ces points (idéalement via le gabarit *Feature — exécution autonome*), puis remets le label \`agent:ready\` :"
+            printf -- '- %s\n' "${missing[@]}"
+          } > /tmp/gate-msg.md
           gh issue edit "$NUM" -R "$REPO" --remove-label "agent:ready"
-          gh issue comment "$NUM" -R "$REPO" --body "🤖 **Pas encore prête pour l'agent nocturne.** Le label \`agent:ready\` a été retiré : l'agent autonome n'a que l'issue + le repo, et il manque des éléments pour qu'il puisse la traiter seul.
-
-Complète ces points (idéalement via le gabarit *Feature — exécution autonome*), puis remets le label \`agent:ready\` :
-$list"
+          gh issue comment "$NUM" -R "$REPO" --body-file /tmp/gate-msg.md


### PR DESCRIPTION
Ajoute le gabarit d'issue *Feature — exécution autonome* et un gate GitHub : quand une issue reçoit le label `agent:ready`, il vérifie qu'elle est complète (contexte, critères, périmètre, zones de code, tests, DoD) et, sinon, retire le label + commente ce qui manque. Objectif : l'agent nocturne ne traite que des issues complètes. Aucun impact runtime sur l'app (déclencheur `issues` uniquement).