### PR TITLE
[#100] Reporting : liste détaillée des remboursements (drill-down depuis le total)

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -21,6 +21,17 @@ class Admin::ReportsController < Admin::BaseController
     @average_order_value_cents = @orders_count.positive? ? (@revenue_cents.to_f / @orders_count).round : 0
   end
 
+  # Drill-down depuis le total des remboursements (#100) : liste détaillée des
+  # remboursements de la période (Stripe + portefeuille).
+  def refunds
+    @start_date = parsed_date(params[:start_date]) || Date.current.beginning_of_year
+    @end_date = parsed_date(params[:end_date]) || Date.current
+    @end_date = @start_date if @end_date < @start_date
+
+    @refunds_summary = Order.refunds_summary_between(@start_date, @end_date)
+    @refund_details = Order.detailed_refunds_between(@start_date, @end_date)
+  end
+
   private
 
   def parsed_date(value)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -165,6 +165,52 @@ class Order < ApplicationRecord
       }
     end
 
+    # Détail ligne à ligne des remboursements de la période (#100), pour le
+    # drill-down depuis le total. Même périmètre que `refunds_summary_between`
+    # (ventilé par jour de cuisson) pour rester cohérent avec les totaux.
+    # Chaque entrée : client, montant remboursé, date du remboursement, commande
+    # liée, source (stripe/wallet) et motif si disponible. Trié du plus récent.
+    def detailed_refunds_between(start_date, end_date)
+      (stripe_refund_details_between(start_date, end_date) +
+        wallet_refund_details_between(start_date, end_date))
+        .sort_by { |refund| refund[:refunded_at] }
+        .reverse
+    end
+
+    def stripe_refund_details_between(start_date, end_date)
+      in_bake_day_range(start_date, end_date)
+        .joins(:payment)
+        .merge(Payment.refunded)
+        .preload(:customer, :payment)
+        .map do |order|
+          {
+            source: :stripe,
+            customer_name: order.customer.full_name,
+            amount_cents: order.total_cents,
+            refunded_at: order.payment.updated_at,
+            order: order,
+            reason: nil
+          }
+        end
+    end
+
+    def wallet_refund_details_between(start_date, end_date)
+      WalletTransaction.order_refund
+        .joins(order: :bake_day)
+        .where(bake_days: { baked_on: start_date..end_date })
+        .preload(order: :customer)
+        .map do |transaction|
+          {
+            source: :wallet,
+            customer_name: transaction.order.customer.full_name,
+            amount_cents: transaction.amount_cents,
+            refunded_at: transaction.created_at,
+            order: transaction.order,
+            reason: transaction.description
+          }
+        end
+    end
+
     def sales_by_product_between(start_date, end_date)
       total_quantity = Arel.sql("SUM(order_items.qty)")
       total_revenue = Arel.sql("SUM(order_items.qty * order_items.unit_price_cents)")

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -62,7 +62,12 @@
 </section>
 
 <section class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-6">
-  <h2 class="text-lg font-medium text-gray-900 mb-1">Remboursements</h2>
+  <div class="flex items-center justify-between mb-1">
+    <h2 class="text-lg font-medium text-gray-900">Remboursements</h2>
+    <%= link_to "Voir le détail →",
+                refunds_admin_reports_path(start_date: @start_date, end_date: @end_date),
+                class: "text-sm font-medium text-blue-600 hover:text-blue-800" %>
+  </div>
   <p class="text-sm text-gray-500 mb-4">
     Remboursements Stripe (commandes annulées remboursées) et remboursements vers le portefeuille
     sur la période, ventilés par jour de cuisson de la commande. Les commandes remboursées sont
@@ -71,7 +76,9 @@
   <dl class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
     <div>
       <dt class="text-sm font-medium text-gray-500 uppercase tracking-wide">Remboursements</dt>
-      <dd class="mt-2 text-2xl font-bold text-gray-900"><%= @refunds[:count] %></dd>
+      <dd class="mt-2 text-2xl font-bold text-gray-900">
+        <%= link_to @refunds[:count], refunds_admin_reports_path(start_date: @start_date, end_date: @end_date), class: "text-gray-900 hover:text-blue-700 underline decoration-dotted" %>
+      </dd>
       <dd class="mt-1 text-sm text-gray-500">
         <%= @refunds[:stripe][:count] %> Stripe · <%= @refunds[:wallet][:count] %> portefeuille
       </dd>

