### PR TITLE
[#97] [BUG] Commandes marquées « payé » à tort (fix, empilé sur #41)

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -7,6 +7,7 @@ class Admin::OrdersController < Admin::BaseController
 
     @orders = @orders.by_bake_day(BakeDay.find(params[:bake_day_id])) if params[:bake_day_id].present?
     @orders = @orders.where(status: params[:status]) if params[:status].present?
+    @orders = @orders.where(payment_status: params[:payment_status]) if params[:payment_status].present?
 
     @bake_days = BakeDay.future.ordered
   end
@@ -195,6 +196,7 @@ class Admin::OrdersController < Admin::BaseController
       :customer_id,
       :bake_day_id,
       :status,
+      :payment_status,
       :requires_invoice,
       :final_total_euros,
       variant_quantities: {}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,6 +14,26 @@ module ApplicationHelper
     labels[status.to_s] || status.to_s.tr("_", " ").capitalize
   end
 
+  def payment_status_label(payment_status)
+    labels = {
+      "unpaid" => "Non payée",
+      "paid" => "Payée",
+      "partially_paid" => "Partiellement payée",
+      "refunded" => "Remboursée"
+    }
+
+    labels[payment_status.to_s] || payment_status.to_s.tr("_", " ").capitalize
+  end
+
+  def invoice_status_label(invoice_status)
+    labels = {
+      "not_invoiced" => "Non facturée",
+      "invoiced" => "Facturée"
+    }
+
+    labels[invoice_status.to_s] || invoice_status.to_s.tr("_", " ").capitalize
+  end
+
   def order_source_label(source)
     labels = {
       "checkout" => "Client (en ligne)",

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -10,6 +10,22 @@ class Order < ApplicationRecord
     planned: 7
   }
 
+  # Statut de paiement (axe financier) — distinct du `status` logistique.
+  # `prefix: :payment_status` évite la collision de méthodes (`paid?`, `unpaid?`)
+  # avec l'enum `status` ci-dessus. `partially_paid` est réservé (non implémenté).
+  enum :payment_status, {
+    unpaid: 0,
+    paid: 1,
+    partially_paid: 2,
+    refunded: 3
+  }, prefix: :payment_status
+
+  # Statut de facturation (axe comptable) — a-t-on émis la facture ?
+  enum :invoice_status, {
+    not_invoiced: 0,
+    invoiced: 1
+  }, prefix: :invoice_status
+
   enum :source, { checkout: 0, calendar: 1, admin: 2 }
 
   belongs_to :customer
@@ -73,6 +89,36 @@ class Order < ApplicationRecord
   def payment_refunded?
     payment&.refunded? ||
       wallet_transactions.any? { |transaction| transaction.transaction_type == "order_refund" }
+  end
+
+  # Statut de paiement déduit des transactions RÉELLES (Stripe + portefeuille),
+  # indépendamment du `status` logistique. C'est la source de vérité automatique
+  # pour `payment_status` (cf. #41) :
+  #   - "refunded" si un remboursement réel existe (prime sur le reste) ;
+  #   - "paid"     si un encaissement réel existe (Stripe succeeded ou débit wallet) ;
+  #   - "unpaid"   sinon.
+  def derived_payment_status
+    return "refunded" if payment_refunded?
+    return "paid" if real_payment_received?
+
+    "unpaid"
+  end
+
+  # Recalcule `payment_status` à partir des transactions réelles et le persiste
+  # si nécessaire. Appelé automatiquement lorsqu'un paiement ou une transaction
+  # de portefeuille est enregistré (cf. Payment / WalletTransaction). Les
+  # commandes hors-ligne (cash) sans transaction ne sont jamais touchées ici :
+  # le marquage manuel admin reste donc préservé.
+  def sync_payment_status!
+    new_status = derived_payment_status
+
+    # La synchronisation automatique ne fait que refléter un encaissement ou un
+    # remboursement RÉEL. Elle ne repasse jamais à "unpaid" : un marquage manuel
+    # admin (paiement hors-ligne cash / client à facture) reste donc préservé.
+    return if new_status == "unpaid"
+    return if payment_status == new_status
+
+    update_column(:payment_status, self.class.payment_statuses[new_status])
   end
 
   # Date d'encaissement du paiement.
@@ -279,6 +325,13 @@ class Order < ApplicationRecord
   end
 
   private
+
+  # Encaissement réel (par opposition au `status` logistique) : un paiement
+  # Stripe abouti, ou un débit du portefeuille.
+  def real_payment_received?
+    (payment.present? && payment.succeeded?) ||
+      wallet_transactions.any? { |transaction| transaction.transaction_type == "order_debit" }
+  end
 
   def generate_public_token
     return if public_token.present?

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -41,8 +41,6 @@ class Order < ApplicationRecord
   validates :requires_invoice, inclusion: { in: [ true, false ] }
 
   COMPLETED_STATUSES = %w[paid ready picked_up].freeze
-  # Statuts qui ne sont atteints qu'une fois le paiement encaissé (Stripe ou portefeuille).
-  PAID_STATUSES = %w[paid ready picked_up no_show].freeze
 
   before_validation :generate_public_token, on: :create
   before_validation :generate_order_number, on: :create
@@ -56,6 +54,12 @@ class Order < ApplicationRecord
   }
   scope :from_calendar, -> { calendar }
   scope :from_checkout, -> { checkout }
