### PR TITLE
Relevé de commandes (PDF) + QR espace client — révision de #38

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,9 +69,11 @@ gem "draper"
 # Soft deletion for models
 gem "soft_deletion"
 
-# Génération de PDF en Ruby pur (factures) — aucun binaire système requis (#38)
+# Génération de PDF en Ruby pur (relevé de commandes) — aucun binaire système requis (#38)
 gem "prawn"
 gem "prawn-table"
+# QR code (Ruby pur) intégré au relevé de commandes, pointant vers l'espace client (#38)
+gem "rqrcode"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
       xpath (~> 3.2)
     childprocess (5.1.0)
       logger (~> 1.5)
+    chunky_png (1.4.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
     crack (1.0.1)
@@ -348,6 +349,10 @@ GEM
     request_store (1.7.0)
       rack (>= 1.4)
     rexml (3.4.4)
+    rqrcode (3.2.0)
+      chunky_png (~> 1.0)
+      rqrcode_core (~> 2.0)
+    rqrcode_core (2.1.0)
     rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
@@ -533,6 +538,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rack-attack
   rails (~> 8.0.3)
+  rqrcode
   rspec-rails
   rubocop-rails-omakase
   selenium-webdriver

--- a/app/presenters/invoice_presenter.rb
+++ b/app/presenters/invoice_presenter.rb
@@ -60,6 +60,17 @@ class InvoicePresenter
     ].compact
   end
 
+  # Identifiant(s) de connexion à rappeler au client sur le relevé : le numéro
+  # de téléphone et/ou l'e-mail, selon ce dont il dispose (#38). Sert à lui
+  # indiquer avec quoi se connecter pour retrouver le détail en ligne.
+  def login_identifiers
+    customer = invoice.customer
+    [
+      customer.phone_e164.presence,
+      customer.email.presence
+    ].compact
+  end
+
   # Lignes « à plat » (facture commande unique, ou usage tabulaire simple).
   def lines
     ordered_orders.flat_map { |order| lines_for(order) }

--- a/app/services/invoice_pdf_service.rb
+++ b/app/services/invoice_pdf_service.rb
@@ -1,15 +1,23 @@
 require "prawn"
 require "prawn/table"
+require "rqrcode"
 
-# Génère le PDF d'une facture (#38) avec Prawn (Ruby pur, aucun binaire système).
+# Génère le PDF d'un **relevé de commandes** (order statement) avec Prawn (Ruby
+# pur, aucun binaire système). Ce relevé est destiné à être **joint à la
+# facture** — ce n'est PAS une facture fiscale (décision produit Michael, 25/06).
 #
-# Contenu : coordonnées boulangerie + client, numéro de facture, date, détail
-# des articles (nom produit + variante, quantité, prix unitaire, total ligne),
-# total HT/TVA/TTC (TVA paramétrable — note TVA #38).
+# Contenu : coordonnées boulangerie + client, période/commandes, détail des
+# articles (nom produit + variante, quantité, prix unitaire, total ligne),
+# total. Pas de bloc TVA / HT-TTC, pas de mention « Facture ».
 #
-# Pour une facture de **période** (mensuelle groupée, clients pro), les
-# commandes sont regroupées **par jour de cuisson**, chaque jour identifiable
-# (cf. #27).
+# S'y ajoutent :
+#   - une invitation à consulter le détail des commandes en ligne ;
+#   - un QR code menant à l'espace client (liste des commandes) ;
+#   - un rappel que la connexion reste nécessaire, avec l'identifiant à utiliser
+#     (téléphone et/ou e-mail du client).
+#
+# Pour un relevé de **période** (mensuel groupé, clients pro), les commandes
+# sont regroupées **par jour de cuisson**, chaque jour identifiable (cf. #27).
 #
 # Usage :
 #   pdf = InvoicePdfService.new(invoice).render   # => String binaire (PDF)
@@ -17,6 +25,10 @@ class InvoicePdfService
   BRAND_COLOR = "7C2D12".freeze   # terracotta (cf. e-mails)
   MUTED_COLOR = "8A8178".freeze
   LIGHT_FILL = "FAF7F2".freeze
+
+  DOCUMENT_TITLE = "Relevé de commandes".freeze
+  ONLINE_DETAILS_MENTION = "Tous les détails de vos commandes sont disponibles en ligne.".freeze
+  QR_SIZE = 96 # côté du QR en points PDF
 
   def initialize(invoice)
     @invoice = invoice
@@ -30,7 +42,7 @@ class InvoicePdfService
 
   # Nom de fichier suggéré pour le téléchargement.
   def filename