--- a/app/views/admin/reports/refunds.html.erb
+++ b/app/views/admin/reports/refunds.html.erb
@@ -1,0 +1,60 @@
+<% content_for :title, "Détail des remboursements" %>
+<% content_for :layout, "admin" %>
+
+<div class="mb-6 flex flex-col md:flex-row md:items-center md:justify-between md:space-x-6 space-y-4 md:space-y-0">
+  <div>
+    <h1 class="text-2xl font-bold text-gray-900">Détail des remboursements</h1>
+    <p class="text-sm text-gray-600">
+      Période du <%= l(@start_date) %> au <%= l(@end_date) %>
+    </p>
+  </div>
+  <%= link_to "← Retour au reporting",
+              admin_reports_path(start_date: @start_date, end_date: @end_date),
+              class: "inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white shadow-sm hover:bg-gray-50" %>
+</div>
+
+<section class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+  <div class="mb-4 flex flex-wrap items-baseline gap-x-6 gap-y-1">
+    <p class="text-sm text-gray-500">
+      <span class="font-semibold text-gray-900"><%= @refunds_summary[:count] %></span> remboursement(s)
+    </p>
+    <p class="text-sm text-gray-500">
+      Montant total : <span class="font-semibold text-gray-900"><%= reports_currency(@refunds_summary[:amount_cents]) %></span>
+    </p>
+  </div>
+
+  <% if @refund_details.any? %>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Client</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Commande</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
+            <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Montant remboursé</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Motif</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          <% @refund_details.each do |refund| %>
+            <tr>
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600"><%= refund[:refunded_at].in_time_zone.strftime("%d/%m/%Y %H:%M") %></td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-900"><%= refund[:customer_name] %></td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm">
+                <%= link_to refund[:order].order_number, admin_order_path(refund[:order]), class: "text-blue-600 hover:text-blue-800" %>
+              </td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600">
+                <%= refund[:source] == :stripe ? "Stripe" : "Portefeuille" %>
+              </td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm text-right font-medium text-gray-900"><%= reports_currency(refund[:amount_cents]) %></td>
+              <td class="px-4 py-3 text-sm text-gray-500"><%= refund[:reason].presence || "—" %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <p class="text-sm text-gray-500">Aucun remboursement sur cette période.</p>
+  <% end %>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,7 +114,11 @@ Rails.application.routes.draw do
     post "login", to: "sessions#create"
     delete "logout", to: "sessions#destroy"
 
-    resources :reports, only: [ :index ]
+    resources :reports, only: [ :index ] do
+      collection do
+        get :refunds
+      end
+    end
     get "billing", to: "billing#index", as: :billing
 
     resources :orders, only: [ :index, :show, :new, :create, :edit, :update ] do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -155,6 +155,39 @@ RSpec.describe Order, type: :model do
     end
   end
 
+  describe '.detailed_refunds_between (#100)' do
+    let(:range_start) { Date.new(2026, 5, 1) }
+    let(:range_end) { Date.new(2026, 5, 31) }
+    let(:bake_day) { create(:bake_day, baked_on: Date.new(2026, 5, 12)) }
+
+    it 'lists each Stripe and wallet refund with customer, amount, order and source' do
+      customer = create(:customer, first_name: "Jo", last_name: "Martin")
+      stripe_order = create(:order, :cancelled, customer: customer, bake_day: bake_day, total_cents: 2000)
+      create(:payment, :refunded, order: stripe_order)
+      wallet_order = create(:order, :cancelled, customer: customer, bake_day: bake_day, total_cents: 1500)
+      create(:wallet_transaction, :order_refund, order: wallet_order, amount_cents: 1500, description: "Remboursement")
+
+      details = described_class.detailed_refunds_between(range_start, range_end)
+
+      expect(details.size).to eq(2)
+      expect(details.map { |r| r[:source] }).to contain_exactly(:stripe, :wallet)
+      stripe = details.find { |r| r[:source] == :stripe }
+      wallet = details.find { |r| r[:source] == :wallet }
+      expect(stripe[:amount_cents]).to eq(2000)
+      expect(stripe[:customer_name]).to eq("Jo Martin")
+      expect(stripe[:order]).to eq(stripe_order)
+      expect(wallet[:amount_cents]).to eq(1500)
+      expect(wallet[:reason]).to eq("Remboursement")
+    end
+
+    it 'excludes refunds whose bake day is outside the range' do
+      out = create(:order, :cancelled, bake_day: create(:bake_day, baked_on: Date.new(2026, 4, 1)), total_cents: 2000)
+      create(:payment, :refunded, order: out)
+
+      expect(described_class.detailed_refunds_between(range_start, range_end)).to be_empty
+    end
+  end
+
   describe '#paid_at' do
     it 'uses the Stripe payment timestamp' do
       order = create(:order)

