### PR TITLE
[#98] Facturation : afficher le nom du produit (pas seulement la variante)

### DIFF
--- a/app/controllers/admin/billing_controller.rb
+++ b/app/controllers/admin/billing_controller.rb
@@ -53,7 +53,7 @@ class Admin::BillingController < Admin::BaseController
 
   def csv_items(order)
     order.order_items.map do |item|
-      "#{item.qty}x #{item.product_variant.name}"
+      "#{item.qty}x #{item.full_name}"
     end.join(", ")
   end
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -5,6 +5,12 @@ class OrderItem < ApplicationRecord
   validates :qty, presence: true, numericality: { greater_than: 0, only_integer: true }
   validates :unit_price_cents, presence: true, numericality: { greater_than: 0 }
 
+  # Libellé complet « Produit — Variante » (ex. « Pain froment — Petit 600 g »),
+  # utilisé pour le détail des commandes de la facturation (#98).
+  def full_name
+    "#{product_variant.product.name} — #{product_variant.name}"
+  end
+
   def subtotal_cents
     qty * unit_price_cents
   end

--- a/app/views/admin/billing/index.html.erb
+++ b/app/views/admin/billing/index.html.erb
@@ -95,7 +95,7 @@
                   <td class="px-4 py-2 text-gray-600">
                     <ul class="space-y-0.5">
                       <% order.order_items.each do |item| %>
-                        <li><%= item.qty %>x <%= item.product_variant.name %></li>
+                        <li><%= item.qty %>x <%= item.full_name %></li>
                       <% end %>
                     </ul>
                   </td>

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe OrderItem, type: :model do
+  describe "#full_name (#98)" do
+    it "combines the product name and the variant name" do
+      product = create(:product, name: "Pain froment")
+      variant = create(:product_variant, product: product, name: "Petit 600 g")
+      item = build(:order_item, product_variant: variant)
+
+      expect(item.full_name).to eq("Pain froment — Petit 600 g")
+    end
+  end
+end

--- a/spec/requests/admin/billing_spec.rb
+++ b/spec/requests/admin/billing_spec.rb
@@ -49,5 +49,28 @@ RSpec.describe "Admin::Billing", type: :request do
       get admin_billing_path(month: "pas-une-date")
       expect(response).to have_http_status(:ok)
     end
+
+    it "affiche le nom du produit en plus de la variante dans le détail (#98)" do
+      product = create(:product, name: "Pain froment")
+      variant = create(:product_variant, product: product, name: "Petit 600 g")
+      detailed = create(:order, :unpaid, customer: pro, bake_day: bake_day, total_cents: 600)
+      create(:order_item, order: detailed, product_variant: variant, qty: 1)
+
+      get admin_billing_path(month: "2026-05")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Pain froment — Petit 600 g")
+    end
+
+    it "inclut le nom du produit + variante dans l'export CSV (#98)" do
+      product = create(:product, name: "Pain seigle")
+      variant = create(:product_variant, product: product, name: "Grand 1 kg")
+      detailed = create(:order, :unpaid, customer: pro, bake_day: bake_day, total_cents: 800)
+      create(:order_item, order: detailed, product_variant: variant, qty: 2)
+
+      get admin_billing_path(month: "2026-05", format: :csv)
+
+      expect(response.body).to include("2x Pain seigle — Grand 1 kg")
+    end
   end
 end


### PR DESCRIPTION
Closes #98

## Ce qui est fait
Sur l'écran **Facturation** (admin), le détail des commandes affiche désormais le **nom du produit + le nom de la variante** (ex. « Pain froment — Petit 600 g »), au lieu de la seule variante.

- **`OrderItem#full_name`** : `"#{produit} — #{variante}"` — méthode réutilisable.
- **Détail HTML** (`admin/billing`) : chaque ligne d'article utilise `full_name`.
- **Export CSV** : la colonne « Articles » utilise aussi `full_name` (cohérence écran/export).
- Le produit est déjà préchargé par `BillingReportService` (`order_items: { product_variant: :product }`) → pas de N+1 introduit.

## Tests (verts)
- `spec/models/order_item_spec.rb` : `full_name` combine produit + variante.
- `spec/requests/admin/billing_spec.rb` : le détail HTML et l'export CSV affichent « Produit — Variante ».
- **Suite complète** : `358 examples, 0 failures`. **`bin/rubocop`** : `no offenses`.

## Notes / ce qui n'a pas été testé
- **Hors périmètre** : refonte du PDF facture (#38) ; affichage des prix dans d'autres tableaux (#72).
- Pas de vérification navigateur (couvert par specs de requête). Branche indépendante depuis `main`, **aucune migration**.