### PR TITLE
[#36] Clients pro : bloquer le paiement en ligne (cash sur autorisation admin)

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -106,7 +106,7 @@ class Admin::CustomersController < Admin::BaseController
   end
 
   def customer_params
-    permitted = params.require(:customer).permit(:first_name, :last_name, :phone_e164, :email, :sms_opt_out, :email_opt_out, :skip_wallet_check, :billable, group_ids: [])
+    permitted = params.require(:customer).permit(:first_name, :last_name, :phone_e164, :email, :sms_opt_out, :email_opt_out, :skip_wallet_check, :billable, :cash_payment_allowed, group_ids: [])
     # Convertir les chaînes vides en nil pour phone_e164
     permitted[:phone_e164] = nil if permitted[:phone_e164].blank?
     permitted

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -23,6 +23,9 @@ class CheckoutController < ApplicationController
     @discount_cents = calculate_discount(@subtotal_cents, @customer)
     @total_cents = @subtotal_cents - @discount_cents
     @otp_verified = phone_verified?
+    # Paiement en ligne par défaut ; le cash n'est proposé qu'aux clients
+    # explicitement autorisés par l'admin (#36).
+    @cash_payment_allowed = @customer&.cash_payment_allowed? || false
   end
 
   def verify_phone
@@ -229,6 +232,14 @@ class CheckoutController < ApplicationController
           email: session[:email].presence || customer.email
         )
       end
+    end
+
+    # Garde-fou serveur (#36) : la commande sans paiement en ligne n'est possible
+    # que pour les clients explicitement autorisés au cash. Empêche tout
+    # contournement du paiement en ligne (page périmée, requête forgée, etc.).
+    unless customer.cash_payment_allowed?
+      render json: { success: false, error: "Le paiement en ligne est requis pour cette commande" }, status: :forbidden
+      return
     end
 
     bake_day = BakeDay.find_by(id: session[:bake_day_id])

--- a/app/views/admin/customers/edit.html.erb
+++ b/app/views/admin/customers/edit.html.erb
@@ -87,6 +87,14 @@
 
     <div class="mt-6">
       <div class="flex items-center">
+        <%= f.check_box :cash_payment_allowed, class: "h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded" %>
+        <%= f.label :cash_payment_allowed, "Paiement cash autorisé", class: "ml-2 block text-sm text-gray-900" %>
+      </div>
+      <p class="mt-1 text-sm text-gray-500">Autorise ce client à commander sans payer en ligne (paiement en liquide / facture). Par défaut, le paiement en ligne est obligatoire.</p>
+    </div>
+
+    <div class="mt-6">
+      <div class="flex items-center">
         <%= f.check_box :skip_wallet_check, class: "h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded" %>
         <%= f.label :skip_wallet_check, "Client interne (pas de vérification de solde)", class: "ml-2 block text-sm text-gray-900" %>
       </div>

--- a/app/views/admin/customers/new.html.erb
+++ b/app/views/admin/customers/new.html.erb
@@ -79,6 +79,14 @@
 
     <div class="mt-6">
       <div class="flex items-center">
+        <%= f.check_box :cash_payment_allowed, class: "h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded" %>
+        <%= f.label :cash_payment_allowed, "Paiement cash autorisé", class: "ml-2 block text-sm text-gray-900" %>
+      </div>
+      <p class="mt-1 text-sm text-gray-500">Autorise ce client à commander sans payer en ligne (paiement en liquide / facture). Par défaut, le paiement en ligne est obligatoire.</p>
+    </div>
+
+    <div class="mt-6">
+      <div class="flex items-center">
         <%= f.check_box :skip_wallet_check, class: "h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded" %>
         <%= f.label :skip_wallet_check, "Client interne (pas de vérification de solde)", class: "ml-2 block text-sm text-gray-900" %>
       </div>

--- a/app/views/checkout/new.html.erb
+++ b/app/views/checkout/new.html.erb
@@ -151,19 +151,27 @@
       </div>
 
       <!-- Sélecteur de méthode de paiement -->
