### PR TITLE
Checkout : client facturable commande sans paiement en ligne (#122)

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -4,8 +4,8 @@ class CheckoutController < ApplicationController
   # Garde-fou (#68) : on resynchronise la ligne forfait Pizza party AVANT de
   # calculer le total / créer le PaymentIntent ou la commande, au cas où le
   # panier aurait été modifié hors des actions du CartController. Idempotent.
-  before_action :sync_pizza_party_forfait!, only: [ :new, :create_payment_intent, :create_cash_order ]
-  before_action :ensure_cutoff_not_passed, only: [ :new, :create_payment_intent, :create_cash_order ]
+  before_action :sync_pizza_party_forfait!, only: [ :new, :create_payment_intent, :create_cash_order, :create_invoice_order ]
+  before_action :ensure_cutoff_not_passed, only: [ :new, :create_payment_intent, :create_cash_order, :create_invoice_order ]
 
   def new
     @cart = session[:cart] || []
@@ -30,6 +30,9 @@ class CheckoutController < ApplicationController
     # Paiement en ligne par défaut ; le cash n'est proposé qu'aux clients
     # explicitement autorisés par l'admin (#36).
     @cash_payment_allowed = @customer&.cash_payment_allowed? || false
+    # Clients facturables (épiceries, points de dépôt, pros) : aucun paiement en
+    # ligne, ils reçoivent une facture (#122). Ce flux prime sur le cash.
+    @billable = @customer&.billable? || false
   end
 
   def verify_phone
@@ -290,6 +293,130 @@ class CheckoutController < ApplicationController
     }
   rescue StandardError => e
     Rails.logger.error("Error creating cash order: #{e.message}")
+    Rails.logger.error(e.backtrace.join("\n"))
+    Sentry.capture_exception(e) if defined?(Sentry)
+    render json: { success: false, error: "Une erreur est survenue lors de la création de la commande" }, status: :internal_server_error
+  end
+
+  # Commande d'un client facturable (#122) : aucun paiement en ligne. La commande
+  # est créée en statut `unpaid` avec `requires_invoice: true` ; le client recevra
+  # une facture (gérée ailleurs dans l'admin). Calqué sur `create_cash_order`.
+  def create_invoice_order
+    unless phone_verified? || customer_signed_in?
+      render json: { success: false, error: "Phone verification required" }, status: :unauthorized
+      return
+    end
+
+    # Parse JSON body
+    begin
+      request.body.rewind
+      json_params = JSON.parse(request.body.read)
+    rescue JSON::ParserError
+      json_params = {}
+    end
+
+    # Store customer info in session if provided
+    if json_params["first_name"].present?
+      session[:first_name] = json_params["first_name"]
+    end
+    if json_params["last_name"].present?
+      session[:last_name] = json_params["last_name"]
+    end
+    if json_params["email"].present?
+      session[:email] = json_params["email"]
+    end
+
+    phone_e164 = if customer_signed_in?
+                   current_customer.phone_e164
+    else
+                   session[:phone_e164]
+    end
+
+    unless phone_e164 && session[:bake_day_id] && session[:cart]&.any?
+      render json: { success: false, error: "Informations manquantes" }, status: :unprocessable_entity
+      return
+    end
+
+    # Utiliser le client connecté si disponible, sinon trouver ou créer
+    if customer_signed_in?
+      customer = current_customer
+
+      update_attrs = {}
+      update_attrs[:first_name] = session[:first_name] if session[:first_name].present?
+      update_attrs[:last_name] = session[:last_name] if session[:last_name].present?
+      update_attrs[:email] = session[:email] if session[:email].present?
+
+      customer.update(update_attrs) if update_attrs.any?
+    else
+      customer = Customer.find_or_create_by(phone_e164: phone_e164)
+
+      if customer.new_record?
+        customer.assign_attributes(
+          first_name: session[:first_name].presence,
+          last_name: session[:last_name].presence,
+          email: session[:email].presence
+        )
+        customer.save!
+      elsif session[:first_name].present? || session[:last_name].present? || session[:email].present?
+        customer.update(
+          first_name: session[:first_name].presence || customer.first_name,
+          last_name: session[:last_name].presence || customer.last_name,
+          email: session[:email].presence || customer.email
+        )
+      end
+    end
+
+    # Garde-fou serveur (#122) : la commande facturée hors-ligne n'est possible que
+    # pour les clients explicitement marqués `billable`. On ne se fie pas au seul
+    # masquage côté vue (page périmée, requête forgée, etc.).
+    unless customer.billable?
+      render json: { success: false, error: "Le paiement en ligne est requis pour cette commande" }, status: :forbidden
+      return
+    end
+
+    bake_day = BakeDay.find_by(id: session[:bake_day_id])
+    unless bake_day
+      render json: { success: false, error: "Jour de cuisson introuvable" }, status: :unprocessable_entity
+      return
+    end
+
+    cart_items = session[:cart] || []
+
+    service = OrderCreationService.new(
+      customer: customer,
+      bake_day: bake_day,
+      cart_items: cart_items,
+      payment_method: "invoice",
+      group_name: json_params["group_name"]
+    )
+
+    order = service.call
+
+    unless order
+      render json: { success: false, error: service.errors.join(", ") }, status: :unprocessable_entity
+      return
+    end
+
+    # Notifications : SMS + email de confirmation mentionnant la facture à venir.
+    SmsService.send_confirmation(order)
+    OrderNotificationService.send_confirmation(order)
+
+    # Clear cart and session data
+    session[:cart] = []
+    session[:bake_day_id] = nil
+    session[:phone_e164] = nil
+    session[:otp_verified] = false
+    session[:otp_verified_at] = nil
+    session[:first_name] = nil
+    session[:last_name] = nil
+    session[:email] = nil
+
+    render json: {
+      success: true,
+      order_token: order.public_token
+    }
+  rescue StandardError => e
+    Rails.logger.error("Error creating invoice order: #{e.message}")
     Rails.logger.error(e.backtrace.join("\n"))
     Sentry.capture_exception(e) if defined?(Sentry)
     render json: { success: false, error: "Une erreur est survenue lors de la création de la commande" }, status: :internal_server_error