--- a/spec/requests/admin/reports_spec.rb
+++ b/spec/requests/admin/reports_spec.rb
@@ -83,5 +83,40 @@ RSpec.describe "Admin::Reports", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Ventes par catégorie interne")
     end
+
+    # #100 : drill-down détaillé des remboursements depuis le total.
+    describe "GET /admin/reports/refunds" do
+      let(:customer) { create(:customer, first_name: "Joséphine", last_name: "Martin") }
+
+      it "liste les remboursements Stripe et portefeuille de la période avec montants" do
+        stripe_order = create(:order, :cancelled, customer: customer, bake_day: bake_day, total_cents: 2000)
+        create(:payment, :refunded, order: stripe_order, stripe_fee_cents: 60)
+
+        wallet_order = create(:order, :cancelled, customer: customer, bake_day: bake_day, total_cents: 1500)
+        create(:wallet_transaction, :order_refund, order: wallet_order, amount_cents: 1500)
+
+        get refunds_admin_reports_path(start_date: "2026-05-01", end_date: "2026-05-31")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Détail des remboursements")
+        expect(response.body).to include("Joséphine Martin")
+        expect(response.body).to include(stripe_order.order_number)
+        expect(response.body).to include(wallet_order.order_number)
+        expect(response.body).to include("20,00") # 2000 cents Stripe
+        expect(response.body).to include("15,00") # 1500 cents portefeuille
+      end
+
+      it "exclut les remboursements hors période" do
+        out = create(:order, :cancelled, customer: customer,
+                                          bake_day: create(:bake_day, baked_on: Date.new(2026, 4, 1)), total_cents: 9999)
+        create(:payment, :refunded, order: out)
+
+        get refunds_admin_reports_path(start_date: "2026-05-01", end_date: "2026-05-31")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include(out.order_number)
+        expect(response.body).to include("Aucun remboursement sur cette période.")
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #100

## Ce qui est fait
Depuis le reporting, le **total des remboursements** est désormais cliquable et ouvre la **liste détaillée** des remboursements de la période.

- **Donnée** : `Order.detailed_refunds_between(start, end)` agrège ligne à ligne les remboursements **Stripe** (commandes au paiement remboursé) et **portefeuille** (transactions `order_refund`), sur le **même périmètre** que `refunds_summary_between` (ventilé par jour de cuisson → cohérent avec le total et avec le filtre « statut de paiement = remboursé » de #41). Trié du plus récent. Chaque entrée : **client, montant remboursé, date du remboursement, commande liée, source (Stripe/portefeuille), motif** (si disponible — description de la transaction portefeuille).
- **Drill-down** : nouvelle action `Admin::ReportsController#refunds` + route `GET /admin/reports/refunds` (collection). Vue `refunds.html.erb` : tableau complet + état vide, lien retour, période conservée.
- **Entrée** : sur le reporting, le **nombre de remboursements** et un lien **« Voir le détail → »** pointent vers le drill-down en conservant la période.

## Tests (verts)
- `spec/models/order_spec.rb` : `.detailed_refunds_between` (contenu Stripe+portefeuille, client/montant/commande/source/motif ; exclusion hors période).
- `spec/requests/admin/reports_spec.rb` : la vue drill-down liste les remboursements de la période avec montants corrects (Stripe + portefeuille) ; exclusion des remboursements hors période ; état vide.
- **Suite complète** : `359 examples, 0 failures`. **`bin/rubocop`** : `no offenses`.

## Notes / ce qui n'a pas été testé
- **Hors périmètre** : la logique de remboursement (déjà en place via `RefundService`) ; le filtre statut de paiement du tableau commandes (#41).
- « Date du remboursement » : pour Stripe c'est `payment.updated_at` (passage à `refunded`), pour le portefeuille `wallet_transaction.created_at` — meilleure approximation disponible (pas d'horodatage de remboursement dédié). Le **filtrage** de période reste sur le jour de cuisson, pour rester cohérent avec le total affiché.
- « Motif » : disponible pour les remboursements portefeuille (description de la transaction) ; pour Stripe aucun motif n'est stocké → « — ».
- Pas de vérification navigateur (couvert par specs de requête). Branche indépendante depuis `main`, **aucune migration / aucun changement de schéma**.