### PR TITLE
[#52] Coût des sacs à pains : compté d'office par pain produit (par catégorie)

### DIFF
--- a/app/models/bread_bag_price.rb
+++ b/app/models/bread_bag_price.rb
@@ -1,0 +1,17 @@
+# Prix d'un sac à pain, paramètre général historisé par date d'activation (#52).
+# Le prix applicable à une date donnée est le palier le plus récent dont
+# `active_from` est antérieure ou égale à la date. Versionnement par date :
+# changer le prix ne modifie jamais les périodes antérieures. Consommé par le
+# calcul des bénéfices (#54) via Order#bread_bags_cost_cents.
+class BreadBagPrice < ApplicationRecord
+  validates :amount_cents, presence: true, numericality: { greater_than_or_equal_to: 0, only_integer: true }
+  validates :active_from, presence: true
+
+  scope :ordered, -> { order(active_from: :desc, id: :desc) }
+
+  # Prix (cents) applicable à `date`, ou nil si aucun palier n'est actif à cette
+  # date (pas de zéro trompeur).
+  def self.amount_cents_on(date = Date.current)
+    where(active_from: ..date).ordered.limit(1).pick(:amount_cents)
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -45,6 +45,23 @@ class Order < ApplicationRecord
     (total_cents / 100.0).round(2)
   end
 
+  # Nombre de sacs à pains pour la commande (#52) : 1 sac par unité de pain
+  # produit (catégorie « breads » en production maison), pâtons/reventes exclus.
+  def bread_bags_count
+    order_items.includes(product_variant: :product).sum do |item|
+      item.product_variant.product.incurs_bag_cost? ? item.qty : 0
+    end
+  end
+
+  # Coût total des sacs à pains de la commande à une date donnée (par défaut le
+  # jour de cuisson). `nb_sacs × prix_du_sac(à la date)`. Exposé pour le calcul
+  # des bénéfices (#54). Si aucun prix de sac n'est défini à la date, le coût
+  # est nul (aucune déduction).
+  def bread_bags_cost_cents(on: bake_day&.baked_on || Date.current)
+    price_cents = BreadBagPrice.amount_cents_on(on) || 0
+    bread_bags_count * price_cents
+  end
+
   def can_be_cancelled_by_customer?
     !bake_day.cut_off_passed? && (paid? || unpaid?)
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -36,6 +36,14 @@ class Product < ApplicationRecord
     product_flours.includes(:flour).map { |pf| "#{pf.flour.name} #{pf.percentage} %" }.join(", ")
   end
 
+  # Un sac à pain est compté d'office pour chaque unité de PAIN PRODUIT (#52) :
+  # catégorie « breads » et production maison (internal_category « boulangerie »).
+  # Les pâtons (pâte à pizza, catégorie dough_balls) et les reventes (épicerie,
+  # traiteur…) n'entraînent aucun coût de sac.
+  def incurs_bag_cost?
+    breads? && internal_category_boulangerie?
+  end
+
   private
 
   def reject_empty_image?(attributes)

--- a/db/migrate/20260625140000_create_bread_bag_prices.rb
+++ b/db/migrate/20260625140000_create_bread_bag_prices.rb
@@ -1,0 +1,22 @@
+class CreateBreadBagPrices < ActiveRecord::Migration[8.0]
+  def up
+    # Prix d'un sac à pain, paramètre général historisé par date d'activation (#52).
+    create_table :bread_bag_prices do |t|
+      t.integer :amount_cents, null: false
+      t.date :active_from, null: false
+
+      t.timestamps
+    end
+    add_index :bread_bag_prices, :active_from
+
+    # Valeur de référence (#52) : 0,04 €/sac, active à partir du 01/01/2026.
+    execute(<<~SQL.squish)
+      INSERT INTO bread_bag_prices (amount_cents, active_from, created_at, updated_at)
+      VALUES (4, '2026-01-01', NOW(), NOW())
+    SQL
+  end
+
+  def down
+    drop_table :bread_bag_prices
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_17_110000) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_25_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -76,6 +76,14 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_17_110000) do
     t.text "internal_note"
     t.boolean "market_day", default: false, null: false
     t.index ["baked_on"], name: "index_bake_days_on_baked_on", unique: true
+  end
+
+  create_table "bread_bag_prices", force: :cascade do |t|
+    t.integer "amount_cents", null: false
+    t.date "active_from", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active_from"], name: "index_bread_bag_prices_on_active_from"
   end
 
   create_table "customer_groups", force: :cascade do |t|