--- a/app/services/order_creation_service.rb
+++ b/app/services/order_creation_service.rb
@@ -15,7 +15,9 @@ class OrderCreationService
   def call
     return false unless valid?
 
-    initial_status = @payment_method == "cash" ? :unpaid : :pending
+    # Le cash et la facture (clients facturables) ne sont pas encaissés en ligne :
+    # la commande est valide mais en attente de paiement hors-ligne (#36, #122).
+    initial_status = %w[cash invoice].include?(@payment_method) ? :unpaid : :pending
 
     ActiveRecord::Base.transaction do
       # Advisory lock on bake_day to prevent race conditions
@@ -36,6 +38,7 @@ class OrderCreationService
         total_cents: calculate_total,
         payment_intent_id: @payment_intent_id,
         status: initial_status,
+        requires_invoice: @payment_method == "invoice",
         group_name: @group_name
       )
 

--- a/app/services/sms_service.rb
+++ b/app/services/sms_service.rb
@@ -6,7 +6,11 @@ class SmsService
   def self.send_confirmation(order)
     return false unless order.customer.sms_enabled?
 
-    message = "Ta commande chez Tranches de Vie est confirmée. Merci !"
+    message = if order.requires_invoice?
+                "Ta commande chez Tranches de Vie est confirmée. Tu recevras une facture pour cette commande. Merci !"
+    else
+                "Ta commande chez Tranches de Vie est confirmée. Merci !"
+    end
     send_sms(
       to: order.customer.phone_e164,
       body: message,

--- a/app/views/checkout/new.html.erb
+++ b/app/views/checkout/new.html.erb
@@ -166,6 +166,26 @@
         </div>
       </div>
 
+      <% if @billable %>
+      <!-- Client facturable (#122) : aucun paiement en ligne, facture à suivre. -->
+      <div id="invoice-order-section">
+        <div class="mb-6 rounded-md border border-sage-300 bg-sage-100 p-4">
+          <div class="flex items-start gap-3">
+            <span class="mt-0.5 text-sage-600"><%= lucide "receipt", size: 20, color: "var(--sage-600)" %></span>
+            <div class="text-sm leading-relaxed text-ink-700">
+              <p class="font-semibold text-ink-900">Tu es un client facturable</p>
+              <p class="mt-1">Aucun paiement en ligne n'est nécessaire : tu recevras une <strong>facture</strong> pour cette commande.</p>
+            </div>
+          </div>
+        </div>
+
+        <button id="submit-invoice-order"
+                class="flex h-12 w-full items-center justify-center rounded-md bg-sage-600 px-4 text-sm font-semibold text-white shadow-xs transition hover:bg-sage-500 focus:outline-none focus:ring-[3px] focus:ring-[color:var(--focus-ring)]">
+          Confirmer la commande
+        </button>
+        <p class="mt-2 text-center text-sm text-ink-500">Tu recevras une facture pour ta commande</p>
+      </div>
+      <% else %>
       <!-- Sélecteur de méthode de paiement -->
       <%# Par défaut, paiement en ligne uniquement. L'option « cash » n'apparaît
           que pour les clients explicitement autorisés par l'admin (#36). %>
@@ -214,6 +234,7 @@
           <p class="mt-2 text-center text-sm text-ink-500">Vous paierez en liquide lors du retrait de votre commande</p>
         </div>
       <% end %>
+      <% end %>
       </div>
     </div>
     <% end %>
@@ -241,6 +262,9 @@
   let elements;
   let stripeInitialized = false;
   let currentPaymentMethod = 'online'; // Par défaut, paiement en ligne (Bancontact)
+  // Client facturable (#122) : aucun paiement en ligne. On n'initialise jamais
+  // Stripe pour lui (sinon un PaymentIntent serait créé à tort).
+  const BILLABLE = <%= @billable ? "true" : "false" %>;
 
   // Initialiser l'état de la méthode de paiement
   function initializePaymentMethodState() {
@@ -350,19 +374,24 @@
     sync();
   }
 
+  // Initialise l'UI de paiement (Stripe / cash). Inopérant pour un client
+  // facturable, qui n'a aucune étape de paiement.
+  function initPaymentUI() {
+    if (BILLABLE) return;
+    initializePaymentMethodState();
+    handlePaymentMethodChange();
+    initStripe();
+  }
+
   // Initialiser au chargement de la page
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', function() {
-      initializePaymentMethodState();
-      handlePaymentMethodChange();
+      initPaymentUI();
       setupGroupPurchaseToggle();
-      initStripe();
     });
   } else {
-    initializePaymentMethodState();
-    handlePaymentMethodChange();
+    initPaymentUI();
     setupGroupPurchaseToggle();
-    initStripe();
   }
 
   // Reinitialiser lors de la navigation Turbo (Turbo Drive)
