### PR TITLE
Bouton admin : annuler une fournée et rembourser tous les clients

### DIFF
--- a/app/controllers/admin/bake_days_controller.rb
+++ b/app/controllers/admin/bake_days_controller.rb
@@ -1,5 +1,5 @@
 class Admin::BakeDaysController < Admin::BaseController
-  before_action :set_bake_day, only: [ :show, :edit, :update, :destroy ]
+  before_action :set_bake_day, only: [ :show, :edit, :update, :destroy, :cancel ]
 
   def index
     # Jours futurs (aujourd'hui et futurs)
@@ -89,7 +89,32 @@ class Admin::BakeDaysController < Admin::BaseController
     redirect_to admin_bake_days_path, notice: "Jour de cuisson supprimé"
   end
 
+  # Annule la fournée : rembourse tous les clients ayant payé (carte ou
+  # portefeuille) et bascule leurs commandes en « annulée ».
+  def cancel
+    result = BakeDayCancellationService.new(@bake_day).call
+
+    if result.success?
+      redirect_to admin_bake_day_path(@bake_day), notice: cancellation_summary(result)
+    else
+      redirect_to admin_bake_day_path(@bake_day),
+                  alert: "#{cancellation_summary(result)} — #{result.failures.size} échec(s) à reprendre : " \
+                         "#{result.failures.map { |f| "#{f[:order]} (#{f[:error]})" }.join(', ')}"
+    end
+  end
+
   private
+
+  def cancellation_summary(result)
+    parts = [ "Fournée annulée : #{result.refunded_count} remboursement(s) " \
+              "(#{format('%.2f', result.refunded_cents / 100.0)} €)" ]
+    if result.manual_refund_orders.any?
+      parts << "#{result.manual_refund_orders.size} à rembourser à la main " \
+               "(#{result.manual_refund_orders.join(', ')})"
+    end
+    parts << "#{result.cancelled_without_refund_count} sans paiement" if result.cancelled_without_refund_count.positive?
+    parts.join(" · ")
+  end
 
   def set_bake_day
     @bake_day = BakeDay.find(params[:id])

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -94,7 +94,7 @@ class Order < ApplicationRecord
     when :unpaid
       [ :paid, :ready, :cancelled ].include?(new_status.to_sym)
     when :ready
-      [ :picked_up, :no_show ].include?(new_status.to_sym)
+      [ :picked_up, :no_show, :cancelled ].include?(new_status.to_sym)
     else
       false
     end

