### PR TITLE
[#41] Séparer statut de paiement et statut de facturation

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -7,6 +7,7 @@ class Admin::OrdersController < Admin::BaseController
 
     @orders = @orders.by_bake_day(BakeDay.find(params[:bake_day_id])) if params[:bake_day_id].present?
     @orders = @orders.where(status: params[:status]) if params[:status].present?
+    @orders = @orders.where(payment_status: params[:payment_status]) if params[:payment_status].present?
 
     @bake_days = BakeDay.future.ordered
   end
@@ -195,6 +196,7 @@ class Admin::OrdersController < Admin::BaseController
       :customer_id,
       :bake_day_id,
       :status,
+      :payment_status,
       :requires_invoice,
       :final_total_euros,
       variant_quantities: {}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,6 +14,26 @@ module ApplicationHelper
     labels[status.to_s] || status.to_s.tr("_", " ").capitalize
   end
 
+  def payment_status_label(payment_status)
+    labels = {
+      "unpaid" => "Non payée",
+      "paid" => "Payée",
+      "partially_paid" => "Partiellement payée",
+      "refunded" => "Remboursée"
+    }
+
+    labels[payment_status.to_s] || payment_status.to_s.tr("_", " ").capitalize
+  end
+
+  def invoice_status_label(invoice_status)
+    labels = {
+      "not_invoiced" => "Non facturée",
+      "invoiced" => "Facturée"
+    }
+
+    labels[invoice_status.to_s] || invoice_status.to_s.tr("_", " ").capitalize
+  end
+
   def order_source_label(source)
     labels = {
       "checkout" => "Client (en ligne)",

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -10,6 +10,22 @@ class Order < ApplicationRecord
     planned: 7
   }
 
+  # Statut de paiement (axe financier) — distinct du `status` logistique.
+  # `prefix: :payment_status` évite la collision de méthodes (`paid?`, `unpaid?`)
+  # avec l'enum `status` ci-dessus. `partially_paid` est réservé (non implémenté).
+  enum :payment_status, {
+    unpaid: 0,
+    paid: 1,
+    partially_paid: 2,
+    refunded: 3
+  }, prefix: :payment_status
+
+  # Statut de facturation (axe comptable) — a-t-on émis la facture ?
+  enum :invoice_status, {
+    not_invoiced: 0,
+    invoiced: 1
+  }, prefix: :invoice_status
+
   enum :source, { checkout: 0, calendar: 1, admin: 2 }
 
   belongs_to :customer
@@ -73,6 +89,36 @@ class Order < ApplicationRecord
   def payment_refunded?
     payment&.refunded? ||
       wallet_transactions.any? { |transaction| transaction.transaction_type == "order_refund" }
+  end
+
+  # Statut de paiement déduit des transactions RÉELLES (Stripe + portefeuille),
+  # indépendamment du `status` logistique. C'est la source de vérité automatique
+  # pour `payment_status` (cf. #41) :
+  #   - "refunded" si un remboursement réel existe (prime sur le reste) ;
+  #   - "paid"     si un encaissement réel existe (Stripe succeeded ou débit wallet) ;
+  #   - "unpaid"   sinon.
+  def derived_payment_status
+    return "refunded" if payment_refunded?
+    return "paid" if real_payment_received?
+
+    "unpaid"
+  end
+
+  # Recalcule `payment_status` à partir des transactions réelles et le persiste
+  # si nécessaire. Appelé automatiquement lorsqu'un paiement ou une transaction
+  # de portefeuille est enregistré (cf. Payment / WalletTransaction). Les
+  # commandes hors-ligne (cash) sans transaction ne sont jamais touchées ici :
+  # le marquage manuel admin reste donc préservé.
+  def sync_payment_status!
+    new_status = derived_payment_status
+
+    # La synchronisation automatique ne fait que refléter un encaissement ou un
+    # remboursement RÉEL. Elle ne repasse jamais à "unpaid" : un marquage manuel
+    # admin (paiement hors-ligne cash / client à facture) reste donc préservé.
+    return if new_status == "unpaid"
+    return if payment_status == new_status
+
+    update_column(:payment_status, self.class.payment_statuses[new_status])
   end
 
   # Date d'encaissement du paiement.
@@ -279,6 +325,13 @@ class Order < ApplicationRecord
   end
 
   private
+
+  # Encaissement réel (par opposition au `status` logistique) : un paiement
+  # Stripe abouti, ou un débit du portefeuille.
+  def real_payment_received?
+    (payment.present? && payment.succeeded?) ||
+      wallet_transactions.any? { |transaction| transaction.transaction_type == "order_debit" }
+  end
 
   def generate_public_token
     return if public_token.present?

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -12,6 +12,10 @@ class Payment < ApplicationRecord
 
   scope :succeeded, -> { where(status: :succeeded) }
 
+  # Le paiement réel est la source de vérité du `payment_status` de la commande
+  # (cf. #41) : à chaque création/modification d'un paiement, on resynchronise.
+  after_commit :sync_order_payment_status
+
   def refunded?
     status == "refunded"
   end
@@ -30,5 +34,11 @@ class Payment < ApplicationRecord
   # Frais Stripe déjà récupérés depuis l'API ?
   def stripe_fee_recorded?
     !stripe_fee_cents.nil?
+  end
+
+  private
+
+  def sync_order_payment_status
+    order&.sync_payment_status!
   end
 end

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -7,7 +7,18 @@ class WalletTransaction < ApplicationRecord
   validates :amount_cents, presence: true
   validates :transaction_type, presence: true
 
+  # Les débits/remboursements de commande participent à la source de vérité du
+  # `payment_status` de la commande (cf. #41). Les recharges (`top_up`) ne sont
+  # pas liées à une commande et n'ont aucun effet ici.
+  after_commit :sync_order_payment_status
+
   def amount_euros
     (amount_cents / 100.0).round(2)
+  end
+
+  private
+
+  def sync_order_payment_status
+    order&.sync_payment_status!
   end
 end

--- a/app/views/admin/orders/edit.html.erb
+++ b/app/views/admin/orders/edit.html.erb
@@ -179,6 +179,22 @@
       </div>
     </div>
 
+    <div class="mt-8">
+      <%= f.label :payment_status, "Statut de paiement", class: "block text-sm font-medium text-gray-700" %>
+      <%= f.select :payment_status,
+                   options_for_select([
+                     [payment_status_label("unpaid"), "unpaid"],
+                     [payment_status_label("paid"), "paid"],
+                     [payment_status_label("refunded"), "refunded"]
+                   ], @order.payment_status),
+                   {},
+                   class: "mt-1 #{admin_input_class}" %>
+      <p class="mt-1 text-xs text-gray-500">
+        Synchronisé automatiquement depuis les paiements réels (Stripe / portefeuille).
+        Le marquage manuel sert aux paiements hors-ligne (cash, clients à facture).
+      </p>
+    </div>
+
     <div class="mt-6">
       <label class="inline-flex items-center space-x-2 text-sm text-gray-700">
         <%= f.check_box :requires_invoice, class: "rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" %>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -21,7 +21,7 @@
       <div class="flex space-x-4">
         <%= form_with url: admin_orders_path, method: :get, local: true, class: "flex space-x-2" do |f| %>
           <%= f.select :status, options_for_select([
-            ['Tous', ''],
+            ['Tous les statuts', ''],
             ['En attente', 'pending'],
             ['Payées', 'paid'],
             ['Prêtes', 'ready'],
@@ -29,9 +29,17 @@
             ['Non récupérées', 'no_show'],
             ['Annulées', 'cancelled']
           ], params[:status]), {}, { class: "rounded-md border border-gray-300" } %>
-          
-          <%= f.select :bake_day_id, options_from_collection_for_select(@bake_days, :id, :baked_on, params[:bake_day_id]), 
-              { include_blank: 'Tous les jours' }, 
+
+          <%= f.select :payment_status, options_for_select([
+            ['Tous les paiements', ''],
+            ['Non payées', 'unpaid'],
+            ['Payées', 'paid'],
+            ['Partiellement payées', 'partially_paid'],
+            ['Remboursées', 'refunded']
+          ], params[:payment_status]), {}, { class: "rounded-md border border-gray-300" } %>
+
+          <%= f.select :bake_day_id, options_from_collection_for_select(@bake_days, :id, :baked_on, params[:bake_day_id]),
+              { include_blank: 'Tous les jours' },
               { class: "rounded-md border border-gray-300" } %>
           
           <%= f.submit "Filtrer", class: "px-3 py-1 bg-blue-600 text-white rounded-md text-sm hover:bg-blue-700" %>
@@ -49,6 +57,7 @@
         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Jour de cuisson</th>
         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Total</th>
         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Statut</th>
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Paiement</th>
         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
       </tr>
     </thead>
@@ -79,6 +88,17 @@
                   else 'bg-gray-100 text-gray-800'
                   end %>">
               <%= order_status_label(order.status) %>
+            </span>
+          </td>
+          <td class="px-6 py-4 whitespace-nowrap">
+            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
+              <%= case order.payment_status
+                  when 'paid' then 'bg-green-100 text-green-800'
+                  when 'partially_paid' then 'bg-yellow-100 text-yellow-800'
+                  when 'refunded' then 'bg-purple-100 text-purple-800'
+                  else 'bg-gray-100 text-gray-800'
+                  end %>">
+              <%= payment_status_label(order.payment_status) %>
             </span>
           </td>
           <td class="px-6 py-4 whitespace-nowrap text-sm">

--- a/db/migrate/20260625120000_add_payment_and_invoice_status_to_orders.rb
+++ b/db/migrate/20260625120000_add_payment_and_invoice_status_to_orders.rb
@@ -1,0 +1,44 @@
+class AddPaymentAndInvoiceStatusToOrders < ActiveRecord::Migration[8.0]
+  def up
+    # Nouveaux axes additifs (l'enum `status` logistique reste inchangé — cf. #41/#102).
+    # payment_status : unpaid=0, paid=1, partially_paid=2 (réservé), refunded=3
+    add_column :orders, :payment_status, :integer, default: 0, null: false
+    # invoice_status : not_invoiced=0, invoiced=1
+    add_column :orders, :invoice_status, :integer, default: 0, null: false
+    add_index :orders, :payment_status
+
+    # Backfill du payment_status depuis le paiement RÉEL (transactions), pas
+    # depuis l'ancien `status` :
+    #   - paid     : un paiement Stripe encaissé (payments.status = succeeded=0)
+    #                OU un débit portefeuille (wallet_transactions.transaction_type = order_debit=1)
+    #   - refunded : un paiement Stripe remboursé (payments.status = refunded=2)
+    #                OU un remboursement portefeuille (transaction_type = order_refund=2)
+    #     (refunded prime sur paid : il s'applique après).
+    #   - unpaid   : aucun des deux (valeur par défaut).
+    execute(<<~SQL.squish)
+      UPDATE orders SET payment_status = 1
+      WHERE id IN (
+        SELECT order_id FROM payments WHERE status = 0
+        UNION
+        SELECT order_id FROM wallet_transactions WHERE transaction_type = 1 AND order_id IS NOT NULL
+      )
+    SQL
+
+    execute(<<~SQL.squish)
+      UPDATE orders SET payment_status = 3
+      WHERE id IN (
+        SELECT order_id FROM payments WHERE status = 2
+        UNION
+        SELECT order_id FROM wallet_transactions WHERE transaction_type = 2 AND order_id IS NOT NULL
+      )
+    SQL
+
+    # invoice_status reste à not_invoiced (0) partout : c'est déjà la valeur par défaut.
+  end
+
+  def down
+    remove_index :orders, :payment_status
+    remove_column :orders, :payment_status
+    remove_column :orders, :invoice_status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_17_110000) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_25_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -211,10 +211,13 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_17_110000) do
     t.boolean "requires_invoice", default: false, null: false
     t.integer "source", default: 0, null: false
     t.datetime "paid_at"