+  # Commandes logistiquement avancées (prêtes / récupérées / non-récupérées) sans
+  # paiement réel : ce sont celles affichées « payé » à tort avant #97
+  # (clients à facture, Sémisto, épicerie). Identifiables pour nettoyage.
+  scope :marked_paid_without_real_payment, lambda {
+    where(status: %w[ready picked_up no_show]).where(payment_status: payment_statuses[:unpaid])
+  }
 
   def total_euros
     (total_cents / 100.0).round(2)
@@ -69,9 +73,13 @@ class Order < ApplicationRecord
     ready? && payment.nil?
   end
 
-  # Le paiement est considéré comme encaissé dès que le statut le sous-entend.
+  # Le paiement est considéré comme encaissé UNIQUEMENT s'il y a eu un paiement
+  # réel (Stripe / portefeuille) ou un marquage explicite admin — jamais par le
+  # simple passage logistique à « prêt » (#97). S'appuie sur `payment_status`
+  # (#41), qui est synchronisé depuis les transactions réelles et n'est jamais
+  # positionné par une transition de statut.
   def payment_received?
-    PAID_STATUSES.include?(status)
+    payment_status_paid?
   end
 
   def wallet_order_debit
@@ -119,6 +127,15 @@ class Order < ApplicationRecord
     return if payment_status == new_status
 
     update_column(:payment_status, self.class.payment_statuses[new_status])
+  end
+
+  # Recalcule `payment_status` depuis les transactions réelles, en autorisant le
+  # retour à "unpaid" — corrige les commandes marquées « payé » à tort (#97).
+  # Contrairement à `sync_payment_status!`, peut RÉTROGRADER : à n'utiliser que
+  # pour un nettoyage ponctuel (un marquage manuel admin sans transaction serait
+  # réinitialisé). Cf. la tâche `orders:resync_payment_status`.
+  def recompute_payment_status!
+    update_column(:payment_status, self.class.payment_statuses[derived_payment_status])
   end
 
   # Date d'encaissement du paiement.

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -12,6 +12,10 @@ class Payment < ApplicationRecord
 
   scope :succeeded, -> { where(status: :succeeded) }
 
+  # Le paiement réel est la source de vérité du `payment_status` de la commande
+  # (cf. #41) : à chaque création/modification d'un paiement, on resynchronise.
+  after_commit :sync_order_payment_status
+
   def refunded?
     status == "refunded"
   end