@@ -370,9 +399,7 @@
     // Ne reinitialiser que si l'utilisateur est sur la page de paiement
     if (window.location.pathname.includes('/checkout')) {
       stripeInitialized = false; // Reinitialiser le drapeau pour autoriser une nouvelle initialisation
-      initializePaymentMethodState();
-      handlePaymentMethodChange();
-      initStripe();
+      initPaymentUI();
     }
   });
 
@@ -542,6 +569,70 @@
     document.addEventListener('DOMContentLoaded', handleCashOrderSubmission);
   } else {
     handleCashOrderSubmission();
+  }
+
+  // Gérer la soumission de commande facturable (#122) : aucun paiement en ligne.
+  function handleInvoiceOrderSubmission() {
+    const submitInvoiceButton = document.getElementById('submit-invoice-order');
+    if (!submitInvoiceButton) return;
+
+    submitInvoiceButton.addEventListener('click', async (e) => {
+      e.preventDefault();
+
+      // Vérifier que les informations client sont remplies
+      const firstName = document.getElementById('customer_first_name')?.value;
+      if (!firstName || firstName.trim() === '' || firstName.trim() === 'Client') {
+        alert('Veuillez remplir votre nom et prénom afin que les pains soient attribués à la bonne personne');
+        return;
+      }
+
+      const lastName = document.getElementById('customer_last_name')?.value;
+      if (!lastName || lastName.trim() === '') {
+        alert('Veuillez remplir votre nom et prénom afin que les pains soient attribués à la bonne personne');
+        return;
+      }
+
+      submitInvoiceButton.disabled = true;
+      submitInvoiceButton.textContent = 'Traitement...';
+
+      try {
+        const response = await fetch('<%= create_invoice_order_checkout_index_path %>', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': '<%= form_authenticity_token %>'
+          },
+          body: JSON.stringify({
+            first_name: document.getElementById('customer_first_name')?.value || '',
+            last_name: document.getElementById('customer_last_name')?.value || '',
+            email: document.getElementById('customer_email')?.value || '',
+            group_name: groupNameValue()
+          })
+        });
+
+        const data = await response.json();
+
+        if (data.success) {
+          window.location.href = '<%= success_checkout_index_url %>?order_token=' + data.order_token;
+        } else {
+          alert(data.error || 'Erreur lors de la création de la commande');
+          submitInvoiceButton.disabled = false;
+          submitInvoiceButton.textContent = 'Confirmer la commande';
+        }
+      } catch (error) {
+        console.error("Erreur lors de la création de la commande facturable :", error);
+        alert('Erreur de connexion. Veuillez réessayer.');
+        submitInvoiceButton.disabled = false;
+        submitInvoiceButton.textContent = 'Confirmer la commande';
+      }
+    });
+  }
+
+  // Initialiser la gestion de la commande facturable
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', handleInvoiceOrderSubmission);
+  } else {
+    handleInvoiceOrderSubmission();
   }
 <% end %>
 

