### PR TITLE
Fix remboursement Stripe : traiter pending comme un succès

### DIFF
--- a/app/services/bake_day_cancellation_service.rb
+++ b/app/services/bake_day_cancellation_service.rb
@@ -110,7 +110,9 @@ class BakeDayCancellationService
   # mise à jour locale survienne après un remboursement déjà passé chez Stripe.
   def refund_stripe(order)
     refund = Stripe::Refund.create(payment_intent: order.payment.stripe_payment_intent_id)
-    return if refund.status == "succeeded"
+    # `pending` est un succès : les remboursements Bancontact/SEPA sont asynchrones
+    # (cf. RefundService::SUCCESSFUL_STRIPE_REFUND_STATUSES).
+    return if RefundService::SUCCESSFUL_STRIPE_REFUND_STATUSES.include?(refund.status)
 
     raise "Remboursement Stripe non abouti (statut: #{refund.status})"
   end

--- a/app/services/refund_service.rb
+++ b/app/services/refund_service.rb
@@ -1,4 +1,9 @@
 class RefundService
+  # Statuts Stripe considérés comme un remboursement abouti. `pending` en fait
+  # partie : les remboursements asynchrones (Bancontact, SEPA…) sont d'abord
+  # `pending` puis passent `succeeded` — le webhook charge.refunded réconcilie.
+  SUCCESSFUL_STRIPE_REFUND_STATUSES = %w[succeeded pending].freeze
+
   attr_reader :order, :errors
 
   def initialize(order)
@@ -13,7 +18,7 @@ class RefundService
       payment_intent: @order.payment.stripe_payment_intent_id
     })
 
-    if refund.status == "succeeded"
+    if SUCCESSFUL_STRIPE_REFUND_STATUSES.include?(refund.status)
       @order.payment.update!(status: :refunded)
       @order.transition_to!(:cancelled)
       SmsService.send_refund(@order) if @order.customer.sms_enabled?

--- a/spec/services/bake_day_cancellation_service_spec.rb
+++ b/spec/services/bake_day_cancellation_service_spec.rb
@@ -136,10 +136,25 @@ RSpec.describe BakeDayCancellationService do
       end
     end
 
-    context "when a Stripe refund does not succeed" do
+    context "with a pending Stripe refund (async method like Bancontact)" do
       let!(:order) { stripe_order }
 
       before { stub_stripe_refund_create(payment_intent_id: order.payment.stripe_payment_intent_id, status: "pending") }
+
+      it "treats it as a success: refunds, cancels and notifies" do
+        expect(SmsService).to receive(:send_bake_cancelled).with(order, refunded: true)
+        result = described_class.new(bake_day).call
+        expect(order.reload.status).to eq("cancelled")
+        expect(order.payment.reload.status).to eq("refunded")
+        expect(result.stripe_refunds_count).to eq(1)
+        expect(result).to be_success
+      end
+    end
+
+    context "when a Stripe refund actually fails" do
+      let!(:order) { stripe_order }
+
+      before { stub_stripe_refund_create(payment_intent_id: order.payment.stripe_payment_intent_id, status: "failed") }
 
       it "records a failure and leaves the order untouched" do
         result = described_class.new(bake_day).call


### PR DESCRIPTION
## Problème (constaté en prod)

L'annulation de la fournée du 19/06 a affiché « 5 échecs : Remboursement Stripe non abouti (statut: pending) ».

En réalité **les 5 remboursements étaient bien partis** : les remboursements **Bancontact/SEPA sont asynchrones** et `Stripe::Refund.create` renvoie `status: pending`, puis `succeeded`. Le webhook `charge.refunded` a fini par réconcilier (paiement `refunded`, commande `cancelled`).

Mais comme le service traitait `pending` comme un échec :
- il levait une erreur et **annulait la transaction locale** (commande non passée en `cancelled` synchroniquement) ;
- le **SMS d'annulation n'était jamais envoyé** à ces clients ;
- le flash affichait de faux échecs.

L'ancien `RefundService` (bouton de remboursement à l'unité) avait la même faille latente.

## Correctif

`RefundService` et `BakeDayCancellationService` acceptent désormais `succeeded` **et** `pending` (constante partagée `RefundService::SUCCESSFUL_STRIPE_REFUND_STATUSES`). Seuls `failed`/`canceled`/`requires_action` restent des échecs.

Le webhook `charge.refunded` reste idempotent (re-`update!(:refunded)` + `transition_to!(:cancelled) unless cancelled?`).

## Tests

16 specs (ajout : `pending` = succès avec SMS ; `failed` = échec réel). Rubocop ✅