@@ -30,5 +34,11 @@ class Payment < ApplicationRecord
   # Frais Stripe déjà récupérés depuis l'API ?
   def stripe_fee_recorded?
     !stripe_fee_cents.nil?
+  end
+
+  private
+
+  def sync_order_payment_status
+    order&.sync_payment_status!
   end
 end

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -7,7 +7,18 @@ class WalletTransaction < ApplicationRecord
   validates :amount_cents, presence: true
   validates :transaction_type, presence: true
 
+  # Les débits/remboursements de commande participent à la source de vérité du
+  # `payment_status` de la commande (cf. #41). Les recharges (`top_up`) ne sont
+  # pas liées à une commande et n'ont aucun effet ici.
+  after_commit :sync_order_payment_status
+
   def amount_euros
     (amount_cents / 100.0).round(2)
+  end
+
+  private
+
+  def sync_order_payment_status
+    order&.sync_payment_status!
   end
 end

--- a/app/views/admin/orders/edit.html.erb
+++ b/app/views/admin/orders/edit.html.erb
@@ -179,6 +179,22 @@
       </div>
     </div>
 
+    <div class="mt-8">
+      <%= f.label :payment_status, "Statut de paiement", class: "block text-sm font-medium text-gray-700" %>
+      <%= f.select :payment_status,
+                   options_for_select([
+                     [payment_status_label("unpaid"), "unpaid"],
+                     [payment_status_label("paid"), "paid"],
+                     [payment_status_label("refunded"), "refunded"]
+                   ], @order.payment_status),
+                   {},
+                   class: "mt-1 #{admin_input_class}" %>
+      <p class="mt-1 text-xs text-gray-500">
+        Synchronisé automatiquement depuis les paiements réels (Stripe / portefeuille).
+        Le marquage manuel sert aux paiements hors-ligne (cash, clients à facture).
+      </p>
+    </div>
+
     <div class="mt-6">
       <label class="inline-flex items-center space-x-2 text-sm text-gray-700">
         <%= f.check_box :requires_invoice, class: "rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" %>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -21,7 +21,7 @@
       <div class="flex space-x-4">
         <%= form_with url: admin_orders_path, method: :get, local: true, class: "flex space-x-2" do |f| %>
           <%= f.select :status, options_for_select([
-            ['Tous', ''],
+            ['Tous les statuts', ''],
             ['En attente', 'pending'],
             ['Payées', 'paid'],
             ['Prêtes', 'ready'],
@@ -29,9 +29,17 @@
             ['Non récupérées', 'no_show'],
             ['Annulées', 'cancelled']
           ], params[:status]), {}, { class: "rounded-md border border-gray-300" } %>
-          
-          <%= f.select :bake_day_id, options_from_collection_for_select(@bake_days, :id, :baked_on, params[:bake_day_id]), 
-              { include_blank: 'Tous les jours' }, 
+
+          <%= f.select :payment_status, options_for_select([
+            ['Tous les paiements', ''],
+            ['Non payées', 'unpaid'],
+            ['Payées', 'paid'],
+            ['Partiellement payées', 'partially_paid'],
+            ['Remboursées', 'refunded']
+          ], params[:payment_status]), {}, { class: "rounded-md border border-gray-300" } %>
+
+          <%= f.select :bake_day_id, options_from_collection_for_select(@bake_days, :id, :baked_on, params[:bake_day_id]),
+              { include_blank: 'Tous les jours' },
               { class: "rounded-md border border-gray-300" } %>
           
           <%= f.submit "Filtrer", class: "px-3 py-1 bg-blue-600 text-white rounded-md text-sm hover:bg-blue-700" %>
@@ -49,6 +57,7 @@
         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Jour de cuisson</th>
         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Total</th>
         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Statut</th>
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Paiement</th>
         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
       </tr>
     </thead>
@@ -79,6 +88,17 @@
                   else 'bg-gray-100 text-gray-800'
                   end %>">
               <%= order_status_label(order.status) %>