--- a/app/services/bake_day_cancellation_service.rb
+++ b/app/services/bake_day_cancellation_service.rb
@@ -1,0 +1,134 @@
+# Annule une fournée entière et rembourse tous les clients qui avaient payé.
+#
+# Contrairement au remboursement à l'unité (RefundService), ce service :
+#   - ignore le cut-off (une fournée annulée l'est forcément après la clôture) ;
+#   - gère les deux modes d'encaissement : Stripe (remboursement sur la carte)
+#     et portefeuille (recrédit du solde) ;
+#   - bascule chaque commande concernée en `cancelled` et prévient le client.
+#
+# Les commandes payées hors-ligne (espèces) sont annulées mais signalées dans
+# `manual_refund_orders` : le remboursement se fait alors à la main.
+class BakeDayCancellationService
+  # Statuts pour lesquels une annulation a un sens (et dont la transition vers
+  # `cancelled` est autorisée par la machine à états de Order).
+  PROCESSABLE_STATUSES = %w[paid ready unpaid planned].freeze
+
+  Result = Struct.new(
+    :stripe_refunds_count,
+    :wallet_refunds_count,
+    :refunded_cents,
+    :manual_refund_orders,
+    :cancelled_without_refund_count,
+    :failures,
+    keyword_init: true
+  ) do
+    def refunded_count
+      stripe_refunds_count + wallet_refunds_count
+    end
+
+    def total_cancelled_count
+      refunded_count + manual_refund_orders.size + cancelled_without_refund_count
+    end
+
+    def success?
+      failures.empty?
+    end
+  end
+
+  attr_reader :bake_day
+
+  def initialize(bake_day)
+    @bake_day = bake_day
+  end
+
+  def call
+    @stripe_refunds_count = 0
+    @wallet_refunds_count = 0
+    @refunded_cents = 0
+    @manual_refund_orders = []
+    @cancelled_without_refund_count = 0
+    @failures = []
+
+    orders.find_each { |order| process(order) }
+
+    Result.new(
+      stripe_refunds_count: @stripe_refunds_count,
+      wallet_refunds_count: @wallet_refunds_count,
+      refunded_cents: @refunded_cents,
+      manual_refund_orders: @manual_refund_orders,
+      cancelled_without_refund_count: @cancelled_without_refund_count,
+      failures: @failures
+    )
+  end
+
+  private
+
+  def orders
+    bake_day.orders.where(status: PROCESSABLE_STATUSES)
+  end
+
+  def process(order)
+    refunded = cancel_and_refund(order)
+    notify(order, refunded: refunded)
+  rescue StandardError => e
+    @failures << { order: order.order_number, error: e.message }
+    Sentry.capture_exception(e) if defined?(Sentry)
+  end
+
+  # Annule la commande en remboursant selon le mode d'encaissement.
+  # Renvoie true si de l'argent a effectivement été rendu au client (Stripe ou
+  # portefeuille), false sinon (commande non encaissée, ou à rembourser à la main).
+  def cancel_and_refund(order)
+    case order.payment_method
+    when :stripe
+      refund_stripe(order)
+      order_transaction(order) { order.payment.update!(status: :refunded) }
+      @stripe_refunds_count += 1
+      @refunded_cents += order.total_cents
+      true
+    when :wallet
+      order_transaction(order) { WalletService.refund_for_order(wallet: order.customer.wallet, order: order) }
+      @wallet_refunds_count += 1
+      @refunded_cents += order.total_cents
+      true
+    else
+      # On lit l'état d'encaissement AVANT la transition (qui change le statut).
+      was_paid = order.payment_received?
+      order.transition_to!(:cancelled)
+      if was_paid
+        # Payée mais sans trace d'encaissement en ligne (paiement hors-ligne) :
+        # remboursement manuel à effectuer.
+        @manual_refund_orders << order.order_number
+      else
+        @cancelled_without_refund_count += 1
+      end
+      false
+    end
+  end
+
+  # Remboursement Stripe hors transaction DB : on ne veut pas qu'un échec de
+  # mise à jour locale survienne après un remboursement déjà passé chez Stripe.
+  def refund_stripe(order)
+    refund = Stripe::Refund.create(payment_intent: order.payment.stripe_payment_intent_id)
+    return if refund.status == "succeeded"
+
+    raise "Remboursement Stripe non abouti (statut: #{refund.status})"
+  end
+
+  def order_transaction(order)
+    ActiveRecord::Base.transaction do
+      yield
+      order.transition_to!(:cancelled)
+    end
+  end
+
+  def notify(order, refunded:)
+    return unless order.customer.sms_enabled?
+
+    SmsService.send_bake_cancelled(order, refunded: refunded)
+  rescue StandardError => e
+    # Un échec d'envoi de SMS ne doit pas faire échouer l'annulation déjà actée.
+    Rails.logger.error("send_bake_cancelled a échoué pour #{order.order_number}: #{e.message}")
+    Sentry.capture_exception(e) if defined?(Sentry)
+  end
+end

--- a/app/services/sms_service.rb
+++ b/app/services/sms_service.rb
@@ -47,6 +47,27 @@ class SmsService
     )
   end
 
