### PR TITLE
[#90] Prix coûtant par variante : saisie manuelle (montant + date d'activation)

### DIFF
--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -65,6 +65,7 @@ class Admin::ProductsController < Admin::BaseController
   def edit_variant
     @product = @variant.product
     @variant.product_images.load # Ensure images are loaded and ordered
+    @variant.variant_cost_prices.build # Ligne vierge pour saisir un nouveau prix coûtant (#90)
   end
 
   def update_variant
@@ -72,6 +73,7 @@ class Admin::ProductsController < Admin::BaseController
     if @variant.update(variant_params)
       redirect_to admin_product_path(@product), notice: "Variante mise à jour"
     else
+      @variant.variant_cost_prices.build # Ligne vierge pour re-saisir un prix coûtant (#90)
       render :edit_variant, status: :unprocessable_entity
     end
   end
@@ -117,6 +119,7 @@ class Admin::ProductsController < Admin::BaseController
       :name, :price_euros, :active, :flour_quantity, :channel, :mold_type_id,
       product_images_attributes: [ :id, :image, :_destroy, :position ],
       variant_ingredients_attributes: [ :id, :ingredient_id, :quantity, :_destroy ],
+      variant_cost_prices_attributes: [ :id, :amount_euros, :active_from, :_destroy ],
       group_ids: []
     )
   end

--- a/app/models/product_variant.rb
+++ b/app/models/product_variant.rb
@@ -8,6 +8,7 @@ class ProductVariant < ApplicationRecord
   has_many :ingredients, through: :variant_ingredients
   has_many :variant_group_restrictions, dependent: :destroy
   has_many :restricted_groups, through: :variant_group_restrictions, source: :group
+  has_many :variant_cost_prices, dependent: :destroy
 
   def group_ids
     restricted_group_ids
@@ -19,6 +20,7 @@ class ProductVariant < ApplicationRecord
 
   accepts_nested_attributes_for :product_images, allow_destroy: true, reject_if: :reject_empty_image?
   accepts_nested_attributes_for :variant_ingredients, allow_destroy: true, reject_if: :reject_blank_ingredient?
+  accepts_nested_attributes_for :variant_cost_prices, allow_destroy: true, reject_if: :reject_blank_cost_price?
 
   after_save :link_images_to_variant
 
@@ -54,6 +56,26 @@ class ProductVariant < ApplicationRecord
       "start_on <= ? AND (end_on IS NULL OR end_on >= ?)",
       date, date
     ).exists?
+  end
+
+  # Prix coûtant applicable à une date (#90), exposé pour le reporting (#54).
+  # Renvoie le montant (cents) du palier le plus récent dont la date
+  # d'activation est antérieure ou égale à `on`, ou `nil` si aucun palier n'est
+  # actif à cette date (coûtant manquant signalé explicitement — pas de zéro
+  # trompeur). Versionnement par date : insensible aux paliers postérieurs.
+  def cost_price_cents(on: Date.current)
+    variant_cost_prices
+      .where(active_from: ..on)
+      .ordered
+      .limit(1)
+      .pick(:amount_cents)
+  end
+
+  def cost_price_euros(on: Date.current)
+    cents = cost_price_cents(on: on)
+    return nil if cents.nil?
+
+    (cents / 100.0).round(2)
   end
 
   def price_euros
@@ -105,5 +127,15 @@ class ProductVariant < ApplicationRecord
 
     # Reject if ingredient_id is blank
     attributes["ingredient_id"].blank?
+  end
+
+  def reject_blank_cost_price?(attributes)
+    # Don't reject deletions or existing records.
+    return false if attributes["_destroy"].present?
+    return false if attributes["id"].present?
+
+    # Reject a brand-new blank row (no amount AND no date) so the spare
+    # "add" row in the form is ignored when left empty.
+    attributes["amount_euros"].to_s.strip.blank? && attributes["active_from"].to_s.strip.blank?
   end
 end