--- a/app/views/checkout/success.html.erb
+++ b/app/views/checkout/success.html.erb
@@ -15,7 +15,11 @@
         Ta commande <strong class="font-semibold text-ink-900"><%= @order.order_number %></strong> a été confirmée.
       </p>
 
-      <% if @order.unpaid? %>
+      <% if @order.requires_invoice? %>
+        <p class="mb-4 text-ink-700">
+          Aucun paiement en ligne n'est nécessaire : tu recevras une facture pour cette commande.
+        </p>
+      <% elsif @order.unpaid? %>
         <p class="mb-4 text-ink-700">
           Tu paieras en liquide lors du retrait de ta commande.
         </p>

--- a/app/views/order_mailer/confirmation.html.erb
+++ b/app/views/order_mailer/confirmation.html.erb
@@ -8,6 +8,16 @@
   Ta commande est confirmée. Voici le récapitulatif :
 </p>
 
+<% if @order.requires_invoice? %>
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#fdf6ef; border:1px solid #ece4d8; border-radius:12px; margin-bottom:24px;">
+    <tr>
+      <td style="padding:16px 20px; font-size:14px; line-height:1.6; color:#5c544b;">
+        🧾 Aucun paiement en ligne n'est nécessaire : tu recevras une <strong style="color:#2d2a26;">facture</strong> pour cette commande.
+      </td>
+    </tr>
+  </table>
+<% end %>
+
 <!-- Order summary card -->
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#faf7f2; border:1px solid #ece4d8; border-radius:12px; margin-bottom:24px;">
   <tr>

--- a/app/views/order_mailer/confirmation.text.erb
+++ b/app/views/order_mailer/confirmation.text.erb
@@ -2,6 +2,10 @@
 Merci <%= @customer.first_name.presence || "" %> !
 
 Ta commande est confirmée.
+<% if @order.requires_invoice? -%>
+
+Aucun paiement en ligne n'est nécessaire : tu recevras une facture pour cette commande.
+<% end -%>
 
 Commande : <%= @order.order_number %>
 À retirer le : <%= I18n.l(@order.bake_day.baked_on, format: :long) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
       post :verify_otp
       post :create_payment_intent
       post :create_cash_order
