### PR TITLE
Pizza party privée : nombre de personnes + forfait 40 € (#68)

### DIFF
--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -1,6 +1,7 @@
 class CartController < ApplicationController
   def show
     remove_unavailable_cart_items!
+    sync_pizza_party_forfait!
     @cart = session[:cart] || []
     @bake_day_id = session[:bake_day_id]
     @bake_day = BakeDay.find_by(id: @bake_day_id) if @bake_day_id
@@ -58,6 +59,8 @@ class CartController < ApplicationController
       }
     end
 
+    sync_pizza_party_forfait!
+
     respond_to do |format|
       format.html { redirect_to catalog_path, notice: "Produit ajouté au panier" }
       format.json do
@@ -89,6 +92,7 @@ class CartController < ApplicationController
     if item && params[:qty].to_i > 0
       item["qty"] = params[:qty].to_i
       session[:cart] = cart
+      sync_pizza_party_forfait!
       redirect_to cart_path, notice: "Panier mis à jour"
     else
       redirect_to cart_path, alert: "Quantité invalide"
@@ -97,6 +101,7 @@ class CartController < ApplicationController
 
   def remove
     session[:cart] = (session[:cart] || []).reject { |item| item["product_variant_id"] == params[:id] }
+    sync_pizza_party_forfait!
     redirect_to cart_path, notice: "Produit retiré du panier"
   end
 
@@ -127,6 +132,12 @@ class CartController < ApplicationController
   end
 
   private
+
+  # Maintient la ligne « forfait Pizza party » (#68) cohérente avec le panier.
+  # Idempotent : sans danger même appelé plusieurs fois par requête.
+  def sync_pizza_party_forfait!
+    session[:cart] = PizzaPartyForfaitService.sync(session[:cart])
+  end
 
   def calculate_subtotal
     (session[:cart] || []).sum do |item|

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -1,6 +1,10 @@
 class CheckoutController < ApplicationController
   before_action :ensure_cart_not_empty, except: [ :success ]
   before_action :ensure_bake_day_set, except: [ :success ]
+  # Garde-fou (#68) : on resynchronise la ligne forfait Pizza party AVANT de
+  # calculer le total / créer le PaymentIntent ou la commande, au cas où le
+  # panier aurait été modifié hors des actions du CartController. Idempotent.
+  before_action :sync_pizza_party_forfait!, only: [ :new, :create_payment_intent, :create_cash_order ]
   before_action :ensure_cutoff_not_passed, only: [ :new, :create_payment_intent, :create_cash_order ]
 
   def new
@@ -357,6 +361,11 @@ class CheckoutController < ApplicationController
   end
 
   private
+
+  # Resynchronise la ligne forfait Pizza party (#68). Idempotent.
+  def sync_pizza_party_forfait!
+    session[:cart] = PizzaPartyForfaitService.sync(session[:cart])
+  end
 
   def find_order_by_payment_intent(payment_intent_id)
     return nil unless payment_intent_id.present?

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -6,6 +6,14 @@ class Product < ApplicationRecord
   # maison (boulangerie) des reventes (épicerie, traiteur, etc.).
   enum :internal_category, { boulangerie: 0, epicerie: 1, traiteur: 2, autre: 3 }, prefix: true
 
+  # Rôle dans le dispositif « Pizza party privée » (#68).
+  # - none    : produit ordinaire, sans lien avec les pizza partys.
+  # - party   : produit « Pizza party privée – Nombre de personnes » (1 boule /
+  #             personne) ; sa présence au panier déclenche le forfait.
+  # - forfait : le forfait Pizza party (40 €), compté UNE seule fois par
+  #             commande, synchronisé automatiquement par PizzaPartyForfaitService.
+  enum :pizza_party_role, { none: 0, party: 1, forfait: 2 }, prefix: true
+
   has_many :product_variants, dependent: :destroy
   has_many :product_availabilities, through: :product_variants
   has_many :product_images, dependent: :destroy
@@ -25,6 +33,8 @@ class Product < ApplicationRecord
   scope :ordered, -> { order(category: :asc, position: :asc, name: :asc) }
   scope :store_channel, -> { where(channel: "store") }
   scope :not_deleted, -> { where(deleted_at: nil) }
