### PR TITLE
[#99] Commande : champ « achat pour un groupe aux 4 Sources » + nom du groupe

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -121,7 +121,8 @@ class CheckoutController < ApplicationController
       customer: customer,
       bake_day: @bake_day,
       cart_items: @cart,
-      payment_method: "online"
+      payment_method: "online",
+      group_name: json_params["group_name"]
     )
     order = service.call
 
@@ -244,7 +245,8 @@ class CheckoutController < ApplicationController
       customer: customer,
       bake_day: bake_day,
       cart_items: cart_items,
-      payment_method: "cash"
+      payment_method: "cash",
+      group_name: json_params["group_name"]
     )
 
     order = service.call

--- a/app/services/order_creation_service.rb
+++ b/app/services/order_creation_service.rb
@@ -1,13 +1,14 @@
 class OrderCreationService
   attr_reader :order, :errors
 
-  def initialize(customer:, bake_day:, cart_items:, payment_intent_id: nil, payment_method: "online", skip_capacity_check: false)
+  def initialize(customer:, bake_day:, cart_items:, payment_intent_id: nil, payment_method: "online", skip_capacity_check: false, group_name: nil)
     @customer = customer
     @bake_day = bake_day
     @cart_items = cart_items
     @payment_intent_id = payment_intent_id
     @payment_method = payment_method
     @skip_capacity_check = skip_capacity_check
+    @group_name = group_name.presence
     @errors = []
   end
 
@@ -34,7 +35,8 @@ class OrderCreationService
         bake_day: @bake_day,
         total_cents: calculate_total,
         payment_intent_id: @payment_intent_id,
-        status: initial_status
+        status: initial_status,
+        group_name: @group_name
       )
 
       create_order_items

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -59,7 +59,12 @@
             <%= order.order_number %>
           </td>
           <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
-            <%= order.customer.full_name %>
+            <% if order.group_name.present? %>
+              <div class="font-medium text-gray-900"><%= order.group_name %></div>
+              <div class="text-xs text-gray-500"><%= order.customer.full_name %></div>
+            <% else %>
+              <%= order.customer.full_name %>
+            <% end %>
           </td>
           <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
             <%= order.bake_day.baked_on.strftime("%d/%m/%Y") %>

--- a/app/views/checkout/new.html.erb
+++ b/app/views/checkout/new.html.erb
@@ -121,6 +121,19 @@
     <div id="payment-section" class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
       <h2 class="text-lg font-medium text-gray-900 mb-4">Paiement</h2>
 
+      <div class="mb-4 border border-gray-200 rounded-md p-4 bg-gray-50">
+        <label class="flex items-center gap-2 text-sm font-medium text-gray-700">
+          <input type="checkbox" id="group_purchase_checkbox" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+          <span>Vous achetez pour un groupe qui vient aux 4 Sources&nbsp;?</span>
+        </label>
+        <div id="group_name_field" class="mt-3 hidden">
+          <label for="order_group_name" class="block text-sm font-medium text-gray-700 mb-1">Nom du groupe *</label>
+          <input type="text" id="order_group_name"
+                 class="w-full rounded-md border border-gray-300 shadow-sm p-2 focus:border-blue-500 focus:ring-blue-500"
+                 placeholder="Ex. Groupe de Joséphine — Entreprise X">
+        </div>
+      </div>
+
       <div class="mb-4">
         <p class="text-sm text-gray-600 mb-2">Résumé de la commande:</p>
         <div class="space-y-2">
@@ -293,16 +306,42 @@
     });
   }
 
+  // Achat pour un groupe « 4 Sources » (#99) : valeur envoyée à la commande.
+  function groupNameValue() {
+    const cb = document.getElementById('group_purchase_checkbox');
+    if (!cb || !cb.checked) return '';
+    return (document.getElementById('order_group_name')?.value || '').trim();
+  }
+
+  // Affiche/masque le champ « nom du groupe » selon la case, et le rend requis.
+  function setupGroupPurchaseToggle() {
+    const cb = document.getElementById('group_purchase_checkbox');
+    const field = document.getElementById('group_name_field');
+    const input = document.getElementById('order_group_name');
+    if (!cb || !field) return;
+    const sync = () => {
+      field.classList.toggle('hidden', !cb.checked);
+      if (input) {
+        input.required = cb.checked;
+        if (!cb.checked) input.value = '';
+      }
+    };
+    cb.addEventListener('change', sync);
+    sync();
+  }
+
   // Initialiser au chargement de la page
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', function() {
       initializePaymentMethodState();
       handlePaymentMethodChange();
+      setupGroupPurchaseToggle();
       initStripe();
     });
   } else {
     initializePaymentMethodState();
     handlePaymentMethodChange();
+    setupGroupPurchaseToggle();
     initStripe();
   }
 
@@ -337,7 +376,8 @@
       body: JSON.stringify({
         first_name: document.getElementById('customer_first_name')?.value || '',
         last_name: document.getElementById('customer_last_name')?.value || '',
-        email: document.getElementById('customer_email')?.value || ''
+        email: document.getElementById('customer_email')?.value || '',
+        group_name: groupNameValue()
       })
     })
     .then(response => {
@@ -453,7 +493,8 @@
           body: JSON.stringify({
             first_name: document.getElementById('customer_first_name')?.value || '',
             last_name: document.getElementById('customer_last_name')?.value || '',
-            email: document.getElementById('customer_email')?.value || ''
+            email: document.getElementById('customer_email')?.value || '',
+            group_name: groupNameValue()
           })
         });
 