+            </span>
+          </td>
+          <td class="px-6 py-4 whitespace-nowrap">
+            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
+              <%= case order.payment_status
+                  when 'paid' then 'bg-green-100 text-green-800'
+                  when 'partially_paid' then 'bg-yellow-100 text-yellow-800'
+                  when 'refunded' then 'bg-purple-100 text-purple-800'
+                  else 'bg-gray-100 text-gray-800'
+                  end %>">
+              <%= payment_status_label(order.payment_status) %>
             </span>
           </td>
           <td class="px-6 py-4 whitespace-nowrap text-sm">

--- a/db/migrate/20260625120000_add_payment_and_invoice_status_to_orders.rb
+++ b/db/migrate/20260625120000_add_payment_and_invoice_status_to_orders.rb
@@ -1,0 +1,44 @@
+class AddPaymentAndInvoiceStatusToOrders < ActiveRecord::Migration[8.0]
+  def up
+    # Nouveaux axes additifs (l'enum `status` logistique reste inchangé — cf. #41/#102).
+    # payment_status : unpaid=0, paid=1, partially_paid=2 (réservé), refunded=3
+    add_column :orders, :payment_status, :integer, default: 0, null: false
+    # invoice_status : not_invoiced=0, invoiced=1
+    add_column :orders, :invoice_status, :integer, default: 0, null: false
+    add_index :orders, :payment_status
+
+    # Backfill du payment_status depuis le paiement RÉEL (transactions), pas
+    # depuis l'ancien `status` :
+    #   - paid     : un paiement Stripe encaissé (payments.status = succeeded=0)
+    #                OU un débit portefeuille (wallet_transactions.transaction_type = order_debit=1)
+    #   - refunded : un paiement Stripe remboursé (payments.status = refunded=2)
+    #                OU un remboursement portefeuille (transaction_type = order_refund=2)
+    #     (refunded prime sur paid : il s'applique après).
+    #   - unpaid   : aucun des deux (valeur par défaut).
+    execute(<<~SQL.squish)
+      UPDATE orders SET payment_status = 1
+      WHERE id IN (
+        SELECT order_id FROM payments WHERE status = 0
+        UNION
+        SELECT order_id FROM wallet_transactions WHERE transaction_type = 1 AND order_id IS NOT NULL
+      )
+    SQL
+
+    execute(<<~SQL.squish)
+      UPDATE orders SET payment_status = 3
+      WHERE id IN (
+        SELECT order_id FROM payments WHERE status = 2
+        UNION
+        SELECT order_id FROM wallet_transactions WHERE transaction_type = 2 AND order_id IS NOT NULL
+      )
+    SQL
+
+    # invoice_status reste à not_invoiced (0) partout : c'est déjà la valeur par défaut.
+  end
+
+  def down
+    remove_index :orders, :payment_status
+    remove_column :orders, :payment_status
+    remove_column :orders, :invoice_status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_17_110000) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_25_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -211,10 +211,13 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_17_110000) do
     t.boolean "requires_invoice", default: false, null: false
     t.integer "source", default: 0, null: false
     t.datetime "paid_at"
+    t.integer "payment_status", default: 0, null: false
+    t.integer "invoice_status", default: 0, null: false
     t.index ["bake_day_id"], name: "index_orders_on_bake_day_id"
     t.index ["customer_id"], name: "index_orders_on_customer_id"
     t.index ["order_number"], name: "index_orders_on_order_number"
     t.index ["payment_intent_id"], name: "index_orders_on_payment_intent_id", unique: true, where: "(payment_intent_id IS NOT NULL)"
+    t.index ["payment_status"], name: "index_orders_on_payment_status"
     t.index ["public_token"], name: "index_orders_on_public_token", unique: true
     t.index ["source"], name: "index_orders_on_source"
     t.index ["status"], name: "index_orders_on_status"