+  # Le produit forfait de la Pizza party (#68) — un seul attendu en base.
+  scope :pizza_party_forfait, -> { where(pizza_party_role: :forfait) }
 
   def display_name
     name

--- a/app/services/pizza_party_forfait_service.rb
+++ b/app/services/pizza_party_forfait_service.rb
@@ -1,0 +1,96 @@
+# Synchronise la ligne « forfait Pizza party » (#68) dans un panier session.
+#
+# Le panier est un array de hashes à clés string :
+#   { "product_variant_id" => id.to_s, "qty" => n, "name" => ..., "price_cents" => ... }
+#
+# Règle métier :
+#   - si le panier (hors forfait) contient AU MOINS une ligne dont la variante
+#     appartient à un produit `pizza_party_role: :party`, alors le panier doit
+#     contenir EXACTEMENT UNE ligne forfait (qty 1, prix 4000) ;
+#   - sinon, toute ligne forfait est retirée.
+#
+# Le forfait est ainsi une simple ligne de panier auto-synchronisée : tout le
+# downstream (totaux, PaymentIntent, OrderCreationService, webhook, page succès)
+# s'appuie sur le panier sans cas particulier. Le forfait est donc compté une
+# seule fois par commande quel que soit le nombre de boules.
+#
+# La méthode est idempotente : `sync(sync(cart)) == sync(cart)`. Elle ne mute
+# pas le panier reçu (renvoie un nouvel array) et ne crashe pas si le produit
+# forfait est absent de la base (cas d'une base sans seeds) : dans ce cas, elle
+# se contente de retirer toute ligne forfait résiduelle.
+class PizzaPartyForfaitService
+  FORFAIT_PRICE_CENTS = 4000
+  FORFAIT_QTY = 1
+
+  def self.sync(cart)
+    new(cart).sync
+  end
+
+  def initialize(cart)
+    @cart = Array(cart)
+  end
+
+  def sync
+    forfait_variant = self.class.forfait_variant
+    forfait_variant_id = forfait_variant&.id&.to_s
+
+    # Panier débarrassé de toute ligne forfait existante (on la reconstruit).
+    base_cart =
+      if forfait_variant_id
+        @cart.reject { |item| item["product_variant_id"].to_s == forfait_variant_id }
+      else
+        # Pas de produit forfait en base : on retire au moins toute ligne dont la
+        # variante pointe vers un produit forfait (défensif), sinon on garde tout.
+        reject_forfait_lines(@cart)
+      end
+
+    return base_cart unless forfait_variant
+    return base_cart unless party_present?(base_cart)
+
+    base_cart + [ forfait_line(forfait_variant) ]
+  end
+
+  # Variante « store » du produit forfait, ou nil si absent (base sans seeds).
+  def self.forfait_variant
+    product = Product.pizza_party_forfait.first
+    return nil unless product
+
+    product.product_variants.find_by(channel: "store") ||
+      product.product_variants.first
+  end
+
+  private
+
+  # Le panier contient-il au moins une variante d'un produit « party » ?
+  def party_present?(cart)
+    variant_ids = cart.map { |item| item["product_variant_id"].to_s }.reject(&:blank?).uniq
+    return false if variant_ids.empty?
+
+    ProductVariant
+      .joins(:product)
+      .where(id: variant_ids, products: { pizza_party_role: Product.pizza_party_roles[:party] })
+      .exists?
+  end
+
+  def reject_forfait_lines(cart)
+    forfait_variant_ids =
+      ProductVariant
+        .joins(:product)
+        .where(products: { pizza_party_role: Product.pizza_party_roles[:forfait] })
+        .pluck(:id)
+        .map(&:to_s)
+
+    return cart if forfait_variant_ids.empty?
+
+    cart.reject { |item| forfait_variant_ids.include?(item["product_variant_id"].to_s) }
+  end
+
+  def forfait_line(variant)
+    {
+      "product_variant_id" => variant.id.to_s,
+      "qty" => FORFAIT_QTY,
+      "name" => variant.name,
+      "price_cents" => FORFAIT_PRICE_CENTS
+    }
+  end
+end