+  def self.send_bake_cancelled(order, refunded: true)
+    return false unless order.customer.sms_enabled?
+
+    date = order.bake_day.baked_on.strftime("%d/%m/%Y")
+    message = if refunded
+                "Bonjour, la fournée du #{date} est malheureusement annulée. " \
+                  "Ta commande t'a été intégralement remboursée. Désolés du contretemps ! Les artisans de Tranche de Vie"
+    else
+                "Bonjour, la fournée du #{date} est malheureusement annulée. " \
+                  "Ta commande a été annulée, aucun montant ne t'a été débité. Désolés du contretemps ! Les artisans de Tranche de Vie"
+    end
+
+    send_sms(
+      to: order.customer.phone_e164,
+      body: message,
+      kind: :refund,
+      baked_on: order.bake_day.baked_on,
+      customer_id: order.customer.id
+    )
+  end
+
   def self.send_custom(customer, body)
     return false unless customer.sms_enabled?
     return false if body.blank?

--- a/app/views/admin/bake_days/show.html.slim
+++ b/app/views/admin/bake_days/show.html.slim
@@ -27,6 +27,7 @@
         = link_to "Modifier", edit_admin_bake_day_path(@bake_day), class: "inline-flex items-center justify-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-white whitespace-nowrap"
         button.inline-flex.items-center.justify-center.gap-2.rounded-full.border.border-slate-300.px-4.py-2.text-sm.font-semibold.text-slate-700.hover:bg-white.whitespace-nowrap type="button" data-action="dashboard-export#print"
           | Imprimer la feuille
+        = button_to "Annuler la fournée", cancel_admin_bake_day_path(@bake_day), method: :post, data: { confirm: "Annuler cette fournée ? Toutes les commandes payées seront remboursées (carte ou portefeuille) et les clients prévenus par SMS. Action irréversible." }, class: "inline-flex items-center justify-center gap-2 rounded-full border border-amber-300 px-4 py-2 text-sm font-semibold text-amber-700 hover:bg-amber-50 whitespace-nowrap"
         = button_to "Supprimer", admin_bake_day_path(@bake_day), method: :delete, data: { confirm: "Supprimer ce jour de cuisson ?" }, class: "inline-flex items-center justify-center gap-2 rounded-full border border-rose-300 px-4 py-2 text-sm font-semibold text-rose-700 hover:bg-rose-50 whitespace-nowrap"
 
   .grid.gap-4.sm:gap-6.lg:grid-cols-3

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -155,7 +155,11 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :bake_days, only: [ :index, :show, :new, :create, :edit, :update, :destroy ]
+    resources :bake_days, only: [ :index, :show, :new, :create, :edit, :update, :destroy ] do
+      member do
+        post :cancel
+      end
+    end
 
     get "parametres", to: "settings#index", as: :settings
     scope path: "parametres", as: "settings", module: "settings" do