+    t.integer "payment_status", default: 0, null: false
+    t.integer "invoice_status", default: 0, null: false
     t.index ["bake_day_id"], name: "index_orders_on_bake_day_id"
     t.index ["customer_id"], name: "index_orders_on_customer_id"
     t.index ["order_number"], name: "index_orders_on_order_number"
     t.index ["payment_intent_id"], name: "index_orders_on_payment_intent_id", unique: true, where: "(payment_intent_id IS NOT NULL)"
+    t.index ["payment_status"], name: "index_orders_on_payment_status"
     t.index ["public_token"], name: "index_orders_on_public_token", unique: true
     t.index ["source"], name: "index_orders_on_source"
     t.index ["status"], name: "index_orders_on_status"

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -39,6 +39,18 @@ FactoryBot.define do
       source { :calendar }
     end
 
+    trait :payment_unpaid do
+      payment_status { :unpaid }
+    end
+
+    trait :payment_paid do
+      payment_status { :paid }
+    end
+
+    trait :payment_refunded do
+      payment_status { :refunded }
+    end
+
     trait :with_items do
       transient do
         items_count { 2 }

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -58,6 +58,110 @@ RSpec.describe Order, type: :model do
     end
   end
 
+  describe 'payment_status / invoice_status enums (#41)' do
+    it 'leaves the logistic status enum untouched (additive increment)' do
+      expect(Order.statuses.keys).to contain_exactly(
+        'pending', 'paid', 'ready', 'picked_up', 'no_show', 'cancelled', 'unpaid', 'planned'
+      )
+    end
+
+    it 'defaults a new order to unpaid / not_invoiced' do
+      order = create(:order)
+
+      expect(order.payment_status).to eq('unpaid')
+      expect(order.invoice_status).to eq('not_invoiced')
+    end
+  end
+
+  describe '#derived_payment_status (source de vérité = transactions réelles)' do
+    it 'is "paid" when a successful Stripe payment exists' do
+      order = create(:order)
+      create(:payment, order: order)
+
+      expect(order.reload.derived_payment_status).to eq('paid')
+    end
+
+    it 'is "paid" when a wallet debit exists' do
+      order = create(:order, :from_calendar)
+      create(:wallet_transaction, :order_debit, order: order)
+
+      expect(order.reload.derived_payment_status).to eq('paid')
+    end
+
+    it 'is "refunded" when the payment is refunded (takes precedence over paid)' do
+      order = create(:order, :cancelled)
+      create(:payment, :refunded, order: order)
+
+      expect(order.reload.derived_payment_status).to eq('refunded')
+    end
+
+    it 'is "refunded" when a wallet refund transaction exists' do
+      order = create(:order, :cancelled)
+      create(:wallet_transaction, :order_refund, order: order)
+
+      expect(order.reload.derived_payment_status).to eq('refunded')
+    end
+
+    it 'is "unpaid" when no real payment trace exists' do
+      expect(create(:order).derived_payment_status).to eq('unpaid')
+    end
+  end
+
+  describe 'automatic payment_status synchronisation from transactions' do
+    it 'syncs to paid when a Stripe payment is recorded' do
+      order = create(:order, :pending)
+      expect(order.payment_status).to eq('unpaid')
+
+      create(:payment, order: order)
+
+      expect(order.reload.payment_status).to eq('paid')
+    end
+
+    it 'syncs to paid when a wallet debit is recorded' do
+      order = create(:order, :from_calendar, :planned)
+
+      create(:wallet_transaction, :order_debit, order: order)
+
+      expect(order.reload.payment_status).to eq('paid')
+    end
+
+    it 'syncs to refunded when the payment becomes refunded' do
+      order = create(:order)
+      payment = create(:payment, order: order)
+      expect(order.reload.payment_status).to eq('paid')
+
+      payment.update!(status: :refunded)
+
+      expect(order.reload.payment_status).to eq('refunded')
+    end
+
+    it 'ignores wallet top-ups (no order attached)' do
+      wallet = create(:wallet)
+
+      expect { create(:wallet_transaction, :top_up, wallet: wallet) }.not_to raise_error
+    end
+  end
+
+  describe '#sync_payment_status! and manual marking' do
+    it 'preserves a manual "paid" marking on an offline order with no transaction' do
+      order = create(:order, :unpaid)
+      order.update!(payment_status: :paid)
+
+      # No Stripe/wallet transaction exists: a sync must not downgrade to unpaid.
+      order.sync_payment_status!
+
+      expect(order.reload.payment_status).to eq('paid')
+    end
+
+    it 'does not change payment_status when the logistic status changes' do
+      order = create(:order, :paid, :payment_paid)
+
+      order.transition_to!(:ready)
+
+      expect(order.reload.payment_status).to eq('paid')
+    end
+  end
+
   describe '.stripe_fees_between' do
     let(:bake_day) { create(:bake_day, baked_on: Date.new(2026, 5, 12)) }
 

