### PR TITLE
Admin planning : en-tête produits figé au défilement (#71)

### DIFF
--- a/app/views/admin/bake_days/show.html.slim
+++ b/app/views/admin/bake_days/show.html.slim
@@ -390,7 +390,9 @@
               - quantities[variant_id] ||= 0
               - quantities[variant_id] += item[:qty]
           - customer_variant_quantities[customer.id] = quantities
-        .overflow-x-auto.rounded-xl.border.border-slate-100
+        / #71 : conteneur scrollable sur les 2 axes (max-h + overflow-auto) pour
+        / que l'en-tête produits (thead.sticky.top-0) reste figé au défilement vertical.
+        .max-h-[75vh].overflow-auto.rounded-xl.border.border-slate-100
           table.min-w-full.divide-y.divide-slate-100.text-sm
             thead.bg-slate-50.sticky.top-0.z-20
               tr

--- a/spec/requests/admin/bake_days_spec.rb
+++ b/spec/requests/admin/bake_days_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Admin::BakeDays", type: :request do
+  before do
+    ENV["ADMIN_PASSWORD"] = "test-admin-pw"
+    post admin_login_path, params: { password: "test-admin-pw" }
+  end
+
+  # #71 : le planning du jour de cuisson contient la matrice « Commandes par client »
+  # (produits en colonnes) dont l'en-tête doit rester figé au défilement. On vérifie
+  # ici que la page rend sans erreur quand il y a au moins une commande (la matrice
+  # est alors affichée), suite au passage du conteneur en scroll vertical.
+  describe "GET /admin/bake_days/:id" do
+    it "rend le planning avec la matrice commandes par client sans erreur" do
+      bake_day = create(:bake_day)
+      customer = create(:customer)
+      product = create(:product, :bread)
+      variant = create(:product_variant, product: product, price_cents: 550)
+      order = create(:order, :paid, customer: customer, bake_day: bake_day, total_cents: 1100)
+      create(:order_item, order: order, product_variant: variant, qty: 2, unit_price_cents: 550)
+
+      get admin_bake_day_path(bake_day)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Commandes par client")
+    end
+  end
+end


### PR DESCRIPTION
Closes #71

## Résumé
Sur le **planning du jour de cuisson** (`/admin/bake_days/:id`), l'en-tête des produits du tableau **« Commandes par client »** (produits en colonnes, clients en lignes) reste désormais **figé au défilement vertical**.

Le tableau portait déjà les classes `thead.sticky.top-0` + colonnes gauche/droite figées (`sticky left-0/right-0`), mais le sticky vertical **ne s'activait pas** : le conteneur était en `overflow-x-auto` (scroll horizontal uniquement), donc le défilement vertical se faisait sur la page entière et le `position: sticky` n'avait aucun contexte de scroll vertical (gotcha classique). 

Correctif : le conteneur passe en **`max-h-[75vh] overflow-auto`** → il devient une zone scrollable sur les deux axes, et l'en-tête `sticky top-0` (ainsi que les colonnes Nom/Total déjà sticky) restent visibles pendant le défilement.

## Testé
- Spec request ajouté (`spec/requests/admin/bake_days_spec.rb`) : `GET /admin/bake_days/:id` avec une commande rend la page (200) et affiche la matrice « Commandes par client » — le template Slim modifié est donc bien exercé.
- Compilation Slim du template vérifiée.
- `bundle exec rspec` : **543 exemples, 0 échec**. `bin/rubocop` : propre.

## NON testé
- **Pas de vérification navigateur** du comportement sticky réel au scroll (c'est du CSS pur). À confirmer visuellement : que l'en-tête produits et les colonnes Nom/Total restent bien figés quand on fait défiler une longue liste de clients, et que `max-h-[75vh]` est une hauteur confortable sur ton écran (ajustable).
- N'affecte que la matrice « Commandes par client » ; les autres tableaux de la page (capacité, ingrédients) sont inchangés.