--- a/spec/factories/bread_bag_prices.rb
+++ b/spec/factories/bread_bag_prices.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :bread_bag_price do
+    amount_cents { 4 } # 0,04 €
+    active_from { Date.new(2026, 1, 1) }
+  end
+end

--- a/spec/models/bread_bag_price_spec.rb
+++ b/spec/models/bread_bag_price_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe BreadBagPrice, type: :model do
+  describe '.amount_cents_on' do
+    it 'returns the amount of the most recent tier active on the given date' do
+      create(:bread_bag_price, amount_cents: 4, active_from: Date.new(2026, 1, 1))
+      create(:bread_bag_price, amount_cents: 6, active_from: Date.new(2026, 3, 1))
+
+      expect(described_class.amount_cents_on(Date.new(2026, 2, 15))).to eq(4)
+      expect(described_class.amount_cents_on(Date.new(2026, 3, 1))).to eq(6)
+      expect(described_class.amount_cents_on(Date.new(2026, 4, 10))).to eq(6)
+    end
+
+    it 'is insensitive to tiers activated after the requested date (versioning)' do
+      create(:bread_bag_price, amount_cents: 4, active_from: Date.new(2026, 1, 1))
+
+      cost_before = described_class.amount_cents_on(Date.new(2026, 2, 1))
+      create(:bread_bag_price, amount_cents: 9, active_from: Date.new(2026, 6, 1))
+
+      expect(cost_before).to eq(4)
+      expect(described_class.amount_cents_on(Date.new(2026, 2, 1))).to eq(4)
+    end
+
+    it 'returns nil when no tier is active on the date' do
+      create(:bread_bag_price, amount_cents: 4, active_from: Date.new(2026, 3, 1))
+
+      expect(described_class.amount_cents_on(Date.new(2026, 1, 1))).to be_nil
+    end
+  end
+
+  describe 'validations' do
+    it 'requires amount_cents and active_from' do
+      price = described_class.new
+      expect(price).not_to be_valid
+      expect(price.errors[:amount_cents]).to be_present
+      expect(price.errors[:active_from]).to be_present
+    end
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -231,4 +231,59 @@ RSpec.describe Order, type: :model do
       expect(result).to be_empty
     end
   end
+
+  describe '#bread_bags_count (#52)' do
+    it 'counts one bag per produced-bread unit, excluding dough balls and resales' do
+      order = create(:order)
+      bread = create(:product_variant, product: create(:product, category: :breads, internal_category: :boulangerie))
+      dough = create(:product_variant, product: create(:product, :dough_ball, internal_category: :boulangerie))
+      resale = create(:product_variant, product: create(:product, category: :breads, internal_category: :epicerie))
+      create(:order_item, order: order, product_variant: bread, qty: 3)
+      create(:order_item, order: order, product_variant: dough, qty: 2)
+      create(:order_item, order: order, product_variant: resale, qty: 5)
+
+      expect(order.reload.bread_bags_count).to eq(3)
+    end
+
+    it 'is zero for an order with only dough balls' do
+      order = create(:order)
+      dough = create(:product_variant, product: create(:product, :dough_ball))
+      create(:order_item, order: order, product_variant: dough, qty: 4)
+
+      expect(order.reload.bread_bags_count).to eq(0)
+    end
+  end
+
+  describe '#bread_bags_cost_cents (#52)' do
+    let(:bread) { create(:product_variant, product: create(:product, category: :breads, internal_category: :boulangerie)) }
+
+    it 'is the bag count times the bag price applicable on the bake day' do
+      bake_day = create(:bake_day, baked_on: Date.new(2026, 2, 1))
+      order = create(:order, bake_day: bake_day)
+      create(:order_item, order: order, product_variant: bread, qty: 3)
+      create(:bread_bag_price, amount_cents: 4, active_from: Date.new(2026, 1, 1))
+
+      expect(order.reload.bread_bags_cost_cents).to eq(12)
+    end
+
+    it 'uses the price versioned by date (later tiers do not affect earlier bake days)' do
+      create(:bread_bag_price, amount_cents: 4, active_from: Date.new(2026, 1, 1))
+      create(:bread_bag_price, amount_cents: 6, active_from: Date.new(2026, 3, 1))
+
+      early = create(:order, bake_day: create(:bake_day, baked_on: Date.new(2026, 2, 1)))
+      create(:order_item, order: early, product_variant: bread, qty: 2)
+      late = create(:order, bake_day: create(:bake_day, baked_on: Date.new(2026, 3, 15)))
+      create(:order_item, order: late, product_variant: bread, qty: 2)
+
+      expect(early.reload.bread_bags_cost_cents).to eq(8)  # 2 × 4
+      expect(late.reload.bread_bags_cost_cents).to eq(12) # 2 × 6
+    end
+
+    it 'is zero when no bag price is configured for the date' do
+      order = create(:order, bake_day: create(:bake_day, baked_on: Date.new(2026, 2, 1)))
+      create(:order_item, order: order, product_variant: bread, qty: 3)
+
+      expect(order.reload.bread_bags_cost_cents).to eq(0)
+    end
+  end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -17,4 +17,21 @@ RSpec.describe Product, type: :model do
       expect(product.internal_category_epicerie?).to be(true)
     end
   end