--- a/lib/tasks/orders.rake
+++ b/lib/tasks/orders.rake
@@ -1,0 +1,25 @@
+namespace :orders do
+  desc "Resynchronise payment_status depuis les paiements RÉELS (#97). Corrige les " \
+       "commandes marquées « payé » à tort. ATTENTION : réinitialise un marquage " \
+       "manuel admin sans transaction — à lancer une fois, après déploiement."
+  task resync_payment_status: :environment do
+    corrected = 0
+    Order.find_each do |order|
+      before = order.payment_status
+      order.recompute_payment_status!
+      corrected += 1 if order.reload.payment_status != before
+    end
+    puts "payment_status resynchronisé depuis les paiements réels : #{corrected} commande(s) corrigée(s)."
+  end
+
+  desc "Liste les commandes affichées « payé » à tort : statut logistique avancé " \
+       "(prête/récupérée/non-récupérée) sans paiement réel (#97)."
+  task report_wrongly_paid: :environment do
+    orders = Order.marked_paid_without_real_payment.includes(:customer)
+    puts "#{orders.count} commande(s) potentiellement marquées « payé » à tort :"
+    orders.find_each do |order|
+      puts "  #{order.order_number} — #{order.customer.full_name} — " \
+           "statut #{order.status} / paiement #{order.payment_status}"
+    end
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -39,6 +39,18 @@ FactoryBot.define do
       source { :calendar }
     end
 
+    trait :payment_unpaid do
+      payment_status { :unpaid }
+    end
+
+    trait :payment_paid do
+      payment_status { :paid }
+    end
+
+    trait :payment_refunded do
+      payment_status { :refunded }
+    end
+
     trait :with_items do
       transient do
         items_count { 2 }

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -58,6 +58,110 @@ RSpec.describe Order, type: :model do
     end
   end
 
+  describe 'payment_status / invoice_status enums (#41)' do
+    it 'leaves the logistic status enum untouched (additive increment)' do
+      expect(Order.statuses.keys).to contain_exactly(
+        'pending', 'paid', 'ready', 'picked_up', 'no_show', 'cancelled', 'unpaid', 'planned'
+      )
+    end
+
+    it 'defaults a new order to unpaid / not_invoiced' do
+      order = create(:order)
+
+      expect(order.payment_status).to eq('unpaid')
+      expect(order.invoice_status).to eq('not_invoiced')
+    end
+  end
+
+  describe '#derived_payment_status (source de vérité = transactions réelles)' do
+    it 'is "paid" when a successful Stripe payment exists' do
+      order = create(:order)
+      create(:payment, order: order)
+
+      expect(order.reload.derived_payment_status).to eq('paid')
+    end
+
+    it 'is "paid" when a wallet debit exists' do
+      order = create(:order, :from_calendar)
+      create(:wallet_transaction, :order_debit, order: order)
+
+      expect(order.reload.derived_payment_status).to eq('paid')
+    end
+
+    it 'is "refunded" when the payment is refunded (takes precedence over paid)' do
+      order = create(:order, :cancelled)
+      create(:payment, :refunded, order: order)
+
+      expect(order.reload.derived_payment_status).to eq('refunded')
+    end
+
+    it 'is "refunded" when a wallet refund transaction exists' do
+      order = create(:order, :cancelled)
+      create(:wallet_transaction, :order_refund, order: order)
+
+      expect(order.reload.derived_payment_status).to eq('refunded')
+    end
+
+    it 'is "unpaid" when no real payment trace exists' do
+      expect(create(:order).derived_payment_status).to eq('unpaid')
+    end
+  end
+
+  describe 'automatic payment_status synchronisation from transactions' do
+    it 'syncs to paid when a Stripe payment is recorded' do
+      order = create(:order, :pending)
+      expect(order.payment_status).to eq('unpaid')
+
+      create(:payment, order: order)
+
+      expect(order.reload.payment_status).to eq('paid')
+    end
+
+    it 'syncs to paid when a wallet debit is recorded' do
+      order = create(:order, :from_calendar, :planned)
+
+      create(:wallet_transaction, :order_debit, order: order)
+
+      expect(order.reload.payment_status).to eq('paid')
+    end
+
+    it 'syncs to refunded when the payment becomes refunded' do
+      order = create(:order)
+      payment = create(:payment, order: order)
+      expect(order.reload.payment_status).to eq('paid')
+
+      payment.update!(status: :refunded)
+
+      expect(order.reload.payment_status).to eq('refunded')
+    end
+
+    it 'ignores wallet top-ups (no order attached)' do
+      wallet = create(:wallet)
+
+      expect { create(:wallet_transaction, :top_up, wallet: wallet) }.not_to raise_error
+    end
+  end
+
+  describe '#sync_payment_status! and manual marking' do
+    it 'preserves a manual "paid" marking on an offline order with no transaction' do
+      order = create(:order, :unpaid)
+      order.update!(payment_status: :paid)
+
+      # No Stripe/wallet transaction exists: a sync must not downgrade to unpaid.
+      order.sync_payment_status!
+
+      expect(order.reload.payment_status).to eq('paid')
+    end
+
+    it 'does not change payment_status when the logistic status changes' do
+      order = create(:order, :paid, :payment_paid)
+
+      order.transition_to!(:ready)
+
+      expect(order.reload.payment_status).to eq('paid')
+    end
+  end
+
   describe '.stripe_fees_between' do
     let(:bake_day) { create(:bake_day, baked_on: Date.new(2026, 5, 12)) }
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,17 +1,73 @@
 require 'rails_helper'
 
 RSpec.describe Order, type: :model do