--- a/app/models/variant_cost_price.rb
+++ b/app/models/variant_cost_price.rb
@@ -1,0 +1,24 @@
+# Prix coûtant d'une variante, historisé par date d'activation (#90).
+# Les artisans saisissent manuellement un montant et une date à partir de
+# laquelle ce coûtant s'applique. Le coûtant applicable à une date donnée est
+# le palier le plus récent dont `active_from` est antérieure ou égale à la date
+# (cf. ProductVariant#cost_price_cents). Versionnement par date : ajouter un
+# nouveau palier ne modifie jamais le coûtant des périodes antérieures.
+class VariantCostPrice < ApplicationRecord
+  belongs_to :product_variant
+
+  validates :amount_cents, presence: true, numericality: { greater_than_or_equal_to: 0, only_integer: true }
+  validates :active_from, presence: true
+
+  scope :ordered, -> { order(active_from: :desc, id: :desc) }
+
+  def amount_euros
+    return nil if amount_cents.nil?
+
+    (amount_cents / 100.0).round(2)
+  end
+
+  def amount_euros=(value)
+    self.amount_cents = value.to_s.strip.blank? ? nil : (value.to_s.tr(",", ".").to_f * 100).round
+  end
+end

--- a/app/views/admin/products/edit_variant.html.slim
+++ b/app/views/admin/products/edit_variant.html.slim
@@ -28,6 +28,27 @@
       = f.collection_select :mold_type_id, MoldType.not_deleted.ordered, :id, :name, { include_blank: "Aucun" }, class: admin_input_class
 
   .space-y-3.border.border-gray-200.rounded-lg.p-4.bg-gray-50
+    span.block.text-sm.font-medium.text-gray-700 Prix coûtant (historisé par date d'activation)
+    p.text-sm.text-gray-500.mb-3
+      | Saisissez le prix coûtant de la variante et la date à partir de laquelle il s'applique. L'historique est conservé : le coûtant retenu à une date donnée est le dernier saisi dont la date d'activation est antérieure ou égale.
+    .space-y-3
+      = f.fields_for :variant_cost_prices do |cp_form|
+        - cost_price = cp_form.object
+        .flex.flex-col.gap-3.sm:flex-row.sm:items-end.sm:gap-4.border-b.border-gray-100.pb-3
+          - if cost_price.persisted?
+            = cp_form.hidden_field :id
+          .flex-1
+            = cp_form.label :amount_euros, "Montant (€)", class: "block text-xs font-medium text-gray-600"
+            = cp_form.number_field :amount_euros, step: 0.01, min: 0, class: admin_input_class
+          .flex-1
+            = cp_form.label :active_from, "Date d'activation", class: "block text-xs font-medium text-gray-600"
+            = cp_form.date_field :active_from, class: admin_input_class
+          - if cost_price.persisted?
+            .flex.items-center.gap-2
+              = cp_form.check_box :_destroy, class: "h-4 w-4 text-red-600 border-gray-300 rounded focus:ring-red-500"
+              = cp_form.label :_destroy, "Supprimer", class: "text-sm text-gray-600"
+
+  .space-y-3.border.border-gray-200.rounded-lg.p-4.bg-gray-50
     span.block.text-sm.font-medium.text-gray-700 En vente en ligne
     p.text-sm.text-gray-500.mb-3 Pour qu'une variante soit visible et achetable sur le site, elle doit être « Active » et en canal « Vente en ligne ».
     .space-y-3

--- a/db/migrate/20260625130000_create_variant_cost_prices.rb
+++ b/db/migrate/20260625130000_create_variant_cost_prices.rb
@@ -1,0 +1,15 @@
+class CreateVariantCostPrices < ActiveRecord::Migration[8.0]
+  def change
+    create_table :variant_cost_prices do |t|
+      t.references :product_variant, null: false, foreign_key: true
+      t.integer :amount_cents, null: false
+      t.date :active_from, null: false
+
+      t.timestamps
+    end
+
+    # Recherche du palier applicable à une date : on filtre sur active_from puis
+    # on prend le plus récent.
+    add_index :variant_cost_prices, [ :product_variant_id, :active_from ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_17_110000) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_25_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -472,6 +472,16 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_17_110000) do
     t.index ["tenant_id"], name: "index_stripe_events_on_tenant_id"
   end
 