+      post :create_invoice_order
       get :success
     end
   end

--- a/spec/requests/checkout_spec.rb
+++ b/spec/requests/checkout_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Checkout — réservation au paiement', type: :request do
 
   before do
     allow(OrderNotificationService).to receive(:send_confirmation)
+    allow(SmsService).to receive(:send_confirmation)
 
     # Authentifier le client (stub OTP) puis garnir le panier.
     allow(OtpService).to receive(:send_code).and_return({ success: true, channel: :sms })
@@ -112,6 +113,89 @@ RSpec.describe 'Checkout — réservation au paiement', type: :request do
       it 'crée une commande unpaid' do
         expect { create_cash_order }.to change { Order.where(status: :unpaid).count }.by(1)
         expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe 'Client facturable (#122)' do
+    describe 'GET /checkout/new' do
+      context 'pour un client non facturable' do
+        it 'n\'affiche pas le callout facture et garde le sélecteur de paiement' do
+          get '/checkout/new'
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).not_to include('id="submit-invoice-order"')
+          expect(response.body[%r{<input[^>]*value="online"[^>]*>}]).to include('checked')
+        end
+      end
+
+      context 'pour un client facturable' do
+        let(:customer) { create(:customer, first_name: 'Léa', billable: true) }
+
+        it 'affiche le callout facture + bouton de confirmation, sans sélecteur de paiement' do
+          get '/checkout/new'
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include('id="submit-invoice-order"')
+          expect(response.body).to include('facture')
+          # Aucun sélecteur de paiement (radios) ni Payment Element Stripe visible.
+          expect(response.body[%r{<input[^>]*name="payment_method"[^>]*>}]).to be_nil
+          expect(response.body).not_to include('id="submit-cash-order"')
+        end
+      end
+
+      context 'pour un client à la fois facturable et autorisé au cash' do
+        let(:customer) { create(:customer, first_name: 'Léa', billable: true, cash_payment_allowed: true) }
+
+        it 'fait primer le flux facturable (pas d\'option cash)' do
+          get '/checkout/new'
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include('id="submit-invoice-order"')
+          expect(response.body).not_to include('id="submit-cash-order"')
+          expect(response.body[%r{<input[^>]*value="cash"[^>]*>}]).to be_nil
+        end
+      end
+    end
+
+    describe 'POST /checkout/create_invoice_order' do
+      def create_invoice_order(body = { first_name: 'Léa' })
+        post '/checkout/create_invoice_order', params: body.to_json,
+             headers: { 'CONTENT_TYPE' => 'application/json' }
+      end
+
+      it 'refuse la commande facturable pour un client non facturable (403)' do
+        expect { create_invoice_order }.not_to change(Order, :count)
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      context 'pour un client facturable' do
+        let(:customer) { create(:customer, first_name: 'Léa', billable: true) }
+
+        it 'crée une commande unpaid + requires_invoice et renvoie le token' do
+          expect { create_invoice_order }.to change { Order.where(status: :unpaid, requires_invoice: true).count }.by(1)
+          expect(response).to have_http_status(:ok)
+
+          order = Order.order(:created_at).last
+          expect(JSON.parse(response.body)['order_token']).to eq(order.public_token)
+          expect(order.requires_invoice).to be(true)
+        end
+
+        it 'déclenche les notifications SMS et email' do
+          expect(SmsService).to receive(:send_confirmation)
+          expect(OrderNotificationService).to receive(:send_confirmation)
+
+          create_invoice_order
+        end
+      end
+
+      context 'pour un client facturable ET autorisé au cash' do
+        let(:customer) { create(:customer, first_name: 'Léa', billable: true, cash_payment_allowed: true) }
+
+        it 'crée une commande facturable (priorité facture sur cash)' do
+          expect { create_invoice_order }.to change { Order.where(requires_invoice: true).count }.by(1)
+          expect(response).to have_http_status(:ok)
+        end
       end
     end
   end

