### PR TITLE
Webhook : gérer l'échec d'un remboursement Stripe (self-healing)

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -42,6 +42,8 @@ class WebhooksController < ApplicationController
       handle_payment_intent_failed(event)
     when "charge.refunded"
       handle_charge_refunded(event)
+    when "charge.refund.updated", "refund.updated", "refund.failed"
+      handle_refund_failed(event)
     end
 
     stripe_event.mark_processed!
@@ -113,6 +115,36 @@ class WebhooksController < ApplicationController
 
     order.payment&.update!(status: :refunded)
     order.transition_to!(:cancelled) unless order.cancelled?
+  end
+
+  # Un remboursement asynchrone (Bancontact, SEPA…) peut échouer APRÈS avoir été
+  # marqué « remboursé » par charge.refunded : l'argent revient alors sur le
+  # solde Stripe sans atteindre le client. On réinscrit le paiement comme
+  # encaissé et on alerte pour un remboursement manuel. La commande reste
+  # annulée (la fournée l'est).
+  def handle_refund_failed(event)
+    refund = event.data.object
+    return unless refund.status == "failed"
+
+    payment_intent_id = refund.payment_intent
+    order = payment_intent_id && Order.find_by(payment_intent_id: payment_intent_id)
+    return unless order
+
+    order.payment&.update!(status: :succeeded)
+
+    reason = refund.try(:failure_reason).presence || "inconnue"
+    message = "⚠️ Remboursement Stripe ÉCHOUÉ — commande #{order.order_number} " \
+              "(#{order.customer.full_name}, #{order.total_euros} €). Raison : #{reason}. " \
+              "La commande reste annulée mais le client n'a PAS été remboursé : remboursement manuel requis."
+    Rails.logger.error(message)
+    Sentry.capture_message(message) if defined?(Sentry)
+    notify_admin(message)
+  end
+
+  def notify_admin(message)
+    SlackService.send_message(message)
+  rescue StandardError => e
+    Rails.logger.error("Alerte admin non envoyée: #{e.message}")
   end
 
   def handle_wallet_reload(payment_intent)

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -77,4 +77,35 @@ RSpec.describe 'Stripe webhook', type: :request do
       expect { deliver(event) }.not_to change { Payment.count }
     end
   end
+
+  describe 'refund failure (charge.refund.updated)' do
+    def fabricate_refund_event(status:, failure_reason: 'expired_or_canceled_card')
+      refund = double('Stripe::Refund', status: status, payment_intent: pi_id, failure_reason: failure_reason)
+      double('Stripe::Event', id: "evt_#{SecureRandom.hex(6)}", type: 'charge.refund.updated',
+                              data: double('event_data', object: refund))
+    end
+
+    before do
+      # La commande a été annulée puis marquée « remboursée » par charge.refunded.
+      order.update!(status: :cancelled)
+      create(:payment, :refunded, order: order)
+      allow(SlackService).to receive(:send_message)
+    end
+
+    it 're-marks the payment as collected when the refund fails' do
+      deliver(fabricate_refund_event(status: 'failed'))
+      expect(order.payment.reload.status).to eq('succeeded')
+    end
+
+    it 'keeps the order cancelled and alerts the admin' do
+      expect(SlackService).to receive(:send_message).with(/Remboursement Stripe ÉCHOUÉ/)
+      deliver(fabricate_refund_event(status: 'failed'))
+      expect(order.reload.status).to eq('cancelled')
+    end
+
+    it 'ignores a refund update that did not fail' do
+      deliver(fabricate_refund_event(status: 'succeeded'))
+      expect(order.payment.reload.status).to eq('refunded')
+    end
+  end
 end


### PR DESCRIPTION
## Problème

Un remboursement asynchrone (Bancontact, SEPA) peut **échouer après coup** : `charge.refunded` arrive d'abord (on marque le paiement `refunded` + commande `cancelled`), puis le règlement échoue côté Stripe et l'argent revient sur le solde **sans atteindre le client**. Jusqu'ici le webhook n'écoutait pas cet échec → la base affichait « remboursé » à tort.

## Correctif

Écoute de `charge.refund.updated` / `refund.updated` / `refund.failed`. Si `refund.status == "failed"` :
- le paiement repasse `succeeded` (l'argent est resté chez nous, le client n'a rien reçu) — il sort donc des totaux de remboursement ;
- la commande **reste annulée** (la fournée l'est) ;
- alerte admin : log + Sentry + Slack (`notify_admin`, best-effort, n'interrompt pas le webhook).

Le remboursement manuel se fait alors à la main, prévenu par l'alerte.

## Tests

3 nouveaux cas (`spec/requests/webhooks_spec.rb`) : échec → paiement réinscrit `succeeded` + commande toujours `cancelled` + alerte Slack ; update non-`failed` ignoré. 8 examples verts. Rubocop ✅