+  create_table "variant_cost_prices", force: :cascade do |t|
+    t.bigint "product_variant_id", null: false
+    t.integer "amount_cents", null: false
+    t.date "active_from", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_variant_id", "active_from"], name: "idx_on_product_variant_id_active_from_f6d86da26b"
+    t.index ["product_variant_id"], name: "index_variant_cost_prices_on_product_variant_id"
+  end
+
   create_table "variant_group_restrictions", force: :cascade do |t|
     t.bigint "product_variant_id", null: false
     t.bigint "group_id", null: false
@@ -544,6 +554,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_17_110000) do
   add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "variant_cost_prices", "product_variants"
   add_foreign_key "variant_group_restrictions", "groups"
   add_foreign_key "variant_group_restrictions", "product_variants"
   add_foreign_key "variant_ingredients", "ingredients"

--- a/spec/factories/variant_cost_prices.rb
+++ b/spec/factories/variant_cost_prices.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :variant_cost_price do
+    product_variant
+    amount_cents { 67 } # 0,67 €
+    active_from { Date.new(2026, 1, 1) }
+  end
+end

--- a/spec/models/product_variant_spec.rb
+++ b/spec/models/product_variant_spec.rb
@@ -28,4 +28,48 @@ RSpec.describe ProductVariant, type: :model do
       expect(variant.available_on?(date)).to be false
     end
   end
+
+  # #90 : prix coûtant historisé par date d'activation.
+  describe '#cost_price_cents' do
+    let(:variant) { create(:product_variant) }
+
+    it 'returns the amount of the most recent tier active on the given date' do
+      create(:variant_cost_price, product_variant: variant, amount_cents: 67, active_from: Date.new(2026, 1, 1))
+      create(:variant_cost_price, product_variant: variant, amount_cents: 80, active_from: Date.new(2026, 3, 1))
+
+      expect(variant.cost_price_cents(on: Date.new(2026, 2, 15))).to eq(67)
+      expect(variant.cost_price_cents(on: Date.new(2026, 3, 1))).to eq(80)
+      expect(variant.cost_price_cents(on: Date.new(2026, 4, 10))).to eq(80)
+    end
+
+    it 'is insensitive to tiers activated after the requested date (versioning)' do
+      create(:variant_cost_price, product_variant: variant, amount_cents: 67, active_from: Date.new(2026, 1, 1))
+
+      cost_before = variant.cost_price_cents(on: Date.new(2026, 2, 1))
+      create(:variant_cost_price, product_variant: variant, amount_cents: 99, active_from: Date.new(2026, 6, 1))
+
+      expect(cost_before).to eq(67)
+      expect(variant.cost_price_cents(on: Date.new(2026, 2, 1))).to eq(67)
+    end
+
+    it 'returns nil when no tier is active on the date (missing cost, not a misleading zero)' do
+      create(:variant_cost_price, product_variant: variant, amount_cents: 67, active_from: Date.new(2026, 3, 1))
+
+      expect(variant.cost_price_cents(on: Date.new(2026, 1, 1))).to be_nil
+    end
+
+    it 'returns nil when the variant has no cost price at all' do
+      expect(variant.cost_price_cents(on: Date.current)).to be_nil
+    end
+  end
+
+  describe '#cost_price_euros' do
+    it 'converts the applicable cost from cents to euros, nil when missing' do
+      variant = create(:product_variant)
+      create(:variant_cost_price, product_variant: variant, amount_cents: 67, active_from: Date.new(2026, 1, 1))
+
+      expect(variant.cost_price_euros(on: Date.new(2026, 2, 1))).to eq(0.67)
+      expect(variant.cost_price_euros(on: Date.new(2025, 1, 1))).to be_nil
+    end
+  end
 end