+  # #97 : « payé » ne dépend QUE du paiement réel (payment_status), jamais du
+  # statut logistique. Passer une commande à « prêt » ne la rend pas « payée ».
   describe '#payment_received?' do
-    it 'is true for statuses reached after collecting payment' do
-      %i[paid ready picked_up no_show].each do |status|
-        expect(build(:order, status: status).payment_received?).to be(true)
+    it 'is true only when payment_status is paid (real payment / manual marking)' do
+      expect(build(:order, payment_status: :paid).payment_received?).to be(true)
+    end
+
+    it 'is false when payment_status is not paid, regardless of logistic status' do
+      %i[unpaid refunded].each do |payment_status|
+        expect(build(:order, payment_status: payment_status).payment_received?).to be(false)
       end
     end
 
-    it 'is false before payment is collected or once cancelled' do
-      %i[pending planned unpaid cancelled].each do |status|
-        expect(build(:order, status: status).payment_received?).to be(false)
+    it 'is false for an advanced logistic status with no real payment (#97 bug)' do
+      # Commande facturable passée à « prêt » sans paiement réel : non payée.
+      %i[ready picked_up no_show].each do |status|
+        order = build(:order, status: status, payment_status: :unpaid)
+        expect(order.payment_received?).to be(false)
       end
+    end
+  end
+
+  describe 'payment is never inferred from the "ready" transition (#97)' do
+    it 'does not mark a billable order paid when it is marked ready' do
+      order = create(:order, :unpaid, :payment_unpaid)
+
+      order.transition_to!(:ready)
+
+      expect(order.reload.payment_status).to eq('unpaid')
+      expect(order.payment_received?).to be(false)
+    end
+
+    it 'keeps reflecting a real online payment after the ready transition' do
+      order = create(:order, :paid)
+      create(:payment, order: order) # paiement Stripe réel → payment_status paid (#41)
+      order.reload.transition_to!(:ready) # paid -> ready
+
+      expect(order.reload.payment_received?).to be(true)
+    end
+  end
+
+  describe '#recompute_payment_status! and .marked_paid_without_real_payment (#97 cleanup)' do
+    it 'downgrades an order with no real payment back to unpaid' do
+      order = create(:order, :ready, :payment_paid) # marquée payée à tort
+      expect(order.payment_received?).to be(true)
+
+      order.recompute_payment_status!
+
+      expect(order.reload.payment_status).to eq('unpaid')
+    end
+
+    it 'keeps an order with a real payment as paid' do
+      order = create(:order, :ready, :payment_unpaid)
+      create(:payment, order: order)
+
+      order.recompute_payment_status!
+
+      expect(order.reload.payment_status).to eq('paid')
+    end
+
+    it 'identifies orders marked paid without a real payment' do
+      bake_day = create(:bake_day)
+      wrong = create(:order, :ready, :payment_unpaid, bake_day: bake_day)
+      really_paid = create(:order, :ready, :payment_paid, bake_day: bake_day)
+
+      expect(Order.marked_paid_without_real_payment).to include(wrong)
+      expect(Order.marked_paid_without_real_payment).not_to include(really_paid)
     end
   end
 