--- a/spec/services/bake_day_cancellation_service_spec.rb
+++ b/spec/services/bake_day_cancellation_service_spec.rb
@@ -1,0 +1,176 @@
+require "rails_helper"
+
+RSpec.describe BakeDayCancellationService do
+  let(:bake_day) { create(:bake_day, :cut_off_passed) }
+
+  before { allow(SmsService).to receive(:send_bake_cancelled).and_return(true) }
+
+  def stripe_order(status: :paid, total_cents: 1100)
+    order = create(:order, status, bake_day: bake_day, total_cents: total_cents)
+    create(:payment, order: order)
+    order
+  end
+
+  def wallet_order(status: :paid, total_cents: 1100, balance_cents: 5000)
+    customer = create(:customer)
+    wallet = create(:wallet, customer: customer, balance_cents: balance_cents)
+    order = create(:order, status, customer: customer, bake_day: bake_day, total_cents: total_cents)
+    create(:wallet_transaction, :order_debit, wallet: wallet, order: order)
+    order
+  end
+
+  describe "#call" do
+    context "with a Stripe-paid order" do
+      let!(:order) { stripe_order }
+
+      before { stub_stripe_refund_create(payment_intent_id: order.payment.stripe_payment_intent_id) }
+
+      it "issues a Stripe refund" do
+        expect(Stripe::Refund).to receive(:create)
+          .with(payment_intent: order.payment.stripe_payment_intent_id)
+          .and_return(double(status: "succeeded"))
+        described_class.new(bake_day).call
+      end
+
+      it "marks the payment refunded and cancels the order" do
+        described_class.new(bake_day).call
+        expect(order.reload.status).to eq("cancelled")
+        expect(order.payment.reload.status).to eq("refunded")
+      end
+
+      it "notifies the customer that they were refunded" do
+        expect(SmsService).to receive(:send_bake_cancelled).with(order, refunded: true)
+        described_class.new(bake_day).call
+      end
+
+      it "reports the refund in the result" do
+        result = described_class.new(bake_day).call
+        expect(result.stripe_refunds_count).to eq(1)
+        expect(result.refunded_cents).to eq(1100)
+        expect(result).to be_success
+      end
+    end
+
+    context "with a wallet-paid order" do
+      let!(:order) { wallet_order(balance_cents: 0) }
+
+      it "credits the wallet back and cancels the order" do
+        described_class.new(bake_day).call
+        expect(order.reload.status).to eq("cancelled")
+        expect(order.customer.wallet.reload.balance_cents).to eq(1100)
+        expect(order.wallet_transactions.where(transaction_type: :order_refund)).to exist
+      end
+
+      it "reports the wallet refund and notifies the customer" do
+        expect(SmsService).to receive(:send_bake_cancelled).with(order, refunded: true)
+        result = described_class.new(bake_day).call
+        expect(result.wallet_refunds_count).to eq(1)
+        expect(result.refunded_cents).to eq(1100)
+      end
+
+      it "does not touch Stripe" do
+        expect(Stripe::Refund).not_to receive(:create)
+        described_class.new(bake_day).call
+      end
+    end
+
+    context "with an unpaid order (nothing collected)" do
+      let!(:order) { create(:order, :unpaid, bake_day: bake_day) }
+
+      it "cancels it without any refund and notifies without promising a refund" do
+        expect(SmsService).to receive(:send_bake_cancelled).with(order, refunded: false)
+        result = described_class.new(bake_day).call
+        expect(order.reload.status).to eq("cancelled")
+        expect(result.cancelled_without_refund_count).to eq(1)
+        expect(result.refunded_count).to eq(0)
+      end
+    end
+
+    context "with a paid order with no online payment trace (offline cash)" do
+      let!(:order) { create(:order, :paid, bake_day: bake_day) }
+
+      it "cancels it and flags it for a manual refund" do
+        result = described_class.new(bake_day).call
+        expect(order.reload.status).to eq("cancelled")
+        expect(result.manual_refund_orders).to eq([ order.order_number ])
+        expect(result.refunded_count).to eq(0)
+      end
+    end
+
+    context "with a ready order" do
+      let!(:order) { stripe_order(status: :ready) }
+
+      before { stub_stripe_refund_create(payment_intent_id: order.payment.stripe_payment_intent_id) }
+
+      it "still refunds and cancels it" do
+        described_class.new(bake_day).call
+        expect(order.reload.status).to eq("cancelled")
+      end
+    end
+
+    context "with already-finished orders" do
+      let!(:picked_up) { create(:order, :picked_up, bake_day: bake_day) }
+      let!(:cancelled) { create(:order, :cancelled, bake_day: bake_day) }
+
+      it "leaves them untouched" do
+        described_class.new(bake_day).call
+        expect(picked_up.reload.status).to eq("picked_up")
+        expect(cancelled.reload.status).to eq("cancelled")
+      end
+    end
+
+    context "when a customer has SMS disabled" do
+      let!(:order) do
+        customer = create(:customer, :with_sms_disabled)
+        wallet = create(:wallet, customer: customer, balance_cents: 0)
+        o = create(:order, :paid, customer: customer, bake_day: bake_day)
+        create(:wallet_transaction, :order_debit, wallet: wallet, order: o)
+        o
+      end
+
+      it "still refunds and cancels, without sending an SMS" do
+        expect(SmsService).not_to receive(:send_bake_cancelled)
+        described_class.new(bake_day).call
+        expect(order.reload.status).to eq("cancelled")
+        expect(order.customer.wallet.reload.balance_cents).to eq(1100)
+      end
+    end
+
+    context "when a Stripe refund does not succeed" do
+      let!(:order) { stripe_order }
+
+      before { stub_stripe_refund_create(payment_intent_id: order.payment.stripe_payment_intent_id, status: "pending") }
+
+      it "records a failure and leaves the order untouched" do
+        result = described_class.new(bake_day).call
+        expect(result).not_to be_success
+        expect(result.failures.first[:order]).to eq(order.order_number)
+        expect(order.reload.status).to eq("paid")
+        expect(order.payment.reload.status).to eq("succeeded")
+      end
+
+      it "does not notify the customer for the failed order" do
+        expect(SmsService).not_to receive(:send_bake_cancelled)
+        described_class.new(bake_day).call
+      end
+    end
+
+    context "with a mix of payment methods" do
+      let!(:stripe) { stripe_order(total_cents: 1000) }
+      let!(:wallet) { wallet_order(total_cents: 2000, balance_cents: 0) }
+      let!(:unpaid) { create(:order, :unpaid, bake_day: bake_day) }
+
+      before { stub_stripe_refund_create(payment_intent_id: stripe.payment.stripe_payment_intent_id) }
+
+      it "aggregates every cohort in the result" do
+        result = described_class.new(bake_day).call
+        expect(result.stripe_refunds_count).to eq(1)
+        expect(result.wallet_refunds_count).to eq(1)
+        expect(result.refunded_cents).to eq(3000)
+        expect(result.cancelled_without_refund_count).to eq(1)
+        expect(result.total_cancelled_count).to eq(3)
+        expect(result).to be_success
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Contexte