--- a/spec/services/order_creation_service_spec.rb
+++ b/spec/services/order_creation_service_spec.rb
@@ -122,3 +122,55 @@ RSpec.describe OrderCreationService do
     expect(order.group_name).to be_nil
   end
 end
+
+# #122 : commande facturable (client `billable`) — pas de paiement en ligne.
+RSpec.describe OrderCreationService do
+  let(:customer) { create(:customer, billable: true) }
+  let(:bake_day) { create(:bake_day, :can_order) }
+  let(:variant) { create(:product_variant) }
+  let(:cart_items) { [ { "product_variant_id" => variant.id, "qty" => 1 } ] }
+
+  def build_service(payment_method:)
+    described_class.new(
+      customer: customer,
+      bake_day: bake_day,
+      cart_items: cart_items,
+      payment_method: payment_method,
+      skip_capacity_check: true
+    )
+  end
+
+  it "creates an unpaid order flagged requires_invoice for the invoice method" do
+    order = build_service(payment_method: "invoice").call
+
+    expect(order).to be_a(Order)
+    expect(order.status).to eq("unpaid")
+    expect(order.requires_invoice).to be(true)
+  end
+
+  it "does not flag requires_invoice for cash orders" do
+    order = build_service(payment_method: "cash").call
+
+    expect(order.status).to eq("unpaid")
+    expect(order.requires_invoice).to be(false)
+  end
+
+  it "does not flag requires_invoice for online orders" do
+    order = build_service(payment_method: "online").call
+
+    expect(order.status).to eq("pending")
+    expect(order.requires_invoice).to be(false)
+  end
+
+  it "still enforces capacity checks for invoice orders" do
+    allow_any_instance_of(BakeCapacityService)
+      .to receive(:cart_fits?).and_return({ fits: false, errors: [ "Four : capacité dépassée" ] })
+
+    service = described_class.new(
+      customer: customer, bake_day: bake_day, cart_items: cart_items, payment_method: "invoice"
+    )
+
+    expect(service.call).to be false
+    expect(service.errors.join).to include("capacité dépassée")
+  end
+end

--- a/spec/services/sms_service_spec.rb
+++ b/spec/services/sms_service_spec.rb
@@ -19,6 +19,34 @@ RSpec.describe SmsService do
     )
   end
 