-      <div class="mb-6">
-        <label class="block text-sm font-medium text-gray-700 mb-3">Méthode de paiement</label>
-        <div class="space-y-3">
-          <label class="flex items-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-blue-500 transition payment-method-option" data-payment-method="cash">
-            <input type="radio" name="payment_method" value="cash" class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300">
-            <span class="ml-3 font-medium text-gray-700">Payer ma commande en liquide au retrait</span>
-          </label>
-          <label class="flex items-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-blue-500 transition payment-method-option" data-payment-method="online">
-            <input type="radio" name="payment_method" value="online" class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300" checked>
-            <span class="ml-3 font-medium text-gray-700">Payer en ligne avec Bancontact ou autre</span>
-          </label>
+      <%# Par défaut, paiement en ligne uniquement. L'option « cash » n'apparaît
+          que pour les clients explicitement autorisés par l'admin (#36). %>
+      <% if @cash_payment_allowed %>
+        <div class="mb-6">
+          <label class="block text-sm font-medium text-gray-700 mb-3">Méthode de paiement</label>
+          <div class="space-y-3">
+            <label class="flex items-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-blue-500 transition payment-method-option" data-payment-method="cash">
+              <input type="radio" name="payment_method" value="cash" class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300">
+              <span class="ml-3 font-medium text-gray-700">Payer ma commande en liquide au retrait</span>
+            </label>
+            <label class="flex items-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-blue-500 transition payment-method-option" data-payment-method="online">
+              <input type="radio" name="payment_method" value="online" class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300" checked>
+              <span class="ml-3 font-medium text-gray-700">Payer en ligne avec Bancontact ou autre</span>
+            </label>
+          </div>
         </div>
-      </div>
+      <% else %>
+        <%# Cas général : paiement en ligne forcé. Radio caché « online » pour que
+            le JavaScript de paiement (lecture de payment_method) reste inchangé. %>
+        <input type="radio" name="payment_method" value="online" class="hidden" checked>
+      <% end %>
 
       <!-- Section paiement Stripe (masquée par défaut) -->
       <div id="stripe-payment-section" class="hidden">
@@ -180,14 +188,16 @@
         <div id="payment-message" class="mt-4 hidden"></div>
       </div>
 
-      <!-- Bouton pour commande cash -->
-      <div id="cash-order-section">
-        <button id="submit-cash-order" 
-                class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">
-          Confirmer la commande
-        </button>
-        <p class="mt-2 text-sm text-gray-500 text-center">Vous paierez en liquide lors du retrait de votre commande</p>
-      </div>
+      <!-- Bouton pour commande cash (clients autorisés au cash uniquement, #36) -->
+      <% if @cash_payment_allowed %>
+        <div id="cash-order-section">
+          <button id="submit-cash-order"
+                  class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">
+            Confirmer la commande
+          </button>
+          <p class="mt-2 text-sm text-gray-500 text-center">Vous paierez en liquide lors du retrait de votre commande</p>
+        </div>
+      <% end %>
     </div>
     <% end %>
   </div>

--- a/db/migrate/20260625160000_add_cash_payment_allowed_to_customers.rb
+++ b/db/migrate/20260625160000_add_cash_payment_allowed_to_customers.rb
@@ -1,0 +1,8 @@
+class AddCashPaymentAllowedToCustomers < ActiveRecord::Migration[8.0]
+  def change
+    # Par défaut, les clients paient en ligne uniquement (#36). Ce réglage admin
+    # ré-autorise le paiement hors-ligne (cash / facture) pour des clients
+    # spécifiques (pros, points de dépôt, habitués).
+    add_column :customers, :cash_payment_allowed, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_17_110000) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_25_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -100,6 +100,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_17_110000) do
     t.boolean "billable", default: false, null: false
     t.datetime "calendar_intro_seen_at"
     t.boolean "email_opt_out", default: false, null: false
+    t.boolean "cash_payment_allowed", default: false, null: false
     t.index "lower((email)::text)", name: "index_customers_on_lower_email_unique", unique: true, where: "((email IS NOT NULL) AND ((email)::text <> ''::text))"
     t.index ["phone_e164"], name: "index_customers_on_phone_e164", unique: true, where: "(phone_e164 IS NOT NULL)"
   end

--- a/spec/requests/admin/customers_spec.rb
+++ b/spec/requests/admin/customers_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe "Admin::Customers", type: :request do
+  around do |ex|
+    original = ENV["ADMIN_PASSWORD"]
+    ENV["ADMIN_PASSWORD"] = "test-admin-pw"
+    ex.run
+    ENV["ADMIN_PASSWORD"] = original
+  end
+
+  before { post admin_login_path, params: { password: "test-admin-pw" } }
+
+  # #36 : réglage admin « paiement cash autorisé » sur le client.
+  describe "PATCH /admin/customers/:id" do
+    it "autorise le paiement cash pour le client" do
+      customer = create(:customer, cash_payment_allowed: false)
+
+      patch admin_customer_path(customer), params: {
+        customer: { first_name: customer.first_name, cash_payment_allowed: "1" }
+      }
+
+      expect(customer.reload.cash_payment_allowed).to be(true)
+    end
+
+    it "retire l'autorisation de paiement cash" do
+      customer = create(:customer, cash_payment_allowed: true)
+
+      patch admin_customer_path(customer), params: {
+        customer: { first_name: customer.first_name, cash_payment_allowed: "0" }
+      }
+
+      expect(customer.reload.cash_payment_allowed).to be(false)
+    end
+  end
+end