Quand une fournée est annulée (ex. boulangère blessée), il n'existait **aucun** moyen propre de rembourser les clients :
- le bouton « Rembourser » à l'unité refuse si le cut-off est passé (`RefundService#valid?`) — donc inutilisable pour la fournée du jour ;
- et il ne gère que Stripe, jamais les commandes payées au portefeuille.

## Ce que fait cette PR

Ajoute un bouton **« Annuler la fournée »** sur la page admin d'un jour de cuisson.

- **`BakeDayCancellationService`** : parcourt les commandes payées et rembourse selon le mode d'encaissement — Stripe → remboursement carte, portefeuille → recrédit du solde — **en ignorant le cut-off**, puis bascule chaque commande en `cancelled`.
- Distingue 4 cohortes dans son `Result` : remboursés Stripe, remboursés wallet, **payés hors-ligne (espèces) → à rembourser à la main** (signalés), non-payés (annulés, rien dû). Chaque commande dans sa propre transaction ; les échecs sont collectés, pas propagés.
- **`SmsService#send_bake_cancelled`** : SMS honnête (« fournée annulée », signé « Les artisans de Tranche de Vie »), variante avec/sans remboursement.
- **`Order`** : autorise la transition `ready → cancelled` (sinon une commande déjà marquée « prête » bloque l'annulation).
- Route `POST /admin/bake_days/:id/cancel` + bouton avec confirmation explicite.

## Tests

- 15 specs service (Stripe, wallet, espèces, non-payé, prêt, SMS désactivé, échec Stripe, mix) ✅
- Rubocop ✅ / Brakeman ✅

## Non couvert

- Pas de request spec pour l'action contrôleur / le rendu du bouton — à vérifier en vrai après déploiement.
- ⚠️ Les paiements **espèces** reçoivent le SMS « remboursée » alors que le remboursement se fait à la main (le cash est rendu après). À ajuster si gênant.