+  describe '.send_confirmation' do
+    it 'mentions the upcoming invoice for an order that requires one (#122)' do
+      order.update!(requires_invoice: true)
+
+      expect(HTTParty).to receive(:post).with(
+        SmsService::SMSTOOLS_API_URL,
+        hash_including(body: a_string_matching(/facture/i))
+      ).and_return(double(success?: true, code: 200, :[] => 'msg_123', body: '{}'))
+
+      SmsService.send_confirmation(order)
+    end
+
+    it 'uses the plain confirmation message for a regular order' do
+      expect(HTTParty).to receive(:post).with(
+        SmsService::SMSTOOLS_API_URL,
+        hash_including(body: a_string_matching(/confirmée/i))
+      ).and_return(double(success?: true, code: 200, :[] => 'msg_123', body: '{}'))
+
+      SmsService.send_confirmation(order)
+      expect(SmsMessage.last.body).not_to match(/facture/i)
+    end
+
+    it 'returns false if customer has SMS disabled' do
+      customer.update!(sms_opt_out: true)
+      expect(SmsService.send_confirmation(order)).to be false
+    end
+  end
+
   describe '.send_planned_order_confirmed' do
     it 'sends an SMS with the debited amount' do
       expect(HTTParty).to receive(:post).with(


### PR DESCRIPTION
Closes #122

## Résumé

Un client **facturable** (`Customer#billable`) peut désormais passer commande au checkout en ligne **sans aucune étape de paiement**. À la place du sélecteur de moyen de paiement, un callout l'informe qu'il recevra une facture, et un bouton « Confirmer la commande » crée directement la commande.

Le flux facturable **prime** sur le flux cash/Stripe : un client à la fois `billable` et `cash_payment_allowed` ne voit que le flux facturable.

### Changements

- **`CheckoutController`**
  - `#new` : expose `@billable = @customer&.billable?`.
  - **`#create_invoice_order`** (nouvelle action, calquée sur `#create_cash_order`) : garde serveur `unless customer.billable?` → **403** ; crée la commande via `OrderCreationService` avec `payment_method: "invoice"` ; envoie SMS + email ; nettoie la session.
- **`config/routes.rb`** : `post :create_invoice_order` dans le bloc `collection` de `resources :checkout`.
- **`OrderCreationService`** : `payment_method == "invoice"` → statut `:unpaid` + `requires_invoice: true`. La vérification de capacité + advisory lock restent appliquées.
- **`app/views/checkout/new.html.erb`** : si `@billable`, le sélecteur de paiement / la section Stripe / le bouton cash sont masqués au profit du callout + bouton « Confirmer la commande ». L'init Stripe est désactivée côté JS pour ces clients (sinon un PaymentIntent serait créé à tort), et un handler dédié poste vers `create_invoice_order`.
- **`app/views/checkout/success.html.erb`** : message « facture à suivre » pour `order.requires_invoice?`.
- **`SmsService#send_confirmation`** : variante du message mentionnant la facture pour `requires_invoice?`.
- **Email** (`order_mailer/confirmation.{html,text}.erb`) : mention de la facture quand `requires_invoice?` (idempotence + `email_enabled?` inchangés via `OrderNotificationService`).

Le client **non facturable** garde un comportement strictement inchangé (Stripe / liquide selon `cash_payment_allowed`).

## 📸 Aperçu

![Checkout — client facturable (callout facture, sans paiement en ligne)](https://github.com/les4sources/tranchesdevie2/raw/agent-screenshots/screenshots/20260630-033447-checkout--client-facturable-callout-facture-sans.png)

> Repo privé → l'aperçu s'ouvre une fois connecté à GitHub. Capture d'un vrai parcours (client `billable` connecté, panier garni) via un test système jetable.

## Testé

- **`bundle exec rspec`** : suite complète verte (583 exemples, 0 échec).
- **Service** (`order_creation_service_spec`) : `payment_method: "invoice"` → `unpaid` + `requires_invoice: true` ; cash/online ne posent pas le flag ; capacité toujours appliquée.
- **Request** (`checkout_spec`) :
  - `GET /checkout/new` — callout facture + bouton sans sélecteur de paiement pour un client `billable` ; sélecteur conservé pour un non-facturable ; priorité facture sur cash.
  - `POST /checkout/create_invoice_order` — **403** si non `billable` (aucune commande) ; sinon commande `unpaid` + `requires_invoice` + token renvoyé ; SMS + email déclenchés ; priorité facture pour un client `billable + cash`.
- **SMS** (`sms_service_spec`) : message de confirmation mentionnant la facture pour `requires_invoice?`, message standard sinon.
- **`bin/rubocop`** : propre sur les fichiers touchés.
- **`bin/brakeman --no-pager`** : 0 erreur, 0 alerte de sécurité.
- **Capture** : parcours réel rejoué (connexion OTP + panier) en test système headless → callout vérifié visuellement (voir Aperçu).

## NON testé

- **Confirmation de paiement Stripe / liquide réelle** pour les clients non facturables (non modifiée par cette PR — seulement le branchement de la vue).
- **Envoi réel** des SMS/emails (mockés dans les specs ; pas d'appel aux API Smstools/SES).
- **Rendu de la facture PDF** et portail de facturation (`Admin::BillingController`) — hors périmètre de l'issue (la commande facturable est seulement créée).
- **Interactions JS fines** côté navigateur (toggle groupe, double-clic) : le test système a dû contourner Stimulus, cassé dans l'environnement de test headless par un pin importmap défaillant (chart.js 404 sur jsdelivr) — problème d'environnement préexistant, indépendant de cette PR.