--- a/db/migrate/20260625150000_add_group_name_to_orders.rb
+++ b/db/migrate/20260625150000_add_group_name_to_orders.rb
@@ -1,0 +1,8 @@
+class AddGroupNameToOrders < ActiveRecord::Migration[8.0]
+  def change
+    # Nom libre du groupe « 4 Sources » pour lequel la commande est passée (#99).
+    # Stocké sur la commande (pas sur le client) : un même client peut commander
+    # pour des groupes différents. Nullable : la plupart des commandes n'en ont pas.
+    add_column :orders, :group_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_17_110000) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_25_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -211,6 +211,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_17_110000) do
     t.boolean "requires_invoice", default: false, null: false
     t.integer "source", default: 0, null: false
     t.datetime "paid_at"
+    t.string "group_name"
     t.index ["bake_day_id"], name: "index_orders_on_bake_day_id"
     t.index ["customer_id"], name: "index_orders_on_customer_id"
     t.index ["order_number"], name: "index_orders_on_order_number"

--- a/spec/requests/admin/orders_spec.rb
+++ b/spec/requests/admin/orders_spec.rb
@@ -44,4 +44,27 @@ RSpec.describe "Admin::Orders", type: :request do
       expect(response.body).to include("Payé le 12/05/2026")
     end
   end
+
+  describe "GET /admin/orders (index, group name #99)" do
+    it "shows the group name as primary with the customer name below it" do
+      customer = create(:customer, first_name: "Joséphine", last_name: "Martin")
+      create(:order, :unpaid, :with_items, customer: customer, group_name: "Entreprise X")
+
+      get admin_orders_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Entreprise X")
+      expect(response.body).to include("Joséphine Martin")
+    end
+
+    it "shows only the customer name when no group is set" do
+      customer = create(:customer, first_name: "Paul", last_name: "Durand")
+      create(:order, :unpaid, :with_items, customer: customer)
+
+      get admin_orders_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Paul Durand")
+    end
+  end
 end

--- a/spec/services/order_creation_service_spec.rb
+++ b/spec/services/order_creation_service_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+# #99 : le nom du groupe « 4 Sources » est persisté sur la commande.
+RSpec.describe OrderCreationService do
+  let(:customer) { create(:customer) }
+  let(:bake_day) { create(:bake_day, :can_order) }
+  let(:variant) { create(:product_variant) } # active, canal "store"
+  let(:cart_items) { [ { "product_variant_id" => variant.id, "qty" => 1 } ] }
+
+  def build_service(group_name: nil)
+    described_class.new(
+      customer: customer,
+      bake_day: bake_day,
+      cart_items: cart_items,
+      payment_method: "cash",
+      skip_capacity_check: true,
+      group_name: group_name
+    )
+  end
+
+  it "persists the group name on the order when provided" do
+    order = build_service(group_name: "Groupe de Joséphine").call
+
+    expect(order).to be_a(Order)
+    expect(order.group_name).to eq("Groupe de Joséphine")
+  end
+
+  it "stores nil when the group name is blank" do
+    order = build_service(group_name: "   ").call
+
+    expect(order.group_name).to be_nil
+  end
+
+  it "stores nil when no group name is provided" do
+    order = build_service.call
+
+    expect(order.group_name).to be_nil
+  end
+end


### PR DESCRIPTION
Closes #99

## Ce qui est fait
Une commande peut désormais être rattachée à un **groupe « 4 Sources »** (nom libre), stocké **sur la commande** (un même client peut commander pour des groupes différents).

- **Modèle** : colonne `group_name` (string, nullable) sur `orders` + migration.
- **Checkout** : case à cocher « Vous achetez pour un groupe qui vient aux 4 Sources ? » ; si cochée, un champ **« nom du groupe »** apparaît, devient **requis** (HTML5) et son contenu est envoyé dans le corps JSON de `create_payment_intent` **et** `create_cash_order`. Décochée → champ masqué/vidé, comportement inchangé.
- **Service** : `OrderCreationService` accepte `group_name:` et le persiste (`presence` → blank devient `nil`).
- **Tableau admin des commandes** : quand un groupe est renseigné, le **nom du groupe** s'affiche en principal et le **nom du client** en plus petit dessous ; sinon le nom du client seul.

## Tests (verts)
- `spec/services/order_creation_service_spec.rb` : `group_name` persisté quand fourni ; `nil` si blanc / absent.
- `spec/requests/admin/orders_spec.rb` : tableau admin affiche « groupe + client » quand un groupe est présent, « client seul » sinon.
- **Suite complète** : `360 examples, 0 failures`. **`bin/rubocop`** : `no offenses`.

## Notes / ce qui n'a pas été testé
- **Hors périmètre** (volontairement) : entité « Groupe » structurée / référentiel (ici simple nom libre) ; facturation / regroupement automatique par groupe (épique #80).
- **UI checkout non testée automatiquement** : la case + le champ conditionnel + l'envoi dans le corps JSON sont implémentés en JS inline (best effort) mais non couverts par RSpec (pas de test système). La **persistance** est testée via `OrderCreationService` et l'**affichage admin** via request spec.
- Le formulaire admin de création de commande n'a pas reçu de champ `group_name` (l'issue cible le passage de commande client + l'affichage admin). À étendre si besoin.
- Branche indépendante depuis `main`. `db/schema.rb` : diff strictement additif (`group_name` + bump version).