--- a/spec/requests/admin/products_spec.rb
+++ b/spec/requests/admin/products_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe "Admin::Products variant cost prices (#90)", type: :request do
+  let(:product) { create(:product) }
+  let(:variant) { create(:product_variant, product: product) }
+
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('ADMIN_PASSWORD').and_return('secret')
+    post admin_login_path, params: { password: 'secret' }
+  end
+
+  describe "GET /admin/products/:id/variants/:variant_id/edit" do
+    it "renders the cost price section" do
+      get edit_variant_admin_product_path(product, variant)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Prix coûtant")
+    end
+  end
+
+  describe "PATCH /admin/products/:id/variants/:variant_id" do
+    it "accepts a cost price amount and an activation date" do
+      patch variant_admin_product_path(product, variant), params: {
+        product_variant: {
+          name: variant.name,
+          price_euros: "5.50",
+          channel: "store",
+          variant_cost_prices_attributes: {
+            "0" => { amount_euros: "0.67", active_from: "2026-01-01" }
+          }
+        }
+      }
+
+      expect(response).to redirect_to(admin_product_path(product))
+      cost_price = variant.reload.variant_cost_prices.last
+      expect(cost_price).to be_present
+      expect(cost_price.amount_cents).to eq(67)
+      expect(cost_price.active_from).to eq(Date.new(2026, 1, 1))
+    end
+
+    it "ignores a blank cost price row" do
+      expect do
+        patch variant_admin_product_path(product, variant), params: {
+          product_variant: {
+            name: variant.name,
+            price_euros: "5.50",
+            channel: "store",
+            variant_cost_prices_attributes: {
+              "0" => { amount_euros: "", active_from: "" }
+            }
+          }
+        }
+      end.not_to change(VariantCostPrice, :count)
+    end
+  end
+end


### PR DESCRIPTION
Closes #90

## Ce qui est fait
Saisie manuelle du **prix coûtant par variante**, historisé par date d'activation (l'ancienne approche « calcul auto depuis les ingrédients » est abandonnée, comme décidé au meeting compta du 25/06/2026).

- **Nouveau modèle `VariantCostPrice`** (`variant_cost_prices`) : `product_variant_id`, `amount_cents`, `active_from` (date). Historisé → plusieurs paliers par variante.
- **Accès reporting** : `ProductVariant#cost_price_cents(on: date)` (et `#cost_price_euros(on:)`) renvoie le montant du palier le plus récent dont `active_from <= date`. **Versionnement par date** : insensible aux paliers postérieurs ; ajouter un palier ne change jamais le coûtant d'une date antérieure. Consommable par #54.
- **Robustesse** : renvoie `nil` (pas `0`) quand aucun palier n'est actif à la date → coûtant manquant signalé explicitement.
- **Saisie admin** : section « Prix coûtant » sur le formulaire d'édition de variante (montant € + date d'activation) via nested attributes, ligne vierge pour ajouter, suppression des paliers existants.
- **Migration** + index `(product_variant_id, active_from)`.

## Tests (verts)
- `spec/models/product_variant_spec.rb` : palier applicable selon `active_from`, versionnement (palier postérieur sans effet rétroactif), `nil` si pas de palier / aucun coûtant, conversion € .
- `spec/requests/admin/products_spec.rb` : le formulaire variante affiche la section et accepte montant + date (crée un `VariantCostPrice`) ; une ligne vide est ignorée.
- **Suite complète** : `363 examples, 0 failures`. **`bin/rubocop`** : `no offenses`.

## Notes / ce qui n'a pas été testé
- **Hors périmètre** (volontairement) : le calcul des bénéfices lui-même (#54, qui *consomme* ce coûtant) ; tout calcul auto du coûtant depuis matières/ingrédients (abandonné).
- Pas de vérification navigateur de l'UI admin (couvert par specs de requête uniquement).
- Branche partie de `main` (indépendante). `db/schema.rb` : diff strictement additif (table `variant_cost_prices` + FK + bump de version). J'ai préservé l'incohérence pré-existante de `main` (`group_product_discounts` / `available_weekdays` présents en schéma sans migration — à assainir séparément), sans la toucher.