--- a/spec/requests/admin/orders_spec.rb
+++ b/spec/requests/admin/orders_spec.rb
@@ -34,6 +34,49 @@ RSpec.describe "Admin::Orders", type: :request do
     end
   end
 
+  describe "GET /admin/orders (index, #41)" do
+    it "displays both a logistic status column and a payment status column" do
+      create(:order, :paid, :payment_paid, :with_items)
+
+      get admin_orders_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(">Statut<")
+      expect(response.body).to include(">Paiement<")
+    end
+
+    it "filters orders by payment status (incl. refunded)" do
+      bake_day = create(:bake_day)
+      paid_order = create(:order, :paid, :payment_paid, :with_items, bake_day: bake_day)
+      refunded_order = create(:order, :cancelled, :payment_refunded, :with_items, bake_day: bake_day)
+
+      get admin_orders_path, params: { payment_status: "refunded" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(refunded_order.order_number)
+      expect(response.body).not_to include(paid_order.order_number)
+    end
+  end
+
+  describe "PATCH /admin/orders/:id (manual payment marking, #41)" do
+    it "lets an admin mark an offline order as paid" do
+      offline_order = create(:order, :unpaid, :with_items)
+
+      patch admin_order_path(offline_order), params: {
+        order: {
+          customer_id: offline_order.customer_id,
+          bake_day_id: offline_order.bake_day_id,
+          status: "unpaid",
+          payment_status: "paid",
+          final_total_euros: (offline_order.total_cents / 100.0).to_s,
+          variant_quantities: offline_order.order_items.each_with_object({}) { |i, h| h[i.product_variant_id] = i.qty }
+        }
+      }
+
+      expect(offline_order.reload.payment_status).to eq("paid")
+    end
+  end
+
   describe "GET /admin/orders/:id (show)" do
     it "displays the manually recorded payment date for an offline payment" do
       order.update!(status: :paid, paid_at: Time.zone.local(2026, 5, 12))


### PR DESCRIPTION
Closes #41

## Ce qui est fait
Incrément **additif** (l'enum `status` logistique reste **inchangé** — la refonte est traitée séparément en #102) :

- **Nouveaux axes sur `orders`** : `payment_status` (`unpaid`/`paid`/`partially_paid` *(réservé)*/`refunded`) et `invoice_status` (`not_invoiced`/`invoiced`, défaut `not_invoiced`). Enums préfixés (`payment_status_*`, `invoice_status_*`) pour éviter la collision de méthodes avec l'enum `status`.
- **Source de vérité = transactions réelles** : `payment_status` est resynchronisé automatiquement via `after_commit` sur `Payment` (Stripe) et `WalletTransaction` (débit/remboursement portefeuille). La dérivation (`Order#derived_payment_status`) : remboursement réel → `refunded` (prioritaire), encaissement réel (Stripe `succeeded` ou débit wallet) → `paid`, sinon `unpaid`.
- **Marquage manuel admin** : sélecteur « Statut de paiement » dans le formulaire d'édition de commande (paiements hors-ligne : cash, clients à facture). La sync auto **ne repasse jamais à `unpaid`** → un marquage manuel n'est pas écrasé.
- **Migration + backfill** : `payment_status` dérivé du **paiement réel** existant (`payments.status = succeeded` ou `wallet_transactions = order_debit` → `paid` ; `payments.status = refunded` ou `order_refund` → `refunded` ; sinon `unpaid`), **pas** de l'ancien `status`. `invoice_status = not_invoiced` partout.
- **Tableau admin commandes** : 2 colonnes (statut commande + statut paiement) + **filtre par statut de paiement** (dont `refunded`).

## Tests (verts)
- `spec/models/order_spec.rb` : dérivation depuis transactions, synchronisation auto (Stripe/wallet/refund), marquage manuel préservé, le changement de statut logistique ne touche pas `payment_status`, enum `status` inchangé.
- `spec/requests/admin/orders_spec.rb` : 2 colonnes affichées, filtre par statut de paiement, marquage manuel via le formulaire admin.
- **Suite complète** : `371 examples, 0 failures`. **`bin/rubocop`** : `no offenses`.

## Notes / ce qui n'a pas été testé
- **Hors périmètre** (volontairement) : la refonte de l'enum `status` (#102) et l'implémentation effective de `partially_paid` (valeur réservée).
- Pas de vérification navigateur de l'UI admin (vérifié par specs de requête uniquement).
- ⚠️ **Pré-existant, non lié à cette PR** : le `db/schema.rb` de `main` contient les tables `group_product_discounts` et la colonne `product_variants.available_weekdays` **sans migration correspondante** dans `db/migrate` (vraisemblablement issu de #86/#87 non encore mergés). J'ai **préservé** ces entrées dans `schema.rb` ; mon diff de schéma est strictement additif (2 colonnes + 1 index + bump de version). À assainir séparément.