### PR TITLE
Reporting des versements Stripe : /admin/reports/payouts (#49)

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -42,6 +42,17 @@ class Admin::ReportsController < Admin::BaseController
     @report = BakerRevenueService.new(start_date: @start_date, end_date: @end_date).call
   end
 
+  # Reporting des versements Stripe (#49). Appels Stripe live (mis en cache court
+  # par le service) ; en cas d'échec Stripe, `@report.error` porte un message FR
+  # et la vue affiche une alerte propre — jamais de 500.
+  def payouts
+    @start_date = parsed_date(params[:start_date]) || Date.current.beginning_of_month
+    @end_date = parsed_date(params[:end_date]) || Date.current
+    @end_date = @start_date if @end_date < @start_date
+
+    @report = StripePayoutReportService.new(start_date: @start_date, end_date: @end_date).call
+  end
+
   private
 
   def parsed_date(value)

--- a/app/services/stripe_payout_report_service.rb
+++ b/app/services/stripe_payout_report_service.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+# Reporting des versements Stripe (#49).
+#
+# Pour une période donnée, interroge l'API Stripe EN DIRECT et reconstruit, par
+# versement (`Stripe::Payout`) :
+#   - le n° de versement, sa date d'arrivée et son statut ;
+#   - le brut / les frais / le net (sommes sur les BalanceTransactions du versement) ;
+#   - le détail des commandes EN LIGNE incluses dans le versement.
+#
+# Pipeline de données :
+#   Stripe::Payout.list(arrival_date: période)
+#     └─ Stripe::BalanceTransaction.list(payout: id, expand: source)
+#          └─ source = Stripe::Charge → charge.payment_intent
+#               └─ notre Payment (stripe_payment_intent_id) → Order
+#
+# Décisions de design (issue #49) :
+#   - Détail des commandes : `source: checkout` UNIQUEMENT. Les top-ups de
+#     portefeuille sont aussi des PaymentIntents Stripe et apparaissent dans le
+#     versement, mais ne correspondent à aucune commande en ligne : on les exclut
+#     du DÉTAIL. Le brut/frais/net du versement, lui, reste calculé sur TOUTES les
+#     transactions (Stripe verse le net global, top-ups compris).
+#   - Frais : somme des `fee` des BalanceTransactions du versement, cohérent avec
+#     StripeFeeService (qui lit `BalanceTransaction#fee` pour un paiement).
+#   - Appels live à chaque chargement, enveloppés dans Rails.cache (TTL court) :
+#     une page rechargée ne refrappe pas l'API. La clé inclut la période.
+#   - Robustesse : toute Stripe::StripeError est capturée et transformée en
+#     `Report#error` (message FR) ; la page n'émet jamais de 500.
+#
+# Usage :
+#   report = StripePayoutReportService.new(start_date: d1, end_date: d2).call
+#   report.payouts            # => [ PayoutRow, ... ]
+#   report.total_net_cents
+#   report.error              # => nil, ou message FR si Stripe a échoué
+class StripePayoutReportService
+  CACHE_TTL = 5.minutes
+
+  # Une commande en ligne reliée à une transaction du versement.
+  PayoutOrder = Struct.new(
+    :order,
+    :order_number,
+    :customer_name,
+    :amount_cents,   # montant brut de la charge (avant frais)
+    :fee_cents,      # frais Stripe de la charge
+    keyword_init: true
+  )
+
+  # Une ligne de versement.
+  PayoutRow = Struct.new(
+    :stripe_id,
+    :arrival_date,   # Date (date d'arrivée du versement sur le compte bancaire)
+    :status,         # statut Stripe (paid, pending, in_transit, failed, …)
+    :gross_cents,    # somme des montants bruts des transactions du versement
+    :fee_cents,      # somme des frais des transactions du versement
+    :net_cents,      # montant réellement versé (gross − fees)
+    :orders,         # [ PayoutOrder, ... ] commandes en ligne incluses
+    keyword_init: true
+  )
+
+  Report = Struct.new(
+    :start_date,
+    :end_date,
+    :payouts,
+    :total_gross_cents,
+    :total_fee_cents,
+    :total_net_cents,
+    :error,          # nil, ou message FR si l'appel Stripe a échoué
+    keyword_init: true
+  )
+
+  def initialize(start_date:, end_date:)
+    @start_date = start_date
+    @end_date = end_date
+  end
+
+  def call
+    Rails.cache.fetch(cache_key, expires_in: CACHE_TTL) { build_report }
+  end
+
+  private
+
+  attr_reader :start_date, :end_date
+
+  def cache_key
+    [ "stripe_payout_report", start_date.iso8601, end_date.iso8601 ].join(":")
+  end
+
+  def build_report
+    payouts = fetch_payouts.map { |payout| build_payout_row(payout) }
+
+    Report.new(
+      start_date: start_date,
+      end_date: end_date,
+      payouts: payouts,
+      total_gross_cents: payouts.sum(&:gross_cents),
+      total_fee_cents: payouts.sum(&:fee_cents),
+      total_net_cents: payouts.sum(&:net_cents),
+      error: nil
+    )
+  rescue Stripe::StripeError => e
+    Rails.logger.error("StripePayoutReportService: erreur Stripe (#{start_date}..#{end_date}): #{e.message}")
+    Sentry.capture_exception(e) if defined?(Sentry)
+    empty_report("La récupération des versements depuis Stripe est momentanément impossible. Réessayez dans quelques minutes.")
+  end
+
+  def empty_report(error_message)
+    Report.new(
+      start_date: start_date,
+      end_date: end_date,
+      payouts: [],
+      total_gross_cents: 0,
+      total_fee_cents: 0,
+      total_net_cents: 0,
+      error: error_message
+    )
+  end
+
+  # Versements dont la date d'arrivée tombe dans la période (bornes incluses).
+  def fetch_payouts
+    payouts = []
+    Stripe::Payout.list(
+      arrival_date: {
+        gte: start_date.beginning_of_day.to_i,
+        lte: end_date.end_of_day.to_i
+      },
+      limit: 100
+    ).auto_paging_each { |payout| payouts << payout }
+    payouts
+  end
+
+  def build_payout_row(payout)
+    transactions = fetch_balance_transactions(payout.id)
+
+    gross_cents = transactions.sum { |txn| txn.amount.to_i }
+    fee_cents = transactions.sum { |txn| txn.fee.to_i }
+
+    PayoutRow.new(
+      stripe_id: payout.id,
+      arrival_date: arrival_date_for(payout),
+      status: payout.status,
+      gross_cents: gross_cents,
+      fee_cents: fee_cents,
+      net_cents: gross_cents - fee_cents,
+      orders: checkout_orders_for(transactions)
+    )
+  end
+
+  def fetch_balance_transactions(payout_id)
+    transactions = []
+    Stripe::BalanceTransaction.list(
+      payout: payout_id,
+      type: "charge",
+      limit: 100,
+      expand: [ "data.source" ]
+    ).auto_paging_each { |txn| transactions << txn }
+    transactions
+  end
+
+  # Relie les transactions à nos commandes EN LIGNE (source: checkout) et
+  # ignore tout le reste (top-ups portefeuille, commandes calendar, PI inconnus).
+  def checkout_orders_for(transactions)
+    payment_intent_ids = transactions.filter_map { |txn| payment_intent_id_for(txn) }
+    return [] if payment_intent_ids.empty?
+
+    payments_by_pi = Payment
+      .where(stripe_payment_intent_id: payment_intent_ids)
+      .includes(order: :customer)
+      .index_by(&:stripe_payment_intent_id)
+
+    transactions.filter_map do |txn|
+      pi = payment_intent_id_for(txn)
+      next if pi.blank?
+
+      payment = payments_by_pi[pi]
+      order = payment&.order
+      next if order.nil? || !order.checkout?
+
+      PayoutOrder.new(
+        order: order,
+        order_number: order.order_number,
+        customer_name: order.customer&.full_name,
+        amount_cents: txn.amount.to_i,
+        fee_cents: txn.fee.to_i
+      )
+    end
+  end
+
+  # La `source` d'une BalanceTransaction de type charge est la Charge ; on en
+  # tire le PaymentIntent. Tolère une source non expandée (id String) ou absente.
+  def payment_intent_id_for(txn)
+    source = txn.source
+    return nil if source.blank?
+    return nil if source.is_a?(String) # source non expandée : on ne peut pas relier
+
+    source.respond_to?(:payment_intent) ? source.payment_intent : nil
+  end
+
+  def arrival_date_for(payout)
+    timestamp = payout.arrival_date
+    return nil if timestamp.blank?
+
+    Time.zone.at(timestamp).to_date
+  end
+end

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -7,9 +7,14 @@
     <p class="text-sm text-gray-600">
       Période du <%= l(@start_date) %> au <%= l(@end_date) %>
     </p>
-    <%= link_to "Revenus des boulangers →",
-                baker_revenue_admin_reports_path(start_date: @start_date, end_date: @end_date),
-                class: "mt-1 inline-block text-sm font-medium text-blue-600 hover:text-blue-800" %>
+    <div class="mt-1 flex flex-wrap gap-x-4 gap-y-1">
+      <%= link_to "Revenus des boulangers →",
+                  baker_revenue_admin_reports_path(start_date: @start_date, end_date: @end_date),
+                  class: "inline-block text-sm font-medium text-blue-600 hover:text-blue-800" %>
+      <%= link_to "Versements Stripe →",
+                  payouts_admin_reports_path(start_date: @start_date, end_date: @end_date),
+                  class: "inline-block text-sm font-medium text-blue-600 hover:text-blue-800" %>
+    </div>
   </div>
   <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
     <%= render "date_range_filter", start_date: @start_date, end_date: @end_date %>

--- a/app/views/admin/reports/payouts.html.erb
+++ b/app/views/admin/reports/payouts.html.erb
@@ -1,0 +1,111 @@
+<% content_for :title, "Versements Stripe" %>
+<% content_for :layout, "admin" %>
+
+<div class="mb-6 flex flex-col md:flex-row md:items-center md:justify-between md:space-x-6 space-y-4 md:space-y-0">
+  <div>
+    <h1 class="text-2xl font-bold text-gray-900">Versements Stripe</h1>
+    <p class="text-sm text-gray-600">
+      Période du <%= l(@start_date) %> au <%= l(@end_date) %>
+    </p>
+    <p class="mt-1 text-xs text-gray-400">
+      Données récupérées en direct depuis Stripe (mises en cache quelques minutes).
+      Détail limité aux commandes payées en ligne.
+    </p>
+  </div>
+  <div class="flex flex-col items-stretch gap-3 md:items-end">
+    <%= link_to "← Retour au reporting",
+                admin_reports_path(start_date: @start_date, end_date: @end_date),
+                class: "inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white shadow-sm hover:bg-gray-50" %>
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+      <%= render "date_range_filter", start_date: @start_date, end_date: @end_date %>
+    </div>
+  </div>
+</div>
+
+<% if @report.error.present? %>
+  <div class="mb-6 rounded-md border border-red-200 bg-red-50 p-4">
+    <p class="text-sm font-medium text-red-800"><%= @report.error %></p>
+  </div>
+<% end %>
+
+<% unless @report.error.present? %>
+  <div class="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-6">
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <h2 class="text-sm font-medium text-gray-500 uppercase tracking-wide">Brut versé</h2>
+      <p class="mt-2 text-3xl font-bold text-gray-900"><%= reports_currency(@report.total_gross_cents) %></p>
+    </div>
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <h2 class="text-sm font-medium text-gray-500 uppercase tracking-wide">Frais Stripe</h2>
+      <p class="mt-2 text-3xl font-bold text-red-600">- <%= reports_currency(@report.total_fee_cents) %></p>
+    </div>
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <h2 class="text-sm font-medium text-gray-500 uppercase tracking-wide">Net versé</h2>
+      <p class="mt-2 text-3xl font-bold text-gray-900"><%= reports_currency(@report.total_net_cents) %></p>
+    </div>
+  </div>
+<% end %>
+
+<% if @report.payouts.any? %>
+  <div class="space-y-6">
+    <% @report.payouts.each do |payout| %>
+      <section class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+        <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4 mb-4">
+          <div>
+            <p class="text-xs font-medium text-gray-400 uppercase tracking-wide">Versement Stripe</p>
+            <p class="text-lg font-semibold text-gray-900"><%= payout.stripe_id %></p>
+            <p class="text-sm text-gray-500">
+              <% if payout.arrival_date %>Arrivée le <%= l(payout.arrival_date) %> · <% end %>Statut : <%= payout.status %>
+            </p>
+          </div>
+          <dl class="grid grid-cols-3 gap-x-6 text-right">
+            <div>
+              <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide">Brut</dt>
+              <dd class="mt-1 text-base font-semibold text-gray-900"><%= reports_currency(payout.gross_cents) %></dd>
+            </div>
+            <div>
+              <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide">Frais</dt>
+              <dd class="mt-1 text-base font-semibold text-red-600">- <%= reports_currency(payout.fee_cents) %></dd>
+            </div>
+            <div>
+              <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide">Net</dt>
+              <dd class="mt-1 text-base font-semibold text-gray-900"><%= reports_currency(payout.net_cents) %></dd>
+            </div>
+          </dl>
+        </div>
+
+        <% if payout.orders.any? %>
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Commande</th>
+                  <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Client</th>
+                  <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Montant</th>
+                  <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Frais</th>
+                </tr>
+              </thead>
+              <tbody class="bg-white divide-y divide-gray-200">
+                <% payout.orders.each do |line| %>
+                  <tr>
+                    <td class="px-4 py-3 whitespace-nowrap text-sm">
+                      <%= link_to line.order_number, admin_order_path(line.order), class: "text-blue-600 hover:text-blue-800" %>
+                    </td>
+                    <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-900"><%= line.customer_name.presence || "—" %></td>
+                    <td class="px-4 py-3 whitespace-nowrap text-sm text-right font-medium text-gray-900"><%= reports_currency(line.amount_cents) %></td>
+                    <td class="px-4 py-3 whitespace-nowrap text-sm text-right text-red-600">- <%= reports_currency(line.fee_cents) %></td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        <% else %>
+          <p class="text-sm text-gray-500">Aucune commande en ligne reliée à ce versement (top-ups de portefeuille ou paiements hors boutique).</p>
+        <% end %>
+      </section>
+    <% end %>
+  </div>
+<% elsif !@report.error.present? %>
+  <section class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+    <p class="text-sm text-gray-500">Aucun versement Stripe sur cette période.</p>
+  </section>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,6 +122,7 @@ Rails.application.routes.draw do
       collection do
         get :refunds
         get :baker_revenue
+        get :payouts
       end
     end
     get "billing", to: "billing#index", as: :billing

--- a/spec/requests/admin/payouts_report_spec.rb
+++ b/spec/requests/admin/payouts_report_spec.rb
@@ -1,0 +1,121 @@
+require "rails_helper"
+
+# Admin : reporting des versements Stripe (#49). Vérifie que la page rend,
+# affiche brut / frais / net + le détail des commandes incluses, filtre par
+# période, et gère une erreur Stripe SANS 500 (message propre).
+RSpec.describe "Admin::Reports payouts", type: :request do
+  around do |ex|
+    original = ENV["ADMIN_PASSWORD"]
+    ENV["ADMIN_PASSWORD"] = "test-admin-pw"
+    ex.run
+    ENV["ADMIN_PASSWORD"] = original
+  end
+
+  def login_admin
+    post admin_login_path, params: { password: "test-admin-pw" }
+  end
+
+  # Stub bas niveau du service : on isole la vue de l'API Stripe.
+  def stub_report(report)
+    allow(StripePayoutReportService).to receive(:new).and_return(
+      instance_double(StripePayoutReportService, call: report)
+    )
+  end
+
+  def payout_order(order)
+    StripePayoutReportService::PayoutOrder.new(
+      order: order,
+      order_number: order.order_number,
+      customer_name: order.customer.full_name,
+      amount_cents: order.total_cents,
+      fee_cents: 250
+    )
+  end
+
+  def build_payout_row(stripe_id:, gross:, fee:, net:, orders: [], arrival_date: Date.new(2026, 5, 15))
+    StripePayoutReportService::PayoutRow.new(
+      stripe_id: stripe_id,
+      arrival_date: arrival_date,
+      status: "paid",
+      gross_cents: gross,
+      fee_cents: fee,
+      net_cents: net,
+      orders: orders.map { |o| payout_order(o) }
+    )
+  end
+
+  def build_report(payouts:, error: nil)
+    StripePayoutReportService::Report.new(
+      start_date: Date.new(2026, 5, 1),
+      end_date: Date.new(2026, 5, 31),
+      payouts: payouts,
+      total_gross_cents: payouts.sum(&:gross_cents),
+      total_fee_cents: payouts.sum(&:fee_cents),
+      total_net_cents: payouts.sum(&:net_cents),
+      error: error
+    )
+  end
+
+  it "exige une authentification" do
+    get payouts_admin_reports_path
+    expect(response).to redirect_to(admin_login_path)
+  end
+
+  context "when authenticated" do
+    before { login_admin }
+
+    it "rend la page avec brut / frais / net et le détail des commandes" do
+      bake_day = create(:bake_day, baked_on: Date.new(2026, 5, 12))
+      order = create(:order, :paid, source: :checkout, bake_day: bake_day, total_cents: 10_000)
+
+      report = build_report(payouts: [
+        build_payout_row(stripe_id: "po_1", gross: 10_000, fee: 250, net: 9_750, orders: [ order ])
+      ])
+      stub_report(report)
+
+      get payouts_admin_reports_path(start_date: "2026-05-01", end_date: "2026-05-31")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Versements Stripe")
+      expect(response.body).to include("po_1")
+      expect(response.body).to include("Brut").or include("brut")
+      expect(response.body).to include("Frais").or include("frais")
+      expect(response.body).to include("Net").or include("net")
+      # Montants : brut 100,00 / frais 2,50 / net 97,50
+      expect(response.body).to include("100,00")
+      expect(response.body).to include("2,50")
+      expect(response.body).to include("97,50")
+      # Le détail des commandes incluses référence le numéro de commande.
+      expect(response.body).to include(order.order_number)
+    end
+
+    it "affiche un message propre (pas de 500) quand Stripe échoue" do
+      report = build_report(payouts: [], error: "Connexion à Stripe impossible")
+      stub_report(report)
+
+      get payouts_admin_reports_path(start_date: "2026-05-01", end_date: "2026-05-31")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Stripe").and include("impossible").or include("indisponible")
+    end
+
+    it "passe les dates de la période filtrée au service" do
+      expect(StripePayoutReportService).to receive(:new)
+        .with(start_date: Date.new(2026, 5, 1), end_date: Date.new(2026, 5, 31))
+        .and_return(instance_double(StripePayoutReportService, call: build_report(payouts: [])))
+
+      get payouts_admin_reports_path(start_date: "2026-05-01", end_date: "2026-05-31")
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "affiche un état vide quand il n'y a aucun versement sur la période" do
+      stub_report(build_report(payouts: []))
+
+      get payouts_admin_reports_path(start_date: "2026-05-01", end_date: "2026-05-31")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Aucun versement")
+    end
+  end
+end

--- a/spec/services/stripe_payout_report_service_spec.rb
+++ b/spec/services/stripe_payout_report_service_spec.rb
@@ -1,0 +1,184 @@
+require "rails_helper"
+
+# Reporting des versements Stripe (#49).
+#
+# Le service interroge l'API Stripe en direct :
+#   - Stripe::Payout.list                       → les versements de la période
+#   - Stripe::BalanceTransaction.list(payout:)  → les transactions de chaque versement
+# Chaque transaction de type charge est reliée à sa Charge → PaymentIntent →
+# notre Payment → Order. On ne garde QUE les commandes `source: checkout`
+# (les top-ups de portefeuille sont exclus du détail).
+#
+# Stripe est stubé au niveau du SDK (pattern du projet, cf. StripeFeeService),
+# pas via des cassettes enregistrées (le dossier spec/cassettes/ est vide).
+RSpec.describe StripePayoutReportService do
+  let(:start_date) { Date.new(2026, 5, 1) }
+  let(:end_date) { Date.new(2026, 5, 31) }
+
+  # --- Construction de doubles Stripe ----------------------------------------
+
+  # Un BalanceTransaction tel que renvoyé par BalanceTransaction.list, avec sa
+  # `source` (la Charge) déjà expandée. `payment_intent` relie à notre Payment.
+  def balance_txn(type:, amount:, fee:, payment_intent: nil)
+    charge = payment_intent ? double("Stripe::Charge", payment_intent: payment_intent) : nil
+    double(
+      "Stripe::BalanceTransaction",
+      id: "txn_#{SecureRandom.hex(4)}",
+      type: type,
+      amount: amount,
+      fee: fee,
+      net: amount - fee,
+      source: charge
+    )
+  end
+
+  def stub_payout_list(payouts)
+    list = double("Stripe::ListObject", data: payouts, auto_paging_each: nil)
+    allow(list).to receive(:auto_paging_each) { |&block| payouts.each(&block) }
+    allow(Stripe::Payout).to receive(:list).and_return(list)
+  end
+
+  def stub_balance_transactions(payout_id:, transactions:)
+    list = double("Stripe::ListObject")
+    allow(list).to receive(:auto_paging_each) { |&block| transactions.each(&block) }
+    allow(Stripe::BalanceTransaction).to receive(:list)
+      .with(hash_including(payout: payout_id))
+      .and_return(list)
+  end
+
+  def stub_payout(id:, amount:, arrival_date: Date.new(2026, 5, 15))
+    double(
+      "Stripe::Payout",
+      id: id,
+      amount: amount,
+      arrival_date: arrival_date.to_time.to_i,
+      status: "paid",
+      currency: "eur"
+    )
+  end
+
+  # --- Cas nominal ------------------------------------------------------------
+
+  describe "#call" do
+    it "relie chaque versement à ses commandes checkout et calcule brut / frais / net" do
+      bake_day = create(:bake_day, baked_on: Date.new(2026, 5, 12))
+      order = create(:order, :paid, source: :checkout, bake_day: bake_day, total_cents: 10_000)
+      create(:payment, order: order, stripe_payment_intent_id: "pi_checkout_1")
+
+      payout = stub_payout(id: "po_1", amount: 9_750)
+      stub_payout_list([ payout ])
+      stub_balance_transactions(
+        payout_id: "po_1",
+        transactions: [
+          balance_txn(type: "charge", amount: 10_000, fee: 250, payment_intent: "pi_checkout_1")
+        ]
+      )
+
+      report = described_class.new(start_date: start_date, end_date: end_date).call
+
+      expect(report.error).to be_nil
+      expect(report.payouts.size).to eq(1)
+
+      payout_row = report.payouts.first
+      expect(payout_row.stripe_id).to eq("po_1")
+      expect(payout_row.gross_cents).to eq(10_000)
+      expect(payout_row.fee_cents).to eq(250)
+      expect(payout_row.net_cents).to eq(9_750)
+      expect(payout_row.orders.map(&:order_number)).to eq([ order.order_number ])
+    end
+
+    it "exclut les top-ups de portefeuille (commandes non-checkout / sans Order)" do
+      bake_day = create(:bake_day, baked_on: Date.new(2026, 5, 12))
+      checkout_order = create(:order, :paid, source: :checkout, bake_day: bake_day, total_cents: 5_000)
+      create(:payment, order: checkout_order, stripe_payment_intent_id: "pi_checkout_2")
+
+      payout = stub_payout(id: "po_2", amount: 11_700)
+      stub_payout_list([ payout ])
+      stub_balance_transactions(
+        payout_id: "po_2",
+        transactions: [
+          # Commande en ligne → incluse dans le détail
+          balance_txn(type: "charge", amount: 5_000, fee: 130, payment_intent: "pi_checkout_2"),
+          # Top-up portefeuille : PI inconnu côté Payment checkout → exclu du détail
+          balance_txn(type: "charge", amount: 7_000, fee: 170, payment_intent: "pi_wallet_topup")
+        ]
+      )
+
+      report = described_class.new(start_date: start_date, end_date: end_date).call
+      payout_row = report.payouts.first
+
+      # Seule la commande checkout figure dans le détail.
+      expect(payout_row.orders.map(&:order_number)).to eq([ checkout_order.order_number ])
+      # Brut / frais / net du versement restent calculés sur TOUTES les
+      # transactions du versement (Stripe verse le net global).
+      expect(payout_row.gross_cents).to eq(12_000)
+      expect(payout_row.fee_cents).to eq(300)
+      expect(payout_row.net_cents).to eq(11_700)
+    end
+
+    it "ignore une commande calendar même si son PaymentIntent est présent" do
+      bake_day = create(:bake_day, baked_on: Date.new(2026, 5, 12))
+      calendar_order = create(:order, :paid, source: :calendar, bake_day: bake_day, total_cents: 4_000)
+      create(:payment, order: calendar_order, stripe_payment_intent_id: "pi_calendar_1")
+
+      payout = stub_payout(id: "po_3", amount: 3_900)
+      stub_payout_list([ payout ])
+      stub_balance_transactions(
+        payout_id: "po_3",
+        transactions: [
+          balance_txn(type: "charge", amount: 4_000, fee: 100, payment_intent: "pi_calendar_1")
+        ]
+      )
+
+      report = described_class.new(start_date: start_date, end_date: end_date).call
+
+      expect(report.payouts.first.orders).to be_empty
+    end
+
+    it "agrège les totaux sur l'ensemble des versements" do
+      payout1 = stub_payout(id: "po_a", amount: 9_750)
+      payout2 = stub_payout(id: "po_b", amount: 4_900)
+      stub_payout_list([ payout1, payout2 ])
+      stub_balance_transactions(
+        payout_id: "po_a",
+        transactions: [ balance_txn(type: "charge", amount: 10_000, fee: 250) ]
+      )
+      stub_balance_transactions(
+        payout_id: "po_b",
+        transactions: [ balance_txn(type: "charge", amount: 5_000, fee: 100) ]
+      )
+
+      report = described_class.new(start_date: start_date, end_date: end_date).call
+
+      expect(report.total_gross_cents).to eq(15_000)
+      expect(report.total_fee_cents).to eq(350)
+      expect(report.total_net_cents).to eq(14_650)
+    end
+
+    it "renvoie un résultat d'erreur (sans lever) quand Stripe échoue" do
+      allow(Stripe::Payout).to receive(:list).and_raise(Stripe::APIConnectionError.new("boom"))
+
+      report = described_class.new(start_date: start_date, end_date: end_date).call
+
+      expect(report.error).to be_present
+      expect(report.payouts).to eq([])
+    end
+
+    it "met en cache le résultat (un seul appel Stripe pour deux exécutions identiques)" do
+      payout = stub_payout(id: "po_cache", amount: 9_750)
+      stub_payout_list([ payout ])
+      stub_balance_transactions(
+        payout_id: "po_cache",
+        transactions: [ balance_txn(type: "charge", amount: 10_000, fee: 250) ]
+      )
+
+      memory_store = ActiveSupport::Cache::MemoryStore.new
+      allow(Rails).to receive(:cache).and_return(memory_store)
+
+      described_class.new(start_date: start_date, end_date: end_date).call
+      described_class.new(start_date: start_date, end_date: end_date).call
+
+      expect(Stripe::Payout).to have_received(:list).once
+    end
+  end
+end


### PR DESCRIPTION
Closes #49

## Résumé
Reporting des versements Stripe — vue admin **`/admin/reports/payouts`** (volet code de #49 ; config dashboard → #115, wallets-sur-Stripe → #116).

- **Service** `StripePayoutReportService` : `Stripe::Payout.list` (filtré par `arrival_date` sur la période) → `Stripe::BalanceTransaction.list(payout:, type: "charge", expand: ["data.source"])` → relie chaque charge à son `PaymentIntent` → notre `Payment`/`Order` (lookup batché, pas de N+1).
- **Détail des commandes** = `source: checkout` **uniquement** (top-ups wallet et commandes `calendar` exclus du détail). En revanche **brut/frais/net du versement = sur toutes les transactions** du payout (Stripe verse le net global ; les exclure fausserait le rapprochement bancaire). Documenté dans la vue.
- **Frais** = somme des `fee` des BalanceTransactions, aligné sur `StripeFeeService`.
- **Live + cache** : `Rails.cache.fetch` TTL 5 min (rechargement = pas de nouvel appel API). **Gestion d'erreur** : `Stripe::StripeError` → message FR + Sentry, jamais de 500.
- **Filtrable par période** (`_date_range_filter`, défaut mois courant). Lien depuis l'index des reports.
- **Aucune migration / aucun changement de schéma** (décision : appels live, pas de persistance).

## Testé
- `bundle exec rspec` : **515 exemples, 0 échec** (vérifié indépendamment).
- Specs : service (mapping versement→commandes `source: checkout`, exclusion top-ups/calendar, calcul brut/frais/net, cache = 1 seul appel pour 2 exécutions) + request (rendu, filtre période, **erreur Stripe gérée sans 500**, états vide).
- Stripe **stubé au niveau SDK** (`allow(Stripe::Payout).to receive(:list)...`) — convention réelle du codebase (`spec/cassettes/` est vide ; cf. `stripe_fee_service_spec.rb`), pas de VCR.
- `bin/rubocop` : 5 fichiers propres. `bin/brakeman` : 0 alerte.

## NON testé
- **Aucun appel Stripe live réel** : la forme des objets (`arrival_date` epoch, `source` expandée en Charge avec `payment_intent`, `auto_paging_each`) repose sur le SDK Stripe 17.1.0 + le pattern de `StripeFeeService`. À confirmer sur données réelles que `expand: ["data.source"]` renvoie bien la Charge complète.
- **Pagination** gérée via `auto_paging_each` mais non testée au-delà d'une page.
- Versements de type `refund`/`adjustment` non inclus dans le détail (choix volontaire, cohérent avec « commandes incluses »).
- Pas de **vérification navigateur**.