--- a/app/views/cart/show.html.erb
+++ b/app/views/cart/show.html.erb
@@ -69,7 +69,9 @@
           <% variant = ProductVariant.find(item['product_variant_id']) %>
           <% product = variant.product %>
           <% qty = item['qty'].to_i %>
-          <% line_total = qty * variant.price_cents %>
+          <% line_total = qty * item['price_cents'].to_i %>
+          <% is_forfait = product&.pizza_party_role_forfait? %>
+          <% is_party = product&.pizza_party_role_party? %>
           <% if product.nil? %>
             <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-6">
               <div class="flex items-center justify-between">
@@ -98,30 +100,45 @@
                   <div class="flex items-start justify-between gap-4">
                     <div>
                       <h3 class="text-lg font-semibold text-gray-900"><%= product.name %></h3>
-                      <p class="text-sm text-gray-500"><%= variant.name %></p>
+                      <% if is_party %>
+                        <p class="text-sm text-gray-500"><%= "#{qty} #{qty > 1 ? 'personnes' : 'personne'}" %></p>
+                      <% elsif is_forfait %>
+                        <p class="text-sm text-gray-500">Ajouté automatiquement à ta Pizza party</p>
+                      <% else %>
+                        <p class="text-sm text-gray-500"><%= variant.name %></p>
+                      <% end %>
                     </div>
                     <span class="text-base font-semibold text-gray-900">
                       <%= number_to_currency(line_total / 100.0, unit: "€", separator: ",", delimiter: "") %>
                     </span>
                   </div>
 