--- a/spec/requests/checkout_spec.rb
+++ b/spec/requests/checkout_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe 'Checkout — réservation au paiement', type: :request do
     end
   end
 
-  describe 'GET /checkout/new — méthode de paiement par défaut' do
-    it 'sélectionne « en ligne » par défaut et non « liquide »' do
+  describe 'GET /checkout/new — méthode de paiement (#36)' do
+    it 'ne propose pas l\'option cash par défaut (paiement en ligne uniquement)' do
       get '/checkout/new'
 
       expect(response).to have_http_status(:ok)
@@ -80,7 +80,39 @@ RSpec.describe 'Checkout — réservation au paiement', type: :request do
       cash_radio = response.body[%r{<input[^>]*value="cash"[^>]*>}]
 
       expect(online_radio).to include('checked')
-      expect(cash_radio).not_to include('checked')
+      expect(cash_radio).to be_nil
+    end
+
+    context 'pour un client autorisé au paiement cash' do
+      let(:customer) { create(:customer, first_name: 'Léa', cash_payment_allowed: true) }
+
+      it 'propose l\'option « payer en liquide »' do
+        get '/checkout/new'
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body[%r{<input[^>]*value="cash"[^>]*>}]).to be_present
+      end
+    end
+  end
+
+  describe 'POST /checkout/create_cash_order (#36)' do
+    def create_cash_order(body = { first_name: 'Léa' })
+      post '/checkout/create_cash_order', params: body.to_json,
+           headers: { 'CONTENT_TYPE' => 'application/json' }
+    end
+
+    it 'refuse la commande sans paiement en ligne pour un client non autorisé' do
+      expect { create_cash_order }.not_to change(Order, :count)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    context 'pour un client autorisé au paiement cash' do
+      let(:customer) { create(:customer, first_name: 'Léa', cash_payment_allowed: true) }
+
+      it 'crée une commande unpaid' do
+        expect { create_cash_order }.to change { Order.where(status: :unpaid).count }.by(1)
+        expect(response).to have_http_status(:ok)
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #36

## Ce qui est fait
Par défaut, **les clients paient en ligne uniquement** (Bancontact). L'option « payer en liquide » est retirée du checkout et ne réapparaît que pour des clients **explicitement autorisés** par l'admin.

- **Réglage client** : `Customer#cash_payment_allowed` (booléen, défaut `false`) + migration. Checkbox **« Paiement cash autorisé »** sur les formulaires admin (création + édition), avec param autorisé dans `customer_params`.
- **Checkout** : le sélecteur « payer en liquide » et le bouton de commande cash ne sont rendus que si le client est autorisé (`@cash_payment_allowed`). Cas général → un seul flux : paiement en ligne (radio `online` caché + checked pour garder le JS intact).
- **Garde-fou serveur** (`create_cash_order`) : renvoie **403** si le client n'est pas autorisé au cash → impossible de contourner le paiement en ligne (page périmée, requête forgée…). Aucun nouveau client / cas par défaut ne peut passer en cash.
- Commande créée en `unpaid` pour les clients autorisés (comportement inchangé, paiement marqué ensuite manuellement — cf. #41 / #80).

## Tests (verts)
- `spec/requests/checkout_spec.rb` : pas d'option cash par défaut (online seul, checked) ; option « liquide » présente pour un client autorisé ; `create_cash_order` → **403** pour un non-autorisé (aucune commande créée), commande **unpaid** créée pour un autorisé.
- `spec/requests/admin/customers_spec.rb` : le réglage « cash autorisé » se règle/se retire via le formulaire admin.
- **Suite complète** : `360 examples, 0 failures`. **`bin/rubocop`** : `no offenses`.

## Notes / ce qui n'a pas été testé
- **Hors périmètre** : refonte des statuts de paiement (#41) ; cycle de facturation complet (#80).
- Le comportement JS du sélecteur (toggle online/cash) n'est pas couvert par un test système ; il est conservé inchangé et tolère l'absence du radio cash (gardes `if (cashSection)`). La logique serveur (rendu conditionnel + garde 403) est testée.
- Branche indépendante depuis `main` ; `db/schema.rb` strictement additif (`cash_payment_allowed` + bump version).