+
+  describe "#incurs_bag_cost? (#52)" do
+    it "is true for an in-house produced bread" do
+      product = build(:product, category: :breads, internal_category: :boulangerie)
+      expect(product.incurs_bag_cost?).to be(true)
+    end
+
+    it "is false for dough balls (pâtons)" do
+      product = build(:product, :dough_ball, internal_category: :boulangerie)
+      expect(product.incurs_bag_cost?).to be(false)
+    end
+
+    it "is false for a resold (non-produced) bread" do
+      product = build(:product, category: :breads, internal_category: :epicerie)
+      expect(product.incurs_bag_cost?).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
Closes #52

## Ce qui est fait
Le coût des sacs à pains est désormais calculable d'office, **par pain produit**, sans réglage par client (approche par client abandonnée — décision Michael 25/06/2026).

- **Rattachement par catégorie** : `Product#incurs_bag_cost?` → vrai pour un **pain produit** (catégorie `breads` + production maison `internal_category: boulangerie`). Les **pâtons** (`dough_balls`, pâte à pizza) et les **reventes** (épicerie/traiteur) n'entraînent **aucun** sac.
- **Comptage** : `Order#bread_bags_count` = 1 sac par unité de pain produit de la commande (pâtons/reventes exclus).
- **Prix du sac historisé** : modèle `BreadBagPrice` (`amount_cents` + `active_from`), `BreadBagPrice.amount_cents_on(date)` renvoie le palier le plus récent applicable (nil si aucun). **Versionnement par date** : changer le prix n'affecte pas les périodes antérieures. **Valeur de référence 0,04 €** insérée par la migration (active au 01/01/2026).
- **Coût total exposé pour #54** : `Order#bread_bags_cost_cents(on:)` = `nb_sacs × prix_du_sac(à la date)` (par défaut le jour de cuisson). 0 si aucun prix défini à la date.

## Tests (verts)
- `spec/models/bread_bag_price_spec.rb` : palier applicable par date, versionnement, nil si aucun.
- `spec/models/product_spec.rb` : `incurs_bag_cost?` (pain produit oui ; pâton non ; revente non).
- `spec/models/order_spec.rb` : `bread_bags_count` (compte uniquement les pains produits) ; `bread_bags_cost_cents` (count × prix au jour de cuisson, versionné, 0 si pas de prix).
- **Suite complète** : `367 examples, 0 failures`. **`bin/rubocop`** : `no offenses`.

## Notes / ce qui n'a pas été testé
- **Hors périmètre** (volontairement) : le **calcul des bénéfices** lui-même (#54, qui *consomme* `bread_bags_cost_cents`) ; tout réglage par client ; coût des pâtons/pizza ; coût bois.
- **Pas d'UI admin** pour éditer le prix du sac : l'interface de configuration des paramètres sans code relève de **#24**. Le prix se définit via la valeur de référence (migration) ou en console en attendant ; le mécanisme d'historisation est livré et testé.
- Définition « pain produit » = `breads` + `boulangerie` (production maison). Si la boulangerie souhaite compter aussi les pains revendus (épicerie), c'est un ajustement d'un seul prédicat — à signaler.
- Branche indépendante depuis `main`. `db/schema.rb` : diff strictement additif (table `bread_bag_prices` + bump version) ; incohérence pré-existante de `main` (`group_product_discounts`/`available_weekdays` sans migration) préservée, non touchée.