### PR TITLE
Admin clients : colonnes d'état Cash OK / Fact. / Interne

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -75,4 +75,22 @@ module ApplicationHelper
       class: "w-5 h-5 text-gray-500 shrink-0", role: "img", "aria-label": label
     )
   end
+
+  # Icône d'état booléen pour les tableaux admin : pastille « check » verte si
+  # l'option est active, grisée sinon. `label` sert d'info-bulle et de libellé
+  # accessible (ex. « Paiement cash autorisé »).
+  CHECK_CIRCLE_ICON_PATH = "M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z".freeze
+
+  def boolean_status_icon(active, label:)
+    state = active ? "actif" : "inactif"
+    color = active ? "text-green-600" : "text-gray-300"
+
+    tag.svg(
+      tag.title("#{label} : #{state}") +
+        tag.path(nil, "stroke-linecap": "round", "stroke-linejoin": "round", d: CHECK_CIRCLE_ICON_PATH),
+      xmlns: "http://www.w3.org/2000/svg", fill: "none", viewBox: "0 0 24 24",
+      "stroke-width": "1.5", stroke: "currentColor",
+      class: "w-5 h-5 #{color} shrink-0 inline-block", role: "img", "aria-label": "#{label} : #{state}"
+    )
+  end
 end

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -41,6 +41,9 @@
         </th>
         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">SMS</th>
         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Groupes</th>
+        <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider" title="Paiement cash autorisé">Cash OK</th>
+        <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider" title="Client facturable (facture mensuelle)">Fact.</th>
+        <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider" title="Client interne (pas de vérification de solde)">Interne</th>
         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           <%= link_to admin_customers_path(search: params[:search], sort: "last_order"),
               class: "hover:text-gray-700 #{'text-gray-900 font-bold' if params[:sort] == 'last_order'}" do %>
@@ -72,6 +75,15 @@
                 <span class="text-gray-400">—</span>
               <% end %>
             </td>
+            <td class="px-6 py-4 whitespace-nowrap text-center">
+              <%= boolean_status_icon(customer.cash_payment_allowed?, label: "Paiement cash autorisé") %>
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-center">
+              <%= boolean_status_icon(customer.billable?, label: "Facturable") %>
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-center">
+              <%= boolean_status_icon(customer.skip_wallet_check?, label: "Client interne") %>
+            </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
               <% last_order = customer.orders.max_by(&:created_at) %>
               <% if last_order %>
@@ -87,7 +99,7 @@
         <% end %>
       <% else %>
         <tr>
-          <td colspan="4" class="px-6 py-4 text-center text-sm text-gray-500">
+          <td colspan="7" class="px-6 py-4 text-center text-sm text-gray-500">
             <% if params[:search].present? %>
               Aucun mangeur trouvé pour cette recherche.
             <% else %>

--- a/spec/requests/admin/customers_spec.rb
+++ b/spec/requests/admin/customers_spec.rb
@@ -10,6 +10,22 @@ RSpec.describe "Admin::Customers", type: :request do
 
   before { post admin_login_path, params: { password: "test-admin-pw" } }
 
+  describe "GET /admin/customers (colonnes d'état)" do
+    it "affiche les colonnes Cash OK / Fact. / Interne avec une icône d'état par client" do
+      create(:customer, first_name: "Pro", cash_payment_allowed: true, billable: true, skip_wallet_check: false)
+
+      get admin_customers_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Cash OK")
+      expect(response.body).to include("Fact.")
+      expect(response.body).to include("Interne")
+      # Icône active (verte) pour une option activée, grisée sinon.
+      expect(response.body).to include("Paiement cash autorisé : actif")
+      expect(response.body).to include("Client interne : inactif")
+    end
+  end
+
   # #36 : réglage admin « paiement cash autorisé » sur le client.
   describe "PATCH /admin/customers/:id" do
     it "autorise le paiement cash pour le client" do


### PR DESCRIPTION
Ajoute 3 colonnes au tableau **Admin → Clients**, chacune avec une **icône d'état** (pastille « check » verte si actif, grisée sinon) :

- **« Cash OK »** → `cash_payment_allowed` (paiement cash autorisé, #36)
- **« Fact. »** → `billable` (client facturable / facture mensuelle)
- **« Interne »** → `skip_wallet_check` (client interne, pas de vérification de solde)

Icône via le helper `boolean_status_icon(active, label:)` (SVG check-circle, info-bulle + libellé accessible « <option> : actif/inactif »). `colspan` de l'état vide ajusté (4 → 7).

## Tests
- `spec/requests/admin/customers_spec.rb` : la page liste affiche les 3 colonnes + l'état actif/inactif des icônes.
- Suite complète : `415 examples, 0 failures`. `bin/rubocop` : propre.

Aucune migration. Prêt à merger quand tu veux (le merge déclenchera le déploiement).