--- a/spec/requests/admin/orders_spec.rb
+++ b/spec/requests/admin/orders_spec.rb
@@ -34,6 +34,49 @@ RSpec.describe "Admin::Orders", type: :request do
     end
   end
 
+  describe "GET /admin/orders (index, #41)" do
+    it "displays both a logistic status column and a payment status column" do
+      create(:order, :paid, :payment_paid, :with_items)
+
+      get admin_orders_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(">Statut<")
+      expect(response.body).to include(">Paiement<")
+    end
+
+    it "filters orders by payment status (incl. refunded)" do
+      bake_day = create(:bake_day)
+      paid_order = create(:order, :paid, :payment_paid, :with_items, bake_day: bake_day)
+      refunded_order = create(:order, :cancelled, :payment_refunded, :with_items, bake_day: bake_day)
+
+      get admin_orders_path, params: { payment_status: "refunded" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(refunded_order.order_number)
+      expect(response.body).not_to include(paid_order.order_number)
+    end
+  end
+
+  describe "PATCH /admin/orders/:id (manual payment marking, #41)" do
+    it "lets an admin mark an offline order as paid" do
+      offline_order = create(:order, :unpaid, :with_items)
+
+      patch admin_order_path(offline_order), params: {
+        order: {
+          customer_id: offline_order.customer_id,
+          bake_day_id: offline_order.bake_day_id,
+          status: "unpaid",
+          payment_status: "paid",
+          final_total_euros: (offline_order.total_cents / 100.0).to_s,
+          variant_quantities: offline_order.order_items.each_with_object({}) { |i, h| h[i.product_variant_id] = i.qty }
+        }
+      }
+
+      expect(offline_order.reload.payment_status).to eq("paid")
+    end
+  end
+
   describe "GET /admin/orders/:id (show)" do
     it "displays the manually recorded payment date for an offline payment" do
       order.update!(status: :paid, paid_at: Time.zone.local(2026, 5, 12))

--- a/spec/services/bake_day_cancellation_service_spec.rb
+++ b/spec/services/bake_day_cancellation_service_spec.rb
@@ -87,7 +87,9 @@ RSpec.describe BakeDayCancellationService do
     end
 
     context "with a paid order with no online payment trace (offline cash)" do
-      let!(:order) { create(:order, :paid, bake_day: bake_day) }
+      # Paiement hors-ligne marqué manuellement payé (payment_status), sans trace
+      # Stripe/portefeuille (#97 : « payé » = paiement réel/marquage, pas le statut).
+      let!(:order) { create(:order, :paid, :payment_paid, bake_day: bake_day) }
 
       it "cancels it and flags it for a manual refund" do
         result = described_class.new(bake_day).call

--- a/spec/services/billing_report_service_spec.rb
+++ b/spec/services/billing_report_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe BillingReportService do
 
   it "regroupe les commandes des clients facturables pour le mois donné" do
     pro = create(:customer, billable: true, first_name: "Épicerie", last_name: "Durand")
-    create(:order, :paid, customer: pro, bake_day: bake_day_in_month, total_cents: 2000)
+    create(:order, :paid, :payment_paid, customer: pro, bake_day: bake_day_in_month, total_cents: 2000)
     create(:order, :unpaid, customer: pro, bake_day: bake_day_in_month, total_cents: 1500)
 
     result = report
@@ -27,7 +27,7 @@ RSpec.describe BillingReportService do
 
   it "agrège les totaux globaux du rapport" do
     pro = create(:customer, billable: true)
-    create(:order, :paid, customer: pro, bake_day: bake_day_in_month, total_cents: 2000)
+    create(:order, :paid, :payment_paid, customer: pro, bake_day: bake_day_in_month, total_cents: 2000)
     create(:order, :unpaid, customer: pro, bake_day: bake_day_in_month, total_cents: 1500)
 
     result = report


### PR DESCRIPTION
Closes #97

> ⚠️ **PR empilée sur #41** (PR #103, `agent/41-payment-invoice-status`). Tant que #41 n'est pas mergé, ce diff inclut aussi les changements de #41. À merger **après** #41.

## Cause identifiée
`Order#payment_received?` dérivait du **statut logistique** (`PAID_STATUSES = paid/ready/picked_up/no_show`). Quand les boulangers passaient une commande **facturable** à « prêt » (transition `unpaid → ready`, pour envoyer le SMS « c'est prêt »), `payment_received?` renvoyait alors `true` → la commande apparaissait **« payée »** dans la facturation (clients à facture, Sémisto, épicerie) **sans aucun paiement réel**. C'était donc un **effet de bord automatique** du passage à « prêt », pas une action manuelle.

## Correctif (s'appuie sur `payment_status` de #41)
- **`payment_received?` = `payment_status_paid?`** : une commande est « payée » **uniquement** si un paiement réel a eu lieu (Stripe / portefeuille, synchronisé automatiquement par #41) **ou** si l'admin l'a explicitement marquée payée — **jamais** par une transition de statut. Constante `PAID_STATUSES` (obsolète) supprimée. Le correctif propage la bonne sémantique à tous les points d'affichage (facturation HTML + CSV, page commande, API, totaux facturation).
- **Non-régression** : marquer une commande facturable « prêt » ne modifie ni `payment_status` ni `payment_received?`.
- **Nettoyage des commandes erronées** :
  - `payment_status` a déjà été **rétro-rempli depuis les paiements réels** par la migration de #41 → l'affichage devient correct dès le déploiement.
  - `Order.marked_paid_without_real_payment` (scope) + `rake orders:report_wrongly_paid` : **identifient** les commandes concernées (statut logistique avancé sans paiement réel).
  - `Order#recompute_payment_status!` + `rake orders:resync_payment_status` : re-dérivent `payment_status` depuis les paiements réels (corrige d'éventuelles dérives ; **peut rétrograder** → à lancer une fois après déploiement, avant accumulation de marquages manuels).

## Tests (verts)
- `spec/models/order_spec.rb` : `payment_received?` ne dépend que de `payment_status` (vrai pour `paid`, faux pour `unpaid`/`refunded` quel que soit le statut logistique) ; transition « prêt » sans effet sur le paiement ; paiement Stripe réel toujours reflété après passage à « prêt » ; `recompute_payment_status!` (rétrograde sans paiement réel, garde « paid » avec paiement) ; scope d'identification.
- MAJ des specs qui encodaient l'ancienne sémantique : `billing_report_service_spec`, `bake_day_cancellation_service_spec` (« payé » = paiement réel/marquage).
- **Suite complète** : `377 examples, 0 failures`. **`bin/rubocop`** : `no offenses`.

## Notes / ce qui n'a pas été testé
- **Hors périmètre** : refonte complète de l'enum `status` (#102) ; nouveau modèle de paiement.
- Pas de vérification navigateur. La tâche `orders:resync_payment_status` n'a pas été exécutée en production (à lancer par Michael après merge de #41 + #97).