-                  <div class="mt-4 flex items-center justify-between">
-                    <div class="flex items-center gap-2">
-                      <%= button_to cart_update_path, method: :patch, form_class: "flex", class: "inline-flex items-center justify-center h-9 w-9 rounded-full border border-gray-200 text-lg font-semibold text-gray-700 hover:bg-gray-100 transition", params: { id: item['product_variant_id'], qty: [qty - 1, 1].max } do %>
-                        &minus;
-                      <% end %>
-                      <span class="inline-flex items-center justify-center h-9 min-w-[3rem] rounded-full bg-gray-100 text-sm font-semibold text-gray-900">
-                        <%= qty %>
-                      </span>
-                      <%= button_to cart_update_path, method: :patch, form_class: "flex", class: "inline-flex items-center justify-center h-9 w-9 rounded-full border border-gray-200 text-lg font-semibold text-gray-700 hover:bg-gray-100 transition", params: { id: item['product_variant_id'], qty: qty + 1 } do %>
-                        +
+                  <% if is_forfait %>
+                    <%# Le forfait est piloté par PizzaPartyForfaitService : pas de
+                        contrôle de quantité ni de retrait indépendant (le sync
+                        rétablirait l'état de toute façon). %>
+                    <div class="mt-4 text-sm text-gray-500">
+                      Forfait unique par commande.
+                    </div>
+                  <% else %>
+                    <div class="mt-4 flex items-center justify-between">
+                      <div class="flex items-center gap-2">
+                        <%= button_to cart_update_path, method: :patch, form_class: "flex", class: "inline-flex items-center justify-center h-9 w-9 rounded-full border border-gray-200 text-lg font-semibold text-gray-700 hover:bg-gray-100 transition", params: { id: item['product_variant_id'], qty: [qty - 1, 1].max } do %>
+                          &minus;
+                        <% end %>
+                        <span class="inline-flex items-center justify-center h-9 min-w-[3rem] rounded-full bg-gray-100 text-sm font-semibold text-gray-900">
+                          <%= qty %>
+                        </span>
+                        <%= button_to cart_update_path, method: :patch, form_class: "flex", class: "inline-flex items-center justify-center h-9 w-9 rounded-full border border-gray-200 text-lg font-semibold text-gray-700 hover:bg-gray-100 transition", params: { id: item['product_variant_id'], qty: qty + 1 } do %>
+                          +
+                        <% end %>
+                      </div>
+
+                      <%= button_to cart_remove_path(item['product_variant_id']), method: :delete, data: { confirm: "Retirer cet article ?" }, class: "text-sm font-medium text-red-500 hover:text-red-600 transition" do %>
+                        Retirer
                       <% end %>
                     </div>
-
-                    <%= button_to cart_remove_path(item['product_variant_id']), method: :delete, data: { confirm: "Retirer cet article ?" }, class: "text-sm font-medium text-red-500 hover:text-red-600 transition" do %>
-                      Retirer
-                    <% end %>
-                  </div>
+                  <% end %>
                 </div>
               </div>
             </div>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -96,6 +96,10 @@
               <%= product.name %>
             <% end %>
 
+            <% if product.pizza_party_role_party? %>
+              <p class="mt-1 text-xs text-gray-500">Nous comptons 1 boule de pâte à pizza / personne</p>
+            <% end %>
+
             <div class="mt-4 space-y-3">
               <% variants.each do |variant| %>
                 <%= form_with url: cart_add_path, method: :post, local: true, data: { action: "submit->cart#add" }, class: "flex items-center justify-between gap-4 rounded-2xl border border-gray-200 bg-white px-4 py-3 shadow-sm transition hover:border-terracotta/40" do |f| %>
@@ -107,7 +111,7 @@
                     <button type="submit" class="flex h-8 w-8 items-center justify-center rounded-lg bg-lime-300 text-lg font-semibold leading-none text-charcoal shadow hover:bg-lime-400 focus:outline-none focus:ring-2 focus:ring-lime-400/60" data-cart-target="button" data-cart-variant-id="<%= variant.id %>" data-cart-current-qty="<%= variant_qty %>">
                       <%= variant_qty > 0 ? variant_qty : "+" %>
                     </button>
-                    <span class="text-sm font-medium text-charcoal"><%= variant.name %></span>
+                    <span class="text-sm font-medium text-charcoal"><%= product.pizza_party_role_party? ? "Nombre de personnes" : variant.name %></span>
                   </div>
 
                   <span class="inline-flex items-center rounded-lg px-3 py-1 text-sm text-right font-semibold text-slate-700">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -98,6 +98,9 @@
         <p class="text-base text-gray-700">
           <%= @product.description %>
         </p>
+        <% if @product.pizza_party_role_party? %>
+          <p class="mt-2 text-xs text-gray-500">Nous comptons 1 boule de pâte à pizza / personne</p>
+        <% end %>
       </div>
 
       <!-- Availability -->
@@ -137,10 +140,11 @@
           <%= f.hidden_field :qty, value: 1, data: { quantity_selector_target: "input" } %>
           
           <!-- Quantity selector -->
+          <% quantity_label = @product.pizza_party_role_party? ? "Nombre de personnes" : "Quantité" %>
           <div>
-            <label class="sr-only">Quantité</label>
+            <label class="sr-only"><%= quantity_label %></label>
             <div class="flex items-center gap-3">
-              <span class="text-sm font-medium text-gray-900">Quantité</span>
+              <span class="text-sm font-medium text-gray-900"><%= quantity_label %></span>
               <div class="flex items-center gap-2">
                 <button type="button" data-action="click->quantity-selector#decrement" class="inline-flex items-center justify-center h-10 w-10 rounded-lg border border-gray-300 text-lg font-semibold text-gray-700 hover:bg-gray-50 transition focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2">
                   &minus;

--- a/db/migrate/20260625170000_add_pizza_party_to_products.rb
+++ b/db/migrate/20260625170000_add_pizza_party_to_products.rb
@@ -1,0 +1,9 @@
+class AddPizzaPartyToProducts < ActiveRecord::Migration[8.0]
+  def change
+    # Rôle d'un produit dans la "Pizza party privée" (#68) :
+    #   none (0)    : produit normal
+    #   party (1)   : le produit "Pizza party privée" (quantité = nombre de personnes)
+    #   forfait (2) : le forfait 40 € (matériel + four à bois), ajouté une fois par commande
+    add_column :products, :pizza_party_role, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_25_160000) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_25_170000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -326,6 +326,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_25_160000) do
     t.string "channel", default: "store", null: false
     t.datetime "deleted_at"
     t.integer "internal_category", default: 0, null: false
+    t.integer "pizza_party_role", default: 0, null: false
     t.index ["category", "position", "name"], name: "index_products_on_category_and_position_and_name"
     t.index ["category"], name: "index_products_on_category"
     t.index ["deleted_at"], name: "index_products_on_deleted_at"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -69,6 +69,9 @@ breads = [
 ]
 
 # Category: Dough balls
+# Le produit « Pizza party privée » et son forfait sont gérés plus bas dans un
+# bloc dédié (#68) : ils demandent un rôle (pizza_party_role) et un rename
+# idempotent que la boucle générique ci-dessous ne sait pas faire.
 dough_balls = [
   {
     name: "Boule de pâte à pizza à emporter",
@@ -76,14 +79,6 @@ dough_balls = [
     position: 1,
     variants: [
       { name: "une boule", price_cents: 200 }
-    ]
-  },
-  {
-    name: "Boule de pâte à pizza pour Pizza Party privée",
-    description: "Boule de pâte à pizza pour Pizza Party privée",
-    position: 2,
-    variants: [
-      { name: "une boule", price_cents: 500 }
     ]
   }
 ]
@@ -120,6 +115,63 @@ dough_balls.each do |product_data|
     end
   end
 end
+
+# --- Pizza party privée (#68) -----------------------------------------------
+# Le produit « party » (1 boule de pâte / personne) et son « forfait » 40 €.
+#
+# Le produit party a été renommé : on le retrouve par son NOUVEAU nom OU son
+# ANCIEN nom (rename historique) pour rester idempotent et ne jamais créer de
+# doublon. Le forfait est un produit `channel: "admin"` (donc absent du
+# catalogue store et non ajoutable directement) dont l'UNIQUE variante reste en
+# `channel: "store"` : ainsi elle survit au filtre panier
+# `remove_unavailable_cart_items!` (qui teste la variante, pas le produit), et
+# le forfait peut être injecté comme ligne de panier par PizzaPartyForfaitService.
+
+pizza_party_new_name = "Pizza party privée – Nombre de personnes"
+pizza_party_old_name = "Boule de pâte à pizza pour Pizza Party privée"
+
+pizza_party_product =
+  Product.find_by(name: pizza_party_new_name) ||
+  Product.find_by(name: pizza_party_old_name) ||
+  Product.new(name: pizza_party_new_name)
+
+pizza_party_product.update!(
+  name: pizza_party_new_name,
+  description: "Une boule de pâte à pizza par personne pour ta Pizza party privée.",
+  category: :dough_balls,
+  position: 2,
+  active: true,
+  channel: "store",
+  pizza_party_role: :party
+)
+
+ProductVariant.find_or_create_by!(product: pizza_party_product, name: "une boule") do |v|
+  v.price_cents = 500
+  v.active = true
+  v.channel = "store"
+end
+
+forfait_product =
+  Product.find_by(pizza_party_role: :forfait) ||
+  Product.find_by(name: "Forfait Pizza party privée") ||
+  Product.new(name: "Forfait Pizza party privée")
+
+forfait_product.update!(
+  name: "Forfait Pizza party privée",
+  description: "Forfait Pizza party privée (matériel, four à bois). Ajouté automatiquement à ta commande.",
+  category: :dough_balls,
+  position: 3,
+  active: true,
+  channel: "admin",
+  pizza_party_role: :forfait
+)
+
+ProductVariant.find_or_create_by!(product: forfait_product, name: "forfait") do |v|
+  v.price_cents = 4000
+  v.active = true
+  v.channel = "store"
+end
+# ---------------------------------------------------------------------------
 
 puts "✅ Products and variants created"
 

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     active { true }
     channel { 'store' }
     internal_category { :boulangerie }
+    pizza_party_role { :none }
 
     trait :epicerie do
       internal_category { :epicerie }
@@ -33,6 +34,19 @@ FactoryBot.define do
 
     trait :admin_channel do
       channel { 'admin' }
+    end
+
+    # Produit « Pizza party privée » (#68) : déclenche le forfait.
+    trait :pizza_party do
+      category { :dough_balls }
+      pizza_party_role { :party }
+    end
+
+    # Produit forfait Pizza party (#68) : admin channel, compté une fois.
+    trait :pizza_party_forfait do
+      category { :dough_balls }
+      channel { 'admin' }
+      pizza_party_role { :forfait }
     end
   end
 end

--- a/spec/requests/pizza_party_cart_spec.rb
+++ b/spec/requests/pizza_party_cart_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+# Panier + forfait Pizza party (#68) : le forfait est une ligne de panier
+# auto-synchronisée, comptée une seule fois, incluse dans le total payé.
+RSpec.describe 'Pizza party — panier & forfait', type: :request do
+  let!(:party_product) do
+    create(:product, :pizza_party, channel: 'store', name: 'Pizza party privée – Nombre de personnes')
+  end
+  let!(:party_variant) do
+    create(:product_variant, product: party_product, name: 'une boule', price_cents: 500, channel: 'store')
+  end
+
+  let!(:forfait_product) { create(:product, :pizza_party_forfait, name: 'Forfait Pizza party privée') }
+  let!(:forfait_variant) do
+    create(:product_variant, product: forfait_product, name: 'forfait', price_cents: 4000, channel: 'store')
+  end
+
+  def forfait_lines(cart)
+    (cart || []).select { |item| item['product_variant_id'] == forfait_variant.id.to_s }
+  end
+
+  describe 'POST /cart/add avec une variante de produit party' do
+    it 'injecte automatiquement la ligne forfait' do
+      post cart_add_path, params: { product_variant_id: party_variant.id, qty: 4 }
+
+      cart = session[:cart]
+      expect(forfait_lines(cart).size).to eq(1)
+      expect(forfait_lines(cart).first['qty']).to eq(1)
+      expect(forfait_lines(cart).first['price_cents']).to eq(4000)
+    end
+
+    it 'porte un sous-total = 500 × N + 4000 (forfait compté une fois)' do
+      n = 4
+      post cart_add_path, params: { product_variant_id: party_variant.id, qty: n }
+
+      subtotal = session[:cart].sum { |item| item['qty'].to_i * item['price_cents'].to_i }
+      expect(subtotal).to eq((500 * n) + 4000)
+    end
+
+    it 'ne double pas le forfait quand on ajoute encore des boules' do
+      post cart_add_path, params: { product_variant_id: party_variant.id, qty: 2 }
+      post cart_add_path, params: { product_variant_id: party_variant.id, qty: 3 }
+
+      cart = session[:cart]
+      expect(forfait_lines(cart).size).to eq(1)
+      party_line = cart.find { |item| item['product_variant_id'] == party_variant.id.to_s }
+      expect(party_line['qty']).to eq(5)
+    end
+  end
+
+  describe 'DELETE /cart/remove du produit party' do
+    it 'retire aussi le forfait' do
+      post cart_add_path, params: { product_variant_id: party_variant.id, qty: 2 }
+      expect(forfait_lines(session[:cart]).size).to eq(1)
+
+      delete cart_remove_path(party_variant.id.to_s)
+      expect(forfait_lines(session[:cart])).to be_empty
+    end
+  end
+
+  describe 'le montant payé en ligne inclut le forfait' do
+    let(:bake_day) { create(:bake_day, :can_order) }
+    let(:customer) { create(:customer, first_name: 'Léa') }
+
+    before do
+      allow(OrderNotificationService).to receive(:send_confirmation)
+      allow(OtpService).to receive(:send_code).and_return({ success: true, channel: :sms })
+      allow(OtpService).to receive(:verify_code).and_return({ success: true })
+      post '/connexion', params: { identifier: customer.phone_e164 }
+      post '/connexion', params: { identifier: customer.phone_e164, otp_code: '123456' }
+
+      post cart_add_path, params: { product_variant_id: party_variant.id, bake_day_id: bake_day.id, qty: 4 }
+      stub_stripe_payment_intent_create(amount: (500 * 4) + 4000)
+    end
+
+    it 'crée une commande dont le total = 500 × N + 4000' do
+      post '/checkout/create_payment_intent',
+           params: { first_name: 'Léa' }.to_json,
+           headers: { 'CONTENT_TYPE' => 'application/json' }
+
+      expect(response).to have_http_status(:ok)
+      order = Order.order(:created_at).last
+      expect(order.total_cents).to eq((500 * 4) + 4000)
+    end
+
+    it 'compte le forfait une seule fois parmi les items de commande' do
+      post '/checkout/create_payment_intent',
+           params: { first_name: 'Léa' }.to_json,
+           headers: { 'CONTENT_TYPE' => 'application/json' }
+
+      order = Order.order(:created_at).last
+      forfait_items = order.order_items.select { |oi| oi.product_variant_id == forfait_variant.id }
+      expect(forfait_items.size).to eq(1)
+      expect(forfait_items.first.qty).to eq(1)
+      expect(forfait_items.first.unit_price_cents).to eq(4000)
+    end
+  end
+end

--- a/spec/services/pizza_party_forfait_service_spec.rb
+++ b/spec/services/pizza_party_forfait_service_spec.rb
@@ -1,0 +1,117 @@
+require 'rails_helper'
+
+# Synchronisation de la ligne forfait Pizza party (#68).
+RSpec.describe PizzaPartyForfaitService do
+  # Produit « party » (1 boule / personne) — déclencheur du forfait.
+  let!(:party_product) do
+    create(:product, :dough_ball, channel: 'store', pizza_party_role: :party)
+  end
+  let!(:party_variant) do
+    create(:product_variant, product: party_product, name: 'une boule', price_cents: 500, channel: 'store')
+  end
+
+  # Produit forfait (admin) avec sa variante store à 40 €.
+  let!(:forfait_product) do
+    create(:product, :dough_ball, :admin_channel, pizza_party_role: :forfait)
+  end
+  let!(:forfait_variant) do
+    create(:product_variant, product: forfait_product, name: 'forfait', price_cents: 4000, channel: 'store')
+  end
+
+  # Produit ordinaire, sans lien pizza party.
+  let!(:bread_product) { create(:product, channel: 'store', pizza_party_role: :none) }
+  let!(:bread_variant) { create(:product_variant, product: bread_product, price_cents: 550, channel: 'store') }
+
+  def line(variant, qty)
+    {
+      'product_variant_id' => variant.id.to_s,
+      'qty' => qty,
+      'name' => variant.name,
+      'price_cents' => variant.price_cents
+    }
+  end
+
+  def forfait_lines(cart)
+    cart.select { |item| item['product_variant_id'] == forfait_variant.id.to_s }
+  end
+
+  describe '.sync' do
+    it 'ajoute exactement une ligne forfait quand un produit party est présent' do
+      cart = [ line(party_variant, 3) ]
+      result = described_class.sync(cart)
+
+      expect(forfait_lines(result).size).to eq(1)
+      forfait = forfait_lines(result).first
+      expect(forfait['qty']).to eq(1)
+      expect(forfait['price_cents']).to eq(4000)
+    end
+
+    it 'ne crée pas de forfait quand aucun produit party n\'est présent' do
+      cart = [ line(bread_variant, 2) ]
+      result = described_class.sync(cart)
+
+      expect(forfait_lines(result)).to be_empty
+      expect(result).to eq(cart)
+    end
+
+    it 'retire un forfait orphelin quand le produit party a disparu du panier' do
+      cart = [ line(bread_variant, 1), line(forfait_variant, 1) ]
+      result = described_class.sync(cart)
+
+      expect(forfait_lines(result)).to be_empty
+    end
+
+    it 'ne garde qu\'UN forfait même avec plusieurs produits party' do
+      other_party = create(:product, :dough_ball, channel: 'store', pizza_party_role: :party)
+      other_party_variant = create(:product_variant, product: other_party, price_cents: 500, channel: 'store')
+
+      cart = [ line(party_variant, 2), line(other_party_variant, 4) ]
+      result = described_class.sync(cart)
+
+      expect(forfait_lines(result).size).to eq(1)
+    end
+
+    it 'dédoublonne un panier contenant déjà plusieurs lignes forfait' do
+      cart = [ line(party_variant, 1), line(forfait_variant, 1), line(forfait_variant, 1) ]
+      result = described_class.sync(cart)
+
+      expect(forfait_lines(result).size).to eq(1)
+    end
+
+    it 'est idempotent (sync deux fois == sync une fois)' do
+      cart = [ line(party_variant, 3), line(bread_variant, 1) ]
+      once = described_class.sync(cart)
+      twice = described_class.sync(once)
+
+      expect(twice).to eq(once)
+    end
+
+    it 'ne mute pas le panier reçu' do
+      cart = [ line(party_variant, 1) ]
+      frozen_snapshot = cart.map(&:dup)
+      described_class.sync(cart)
+
+      expect(cart).to eq(frozen_snapshot)
+    end
+
+    it 'gère un panier vide ou nil sans crasher' do
+      expect(described_class.sync([])).to eq([])
+      expect(described_class.sync(nil)).to eq([])
+    end
+
+    context 'quand le produit forfait est absent de la base (pas de seeds)' do
+      before do
+        forfait_variant.destroy
+        forfait_product.really_destroy! if forfait_product.respond_to?(:really_destroy!)
+        forfait_product.destroy
+      end
+
+      it 'ne crashe pas et laisse le panier party intact' do
+        cart = [ line(party_variant, 2) ]
+        expect { described_class.sync(cart) }.not_to raise_error
+        result = described_class.sync(cart)
+        expect(result).to eq(cart)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #68

## Résumé
Implémente la **Pizza party privée** (#68).

- Le produit « Boule de pâte à pizza pour Pizza Party privée » est **renommé** « **Pizza party privée – Nombre de personnes** ». La **quantité du panier = nombre de personnes** (1 boule de pâte / personne), avec le contrôle libellé « Nombre de personnes » et le commentaire « *Nous comptons 1 boule de pâte à pizza / personne* » (catalogue + page produit).
- **Forfait 40 €** (matériel + four à bois) ajouté **automatiquement, une seule fois par commande** contenant le produit party, quel que soit le nombre de personnes. Il est modélisé comme un **produit dédié** (`pizza_party_role: forfait`, `channel: admin` → invisible au catalogue et non ajoutable directement ; sa variante reste `channel: store` pour survivre au filtre panier).
- **Mécanique** : `PizzaPartyForfaitService.sync(cart)` maintient la ligne forfait cohérente dans `session[:cart]`. Comme **tout le downstream** (sous-total, `current_cart_*`, montant du PaymentIntent = `order.total_cents`, métadonnées Stripe, `OrderCreationService` côté webhook **et** page succès) s'appuie sur le panier, le forfait traverse **tous** les chemins sans cas particulier. Le service est **idempotent** ; appelé dans `CartController#add/#update/#remove/#show` et en garde-fou dans `CheckoutController`.
- La party reste **payable en ligne** (Bancontact) comme toute commande ; le montant inclut le forfait.
- Nouvel enum `Product#pizza_party_role` (`none`/`party`/`forfait`) + migration `add_pizza_party_role_to_products`. **Seeds idempotents** (rename géré par ancien OU nouveau nom, pas de doublon).

**Hors périmètre** (non traité, conforme à l'issue) : répartition compta (#22/#54), partys publiques (#70), camembert party (#69).

## Testé
- `bundle exec rspec` : **430 exemples, 0 échec** (suite complète, aucune régression).
- Nouvelles specs (15 ex.) :
  - `spec/services/pizza_party_forfait_service_spec.rb` : party présent → 1 ligne forfait ; absent → 0 ; plusieurs produits party → 1 seul forfait ; idempotence ; pas de crash si produit forfait absent en base.
  - `spec/requests/pizza_party_cart_spec.rb` : ajout du produit party (qty N) → forfait présent ; sous-total = 500×N + 4000 cents.
- `bin/rubocop` : **fichiers modifiés propres**. (`db/schema.rb` conserve 212 offenses `Layout/SpaceInsideArrayLiteralBrackets` **strictement identiques à `main`** — schéma auto-généré, pré-existant, non introduit par cette PR.)
- `bin/brakeman --no-pager` : **0 alerte de sécurité**.

## NON testé
- Pas de test **navigateur de bout en bout** du paiement Bancontact réel (les specs vérifient le montant/total côté serveur, pas le tunnel Stripe live).
- Rendu **visuel** des vues (catalogue / page produit / panier) non vérifié dans un vrai navigateur — seulement la logique.
- `_mini_cart` : le forfait y apparaît via les helpers `current_cart_*` (ligne standard) ; non spécifiquement stylé.
- Comportement si un client manipule manuellement la ligne forfait : le `sync` rétablit l'état à la requête suivante, mais aucun contrôle d'édition n'est exposé sur cette ligne (pas de spec dédiée à une manipulation adverse).