-    "facture-#{@invoice.number}.pdf"
+    "releve-commandes-#{@invoice.number}.pdf"
   end
 
   private
@@ -43,7 +55,8 @@ class InvoicePdfService
     render_parties(pdf)
     render_meta(pdf)
     render_body(pdf)
-    render_totals(pdf)
+    render_total(pdf)
+    render_online_access(pdf)
     render_footer(pdf)
 
     pdf
@@ -56,7 +69,7 @@ class InvoicePdfService
     pdf.text BakeryDetails::TAGLINE, size: 9, style: :normal
     pdf.fill_color "000000"
     pdf.move_down 6
-    pdf.text "FACTURE", size: 16, style: :bold
+    pdf.text DOCUMENT_TITLE, size: 16, style: :bold
     pdf.move_down 12
   end
 
@@ -65,7 +78,7 @@ class InvoicePdfService
     customer = @presenter.customer_address_lines.join("\n")
 
     pdf.table(
-      [ [ box("Émetteur", bakery), box("Client", customer) ] ],
+      [ [ box("Boulangerie", bakery), box("Client", customer) ] ],
       width: pdf.bounds.width,
       column_widths: [ pdf.bounds.width / 2, pdf.bounds.width / 2 ],
       cell_style: { borders: [], padding: [ 0, 8, 0, 0 ] }
@@ -77,12 +90,10 @@ class InvoicePdfService
     "#{title}\n#{content}"
   end
 
+  # Référence discrète (date / période) — sans aucune mention « facture ».
   def render_meta(pdf)
-    rows = [
-      [ "Numéro de facture", @presenter.number ],
-      [ "Date d'émission", I18n.l(@presenter.issued_on) ]
-    ]
-    rows << [ "Période facturée", @presenter.period_label ] if @presenter.period?
+    rows = [ [ "Date du relevé", I18n.l(@presenter.issued_on) ] ]
+    rows << [ "Période", @presenter.period_label ] if @presenter.period?
 
     pdf.table(
       rows,
@@ -103,7 +114,7 @@ class InvoicePdfService
     end
   end
 
-  # Facture de période : un sous-tableau par jour de cuisson, identifiable.
+  # Relevé de période : un sous-tableau par jour de cuisson, identifiable.
   def render_grouped_body(pdf)
     @presenter.bake_day_groups.each do |group|
       pdf.fill_color BRAND_COLOR
@@ -146,36 +157,90 @@ class InvoicePdfService
     [ total - 210, 50, 80, 80 ]
   end
 
-  def render_totals(pdf)
+  # Un seul total (montant des commandes) — aucun découpage HT / TVA / TTC.
+  def render_total(pdf)
     pdf.move_down 6
-    rows = []
-    if @presenter.vat_applied?
-      rows << [ "Total HT", euros(@presenter.subtotal_cents) ]
-      rows << [ "TVA (#{format('%g', @presenter.vat_rate)} %)", euros(@presenter.vat_cents) ]
-      rows << [ "Total TTC", euros(@presenter.total_cents) ]
-    else
-      rows << [ "Total", euros(@presenter.total_cents) ]
-    end
-
     pdf.table(
-      rows,
+      [ [ "Total", euros(@presenter.total_cents) ] ],
       position: :right,
       column_widths: [ 120, 90 ],
-      cell_style: { size: 10, padding: [ 4, 6 ], borders: [] }
+      cell_style: { size: 12, padding: [ 4, 6 ], borders: [], font_style: :bold }
     ) do |t|
-      t.column(0).font_style = :bold
       t.columns(0..1).align = :right
-      t.row(rows.size - 1).font_style = :bold
-      t.row(rows.size - 1).size = 12
     end
   end
 
-  def render_footer(pdf)
+  # Bloc « accès en ligne » : mention, QR code vers l'espace client, et rappel
+  # de l'identifiant de connexion (téléphone et/ou e-mail).
+  def render_online_access(pdf)
     pdf.move_down 24
+    pdf.stroke_color "EEEEEE"
+    pdf.stroke_horizontal_rule
+    pdf.stroke_color "000000"
+    pdf.move_down 14
+
+    qr_png = qr_code_png(customer_space_url)
+    qr_box_width = QR_SIZE + 16
+
+    pdf.float do
+      pdf.image StringIO.new(qr_png), at: [ pdf.bounds.right - QR_SIZE, pdf.cursor ],
+        width: QR_SIZE, height: QR_SIZE
+    end
+
+    pdf.text_box(
+      online_access_text,
+      at: [ 0, pdf.cursor ],
+      width: pdf.bounds.width - qr_box_width,
+      size: 10,
+      inline_format: true
+    )
+
+    pdf.move_down [ QR_SIZE, online_access_lines_height(pdf) ].max + 8
+  end
+
+  def online_access_text
+    lines = [ "<b>#{ONLINE_DETAILS_MENTION}</b>" ]
+    lines << "Scannez le QR code ou rendez-vous sur #{customer_space_url}."
+    lines << "Une connexion reste nécessaire. Identifiant à utiliser : " \
+             "#{@presenter.login_identifiers.join(' ou ')}."
+    lines.join("\n\n")
+  end
+
+  # Hauteur approximative du bloc texte, pour réserver la place sous le QR.
+  def online_access_lines_height(pdf)
+    pdf.height_of(
+      online_access_text,
+      width: pdf.bounds.width - (QR_SIZE + 16),
+      size: 10,
+      inline_format: true
+    )
+  end
+
+  def render_footer(pdf)
+    pdf.move_down 12
     pdf.fill_color MUTED_COLOR
     pdf.text "Merci de votre confiance.", size: 9, align: :center
     pdf.text [ BakeryDetails::NAME, BakeryDetails::EMAIL ].join(" · "), size: 8, align: :center
     pdf.fill_color "000000"
+  end
+
+  # URL de l'espace client (liste de ses commandes). Le chemin est résolu via le
+  # routeur ; l'hôte vient de APP_HOST (cohérent avec les liens des e-mails).
+  def customer_space_url
+    Rails.application.routes.url_helpers.customers_account_url(host: app_host)
+  end
+
+  def app_host
+    ENV.fetch("APP_HOST", "tranchesdevie.be")
+  end
+
+  # PNG (binaire) du QR code encodant l'URL fournie. `size` fixe le côté en
+  # pixels du PNG ; Prawn le redimensionne ensuite à QR_SIZE points.
+  def qr_code_png(url)
+    RQRCode::QRCode.new(url).as_png(
+      size: 240,
+      border_modules: 2
+    ).to_s
   end
 
   def euros(cents)

--- a/app/services/invoice_pdf_service.rb
+++ b/app/services/invoice_pdf_service.rb
@@ -226,12 +226,18 @@ class InvoicePdfService
 
   # URL de l'espace client (liste de ses commandes). Le chemin est résolu via le
   # routeur ; l'hôte vient de APP_HOST (cohérent avec les liens des e-mails).
+  # HTTPS en production (lien public scanné par le client) ; http ailleurs pour
+  # rester compatible avec localhost / lvh.me en développement et test.
   def customer_space_url
-    Rails.application.routes.url_helpers.customers_account_url(host: app_host)
+    Rails.application.routes.url_helpers.customers_account_url(host: app_host, protocol: url_protocol)
   end
 
   def app_host
     ENV.fetch("APP_HOST", "tranchesdevie.be")
+  end
+
+  def url_protocol
+    Rails.env.production? ? "https" : "http"
   end
 
   # PNG (binaire) du QR code encodant l'URL fournie. `size` fixe le côté en

--- a/app/views/admin/billing/index.html.erb
+++ b/app/views/admin/billing/index.html.erb
@@ -67,8 +67,8 @@
             </p>
           </div>
           <div>
-            <%# Facture mensuelle groupée (par jour de cuisson) du client — #38. %>
-            <%= link_to "Facture PDF du mois",
+            <%# Relevé mensuel groupé (par jour de cuisson) du client — #38. %>
+            <%= link_to "Relevé de commandes (PDF) du mois",
                   admin_period_invoice_path(customer_id: billing.customer.id, month: @month.strftime("%Y-%m")),
                   class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50" %>
           </div>
@@ -89,7 +89,7 @@
                 <tr>
                   <td class="px-4 py-2 text-gray-900 whitespace-nowrap">
                     <%= link_to l(order.bake_day.baked_on), admin_order_path(order), class: "hover:underline" %>
-                    <%= link_to "Facture PDF",
+                    <%= link_to "Relevé de commandes (PDF)",
                           admin_order_invoice_path(order_id: order.id),
                           class: "block text-xs text-blue-600 hover:underline mt-0.5" %>
                   </td>

--- a/app/views/customers/account/show.html.erb
+++ b/app/views/customers/account/show.html.erb
@@ -114,10 +114,10 @@
                     <%= order_status_label(order.status) %>
                   </span>
                   <% if @customer.billable? %>
-                    <%# Facture PDF du détail réservée aux clients facturables (#38).
+                    <%# Relevé de commandes (PDF) réservé aux clients facturables (#38).
                         `order-modal#download` stoppe la propagation pour ne pas
                         ouvrir la modale de la carte au clic sur le lien. %>
-                    <%= link_to "Télécharger la facture (PDF)",
+                    <%= link_to "Télécharger le relevé (PDF)",
                           customers_order_invoice_path(order_id: order.id),
                           class: "block text-xs text-blue-600 hover:underline mt-1",
                           data: { turbo: false, action: "click->order-modal#download" } %>

--- a/spec/requests/admin/invoices_spec.rb
+++ b/spec/requests/admin/invoices_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe "Admin::Invoices", type: :request do
       end
     end
 
-    describe "GET facture de période (mensuelle groupée)" do
-      it "renvoie un PDF groupé par jour de cuisson" do
+    describe "GET relevé de période (mensuel groupé)" do
+      it "renvoie un relevé PDF groupé par jour de cuisson, sans mention fiscale" do
         get admin_period_invoice_path(customer_id: customer.id, month: "2026-05")
 
         expect(response).to have_http_status(:ok)
@@ -59,6 +59,8 @@ RSpec.describe "Admin::Invoices", type: :request do
         expect(response.body).to start_with("%PDF")
 
         text = PDF::Reader.new(StringIO.new(response.body)).pages.map(&:text).join("\n")
+        expect(text).to include("Relevé de commandes")
+        expect(text).not_to match(/facture/i)
         expect(text).to include(I18n.l(Date.new(2026, 5, 12)))
         expect(text).to include(I18n.l(Date.new(2026, 5, 15)))
       end

--- a/spec/services/invoice_pdf_service_spec.rb
+++ b/spec/services/invoice_pdf_service_spec.rb
@@ -1,8 +1,17 @@
 require "rails_helper"
 require "pdf/reader"
 
+# Le PDF produit est un **relevé de commandes** (order statement) destiné à être
+# joint à la facture — PAS une facture fiscale (décision produit Michael, 25/06).
+# Pas de bloc TVA / HT-TTC, pas de mention « Facture ». Il porte le détail des
+# articles, une invitation à consulter le détail en ligne, l'identifiant de
+# connexion du client, et un QR code vers l'espace client.
 RSpec.describe InvoicePdfService, type: :service do
-  let(:customer) { create(:customer, first_name: "Épicerie", last_name: "Durand", email: "epicerie@example.com") }
+  let(:customer) do
+    create(:customer,
+      first_name: "Épicerie", last_name: "Durand",
+      email: "epicerie@example.com", phone_e164: "+32470000001")
+  end
   let(:product) { create(:product, name: "Pain froment") }
   let(:variant) { create(:product_variant, product: product, name: "Petit 600 g", price_cents: 550) }
   let(:bake_day) { create(:bake_day, baked_on: Date.new(2026, 5, 12)) }
@@ -17,21 +26,32 @@ RSpec.describe InvoicePdfService, type: :service do
     PDF::Reader.new(StringIO.new(binary)).pages.map(&:text).join("\n")
   end
 
+  def pdf_image_count(binary)
+    PDF::Reader.new(StringIO.new(binary)).pages.sum { |page| page.xobjects.size }
+  end
+
   it "produit un PDF non vide commençant par %PDF" do
     binary = described_class.new(invoice).render
     expect(binary).to be_present
     expect(binary).to start_with("%PDF")
   end
 
-  it "propose un nom de fichier basé sur le numéro de facture" do
-    expect(described_class.new(invoice).filename).to eq("facture-#{invoice.number}.pdf")
+  it "propose un nom de fichier de relevé" do
+    expect(described_class.new(invoice).filename).to eq("releve-commandes-#{invoice.number}.pdf")
   end
 
-  describe "contenu de la facture d'une commande" do
+  describe "contenu du relevé d'une commande" do
     let(:text) { pdf_text(described_class.new(invoice).render) }
 
-    it "contient le numéro de facture et les coordonnées boulangerie + client" do
-      expect(text).to include(invoice.number)
+    it "s'intitule « Relevé de commandes » et n'est PAS une facture" do
+      expect(text).to include("Relevé de commandes")
+      expect(text).not_to match(/facture/i)
+      expect(text).not_to match(/\bTVA\b/)
+      expect(text).not_to match(/\bHT\b/)
+      expect(text).not_to match(/\bTTC\b/)
+    end
+
+    it "contient les coordonnées boulangerie + client" do
       expect(text).to include(BakeryDetails::NAME)
       expect(text).to include("Épicerie Durand")
     end
@@ -50,9 +70,42 @@ RSpec.describe InvoicePdfService, type: :service do
     it "contient le total" do
       expect(text).to include("16,50")
     end
+
+    it "invite à consulter le détail des commandes en ligne" do
+      expect(text).to include("Tous les détails de vos commandes sont disponibles en ligne.")
+    end
+
+    it "rappelle que la connexion reste nécessaire et affiche l'identifiant (téléphone et e-mail)" do
+      expect(text).to match(/connexion|connecter/i)
+      expect(text).to include("+32470000001")
+      expect(text).to include("epicerie@example.com")
+    end
+
+    it "intègre un QR code (au moins une image dans le PDF)" do
+      binary = described_class.new(invoice).render
+      expect(pdf_image_count(binary)).to be >= 1
+    end
   end
 
-  describe "facture mensuelle groupée par jour de cuisson (#27)" do
+  describe "identifiant de connexion selon les coordonnées disponibles" do
+    it "n'affiche que le téléphone si le client n'a pas d'e-mail" do
+      customer.update!(email: nil)
+      text = pdf_text(described_class.new(invoice).render)
+
+      expect(text).to include("+32470000001")
+      expect(text).not_to include("epicerie@example.com")
+    end
+
+    it "n'affiche que l'e-mail si le client n'a pas de téléphone" do
+      customer.update_columns(phone_e164: nil)
+      text = pdf_text(described_class.new(invoice).render)
+
+      expect(text).to include("epicerie@example.com")
+      expect(text).not_to include("+32470000001")
+    end
+  end
+
+  describe "relevé mensuel groupé par jour de cuisson (#27)" do
     let(:tuesday) { create(:bake_day, baked_on: Date.new(2026, 5, 12)) }
     let(:friday) { create(:bake_day, baked_on: Date.new(2026, 5, 15)) }
 


### PR DESCRIPTION
## Résumé — Révision de #38 (relevé ≠ facture)
Suite au test de Michael : on n'a pas besoin d'une **facture** PDF, mais d'un **relevé de commandes** (order statement) à **joindre** à la facture. Le PDF de #38 (PR #114) est donc reframé en relevé.

- **Le PDF devient un « Relevé de commandes »** : coordonnées boulangerie + client, période/commandes, **détail des articles** (produit + variante, quantité, prix unitaire, total ligne), total. Pour un relevé de **période** (mensuel groupé, clients pro) : un sous-tableau **par jour de cuisson**. **Plus de bloc TVA / HT-TTC ni de mention « facture »** (un relevé n'est pas une pièce fiscale).
- **Accès en ligne** ajouté au PDF : mention « **Tous les détails de vos commandes sont disponibles en ligne.** » + un **QR code** (gem `rqrcode`, pur Ruby) menant à l'espace client (liste des commandes) + le rappel « **une connexion reste nécessaire — identifiant à utiliser : <téléphone et/ou e-mail du client>** ». URL en **HTTPS en production** (lien public scanné), http en dev/test ; hôte via `APP_HOST`.
- **Libellés UI** : admin facturation + espace client → « Relevé de commandes (PDF) » / « Télécharger le relevé ». Gating `billable?` côté client inchangé.
- **Churn minimal** : le modèle `Invoice`/`invoice_orders` + `InvoiceBuilderService` sont **conservés** comme mécanisme d'enregistrement/regroupement sous-jacent (aucune migration). Seuls le **contenu produit** et les **libellés** deviennent ceux d'un relevé.

## Testé
- `bundle exec rspec` : **550 exemples, 0 échec** (état complet, incluant les PR #118/#119 déjà mergées — vérifié indépendamment après alignement sur `main`).
- Specs mises à jour (`invoice_pdf_service_spec`) : le relevé contient le détail (produit+variante, quantités, total), la mention « disponibles en ligne » et l'identifiant de connexion ; un QR (image) est intégré. Gating espace client conservé.
- `bin/rubocop` : fichiers propres. `bin/brakeman` : 0 alerte. Aucune migration / schéma inchangé.

## NON testé
- **Pas de vérification navigateur** ni de **scan réel du QR** : le QR est généré et intégré au PDF (validé par spec : image présente), mais l'URL n'a pas été scannée/ouverte en vrai. À confirmer : que `APP_HOST` pointe bien vers le bon domaine en prod et que la route de l'espace client est la bonne cible.
- Rendu visuel du PDF (mise en page du bloc QR + texte) non inspecté à l'œil.
- **À valider produit** : le modèle `Invoice` (+ numérotation, conservée pour le nom de fichier `releve-commandes-<n>.pdf`) est gardé comme support technique. Si tu veux supprimer toute trace de « facture/numéro » côté données, c'est un suivi séparé.
