### PR TITLE
Checkout : create_payment_intent idempotent + grâce à 15 min (#124)

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -162,6 +162,15 @@ class CheckoutController < ApplicationController
 
     customer = find_or_create_customer(json_params)
 
+    # Idempotence (#124) : le JS rappelle ce endpoint à chaque turbo:load sur
+    # /checkout. Plutôt que d'accumuler une commande pending par visite, on
+    # réutilise la commande pending existante (même client + même jour) et on met
+    # son PaymentIntent à jour. Si la réutilisation aboutit, la réponse est déjà
+    # rendue ci-dessous.
+    if (existing = reusable_pending_order(customer)) && reuse_pending_order(existing, json_params)
+      return
+    end
+
     # Réserver la capacité AVANT de prendre l'argent : on crée la commande
     # (statut pending) sous verrou consultatif + contrôle de capacité. Une commande
     # pending compte dans la capacité, donc deux clients ne peuvent pas réserver le
@@ -464,6 +473,79 @@ class CheckoutController < ApplicationController
     return nil unless payment_intent_id.present?
 
     Order.uncached { Order.find_by(payment_intent_id: payment_intent_id) }
+  end
+
+  # Statuts Stripe dans lesquels un PaymentIntent est encore modifiable : on peut
+  # y réutiliser la commande pending et ajuster le montant.
+  REUSABLE_PI_STATUSES = %w[requires_payment_method requires_confirmation requires_action].freeze
+
+  # Statuts « paiement vivant » : en cours (Bancontact) ou déjà abouti. Le PI
+  # n'est plus modifiable, mais la commande existante ne doit surtout PAS être
+  # doublée — on renvoie simplement le client_secret existant pour que le client
+  # reprenne le même flux (Stripe.js le redirige vers success si succeeded).
+  LIVE_PI_STATUSES = %w[processing succeeded].freeze
+
+  # Commande pending réutilisable pour ce client + ce jour (la plus récente).
+  def reusable_pending_order(customer)
+    Order.pending
+         .where(customer: customer, bake_day: @bake_day)
+         .where.not(payment_intent_id: nil)
+         .order(:created_at)
+         .last
+  end
+
+  # Tente de réutiliser une commande pending existante : met à jour ses lignes et
+  # son total pour refléter le panier courant, ajuste le PaymentIntent Stripe si
+  # le montant change, et renvoie son client_secret. Retourne true si la requête a
+  # été traitée (réponse rendue), false pour laisser le flux créer une nouvelle
+  # commande + PI.
+  #
+  # Cas « paiement vivant » (processing/succeeded) : on ne modifie rien et on ne
+  # crée pas de doublon — on renvoie le client_secret existant. Cas « inutilisable »
+  # (canceled) ou erreur Stripe : on retourne false → le flux normal crée une
+  # commande fraîche (choix documenté au #124 : ne jamais bloquer le client, la
+  # commande morte est laissée au job de nettoyage).
+  def reuse_pending_order(order, json_params)
+    payment_intent = Stripe::PaymentIntent.retrieve(order.payment_intent_id)
+
+    unless REUSABLE_PI_STATUSES.include?(payment_intent.status)
+      if LIVE_PI_STATUSES.include?(payment_intent.status)
+        session[:payment_intent_id] = payment_intent.id
+        render json: {
+          client_secret: payment_intent.client_secret,
+          payment_intent_id: payment_intent.id
+        }
+        return true
+      end
+      return false
+    end
+
+    updater = PendingOrderUpdateService.new(order: order, cart_items: @cart, group_name: json_params["group_name"])
+    unless updater.call
+      capture_checkout_issue("pending_order_update_rejected", level: :warning, extra: { service_errors: updater.errors })
+      render json: { error: updater.errors.join(". ") }, status: :unprocessable_entity
+      return true
+    end
+
+    if payment_intent.amount != order.total_cents
+      payment_intent = Stripe::PaymentIntent.update(
+        payment_intent.id,
+        amount: order.total_cents,
+        metadata: { cart_items: @cart.to_json }
+      )
+    end
+
+    session[:payment_intent_id] = payment_intent.id
+    render json: {
+      client_secret: payment_intent.client_secret,
+      payment_intent_id: payment_intent.id
+    }
+    true
+  rescue Stripe::StripeError => e
+    # PI introuvable / non modifiable côté Stripe : on retombe sur la création
+    # d'une nouvelle commande + PI (le flux nominal ci-dessous).
+    capture_checkout_issue("pending_order_reuse_stripe_failed", exception: e)
+    false
   end
 
   def ensure_cart_not_empty

--- a/app/jobs/expire_stale_pending_orders_job.rb
+++ b/app/jobs/expire_stale_pending_orders_job.rb
@@ -11,7 +11,7 @@
 class ExpireStalePendingOrdersJob < ApplicationJob
   queue_as :default
 
-  GRACE_PERIOD = 30.minutes
+  GRACE_PERIOD = 15.minutes
 
   # Statuts Stripe considérés comme non aboutis (la commande peut être supprimée).
   ABANDONED_PI_STATUSES = %w[requires_payment_method requires_confirmation requires_action canceled].freeze

--- a/app/services/bake_capacity_service.rb
+++ b/app/services/bake_capacity_service.rb
@@ -41,7 +41,11 @@ class BakeCapacityService
 
   # Check if adding cart_items would exceed capacity
   # cart_items: array of { variant_id:, qty: } or objects responding to product_variant_id and qty
-  def cart_fits?(cart_items)
+  # exclude_order_id: exclut l'usage déjà réservé par une commande donnée (utile lors de
+  # la mise à jour d'une commande pending existante, pour ne pas double-compter sa propre
+  # réservation).
+  def cart_fits?(cart_items, exclude_order_id: nil)
+    @exclude_order_id = exclude_order_id
     errors = []
     additional = compute_additional(cart_items)
 
@@ -75,13 +79,16 @@ class BakeCapacityService
 
   # All breads order_items for this bake_day (excluding cancelled)
   def breads_order_items
-    @breads_order_items ||= OrderItem
-      .joins(order: [], product_variant: :product)
-      .where(orders: { bake_day_id: bake_day.id })
-      .where.not(orders: { status: :cancelled })
-      .where(products: { category: :breads })
-      .includes(product_variant: { product: { product_flours: :flour } })
-      .to_a
+    @breads_order_items ||= begin
+      scope = OrderItem
+        .joins(order: [], product_variant: :product)
+        .where(orders: { bake_day_id: bake_day.id })
+        .where.not(orders: { status: :cancelled })
+        .where(products: { category: :breads })
+        .includes(product_variant: { product: { product_flours: :flour } })
+      scope = scope.where.not(orders: { id: @exclude_order_id }) if @exclude_order_id
+      scope.to_a
+    end
   end
 
   def mold_usage

--- a/app/services/pending_order_update_service.rb
+++ b/app/services/pending_order_update_service.rb
@@ -1,0 +1,85 @@
+# Met à jour une commande `pending` (paiement en ligne) existante pour la faire
+# refléter le panier courant, sans en créer une nouvelle. Utilisé par le tunnel
+# de checkout idempotent (#124) : quand un client recharge `/checkout`, on
+# réutilise sa commande `pending` au lieu d'en accumuler une par visite.
+#
+# Le re-contrôle de capacité se fait sous verrou consultatif, en EXCLUANT la
+# commande elle-même de l'usage déjà réservé (sinon une simple mise à jour
+# échouerait à tort sur une fournée proche de la limite en double-comptant sa
+# propre réservation).
+class PendingOrderUpdateService
+  attr_reader :order, :errors
+
+  def initialize(order:, cart_items:, group_name: nil)
+    @order = order
+    @cart_items = cart_items
+    @group_name = group_name.presence || order.group_name
+    @errors = []
+  end
+
+  def call
+    return false unless valid?
+
+    ActiveRecord::Base.transaction do
+      # Même verrou consultatif que la création : garantit qu'on ne survend pas
+      # le dernier créneau, y compris lors d'une mise à jour concurrente.
+      ActiveRecord::Base.connection.execute("SELECT pg_advisory_xact_lock(#{@order.bake_day_id})")
+
+      result = BakeCapacityService.new(@order.bake_day).cart_fits?(@cart_items, exclude_order_id: @order.id)
+      unless result[:fits]
+        @errors.concat(result[:errors])
+        raise ActiveRecord::Rollback
+      end
+
+      @order.order_items.destroy_all
+      create_order_items
+      @order.update!(total_cents: calculate_total, group_name: @group_name)
+    end
+
+    @errors.empty? ? @order : false
+  end
+
+  private
+
+  def valid?
+    @errors = []
+
+    @errors << "Order is not pending" unless @order.pending?
+    @errors << "Cart is empty" if @cart_items.empty?
+    @errors << "Bake day cut-off has passed" unless BakeDayService.can_order_for?(@order.bake_day.baked_on)
+
+    @cart_items.each do |item|
+      variant = ProductVariant.find(item["product_variant_id"])
+      unless variant.active? && variant.channel == "store"
+        @errors << "La version '#{variant.name}' du produit '#{variant.product.name}' n'est plus disponible"
+      end
+
+      unless variant.available_on_weekday?(@order.bake_day.baked_on.wday)
+        @errors << "La version '#{variant.name}' du produit '#{variant.product.name}' n'est pas disponible le #{BakeDay::WDAY_LABELS[@order.bake_day.baked_on.wday]}"
+      end
+    end
+
+    @errors.empty?
+  end
+
+  def calculate_total
+    lines = @cart_items.map do |item|
+      { variant: ProductVariant.find(item["product_variant_id"]), qty: item["qty"].to_i }
+    end
+
+    subtotal = lines.sum { |line| line[:variant].price_cents * line[:qty] }
+    discount_cents = GroupDiscountService.new(@order.customer).total_discount_cents(lines)
+    subtotal - discount_cents
+  end
+
+  def create_order_items
+    @cart_items.each do |item|
+      variant = ProductVariant.find(item["product_variant_id"])
+      @order.order_items.create!(
+        product_variant: variant,
+        qty: item["qty"].to_i,
+        unit_price_cents: variant.price_cents
+      )
+    end
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -18,11 +18,11 @@ production:
     schedule: at 6:15 pm every day
     description: "Mark orders as ready and send SMS notifications at 6:15pm"
 
-  # Libère la capacité réservée par les paiements en ligne abandonnés (>30 min)
+  # Libère la capacité réservée par les paiements en ligne abandonnés (>15 min)
   expire_stale_pending_orders:
     class: ExpireStalePendingOrdersJob
     schedule: "*/10 * * * *"
-    description: "Cancel abandoned online checkouts (pending > 30 min) to free bake capacity"
+    description: "Cancel abandoned online checkouts (pending > 15 min) to free bake capacity"
 
   # Process planned orders after cut-offs (Sunday 18:05 for Tuesday, Wednesday 18:05 for Friday)
   process_planned_orders_sunday:

--- a/spec/jobs/expire_stale_pending_orders_job_spec.rb
+++ b/spec/jobs/expire_stale_pending_orders_job_spec.rb
@@ -49,6 +49,27 @@ RSpec.describe ExpireStalePendingOrdersJob, type: :job do
     expect(order.reload.status).to eq("pending")
   end
 
+  # Grâce raccourcie à 15 min (#124) : une réservation de 16 min est désormais
+  # traitée (elle ne l'aurait pas été sous l'ancien délai de 30 min).
+  it "processes an abandoned reservation older than the 15-minute grace" do
+    order = create(:order, :pending, :with_items, customer: customer, bake_day: bake_day, payment_intent_id: "pi_16min")
+    order.update_column(:created_at, 16.minutes.ago)
+    stub_stripe_payment_intent_retrieve(id: "pi_16min", status: "requires_payment_method")
+    allow(Stripe::PaymentIntent).to receive(:cancel).with("pi_16min")
+
+    expect { described_class.new.perform }.to change { Order.exists?(order.id) }.from(true).to(false)
+  end
+
+  it "leaves a reservation younger than the 15-minute grace" do
+    order = create(:order, :pending, :with_items, customer: customer, bake_day: bake_day, payment_intent_id: "pi_10min")
+    order.update_column(:created_at, 10.minutes.ago)
+    expect(Stripe::PaymentIntent).not_to receive(:retrieve)
+
+    described_class.new.perform
+
+    expect(order.reload.status).to eq("pending")
+  end
+
   it "ignores orders without a payment intent (e.g. cash/unpaid)" do
     order = create(:order, :unpaid, :with_items, customer: customer, bake_day: bake_day, payment_intent_id: nil)
     order.update_column(:created_at, 2.hours.ago)

--- a/spec/requests/checkout_spec.rb
+++ b/spec/requests/checkout_spec.rb
@@ -46,6 +46,58 @@ RSpec.describe 'Checkout — réservation au paiement', type: :request do
     end
   end
 
+  # Idempotence (#124) : le JS rappelle create_payment_intent à chaque turbo:load.
+  # On ne doit pas accumuler une commande pending par visite.
+  context 'idempotence — réutilisation de la commande pending' do
+    before { stub_stripe_payment_intent_create(amount: 550) }
+
+    it 'ne crée pas de doublon et réutilise le même PI quand le panier est identique' do
+      create_payment_intent
+      order = Order.order(:created_at).last
+      pi_id = order.payment_intent_id
+
+      stub_stripe_payment_intent_retrieve(id: pi_id, status: 'requires_payment_method', amount: 550)
+      allow(Stripe::PaymentIntent).to receive(:update)
+
+      expect { create_payment_intent }.not_to change { Order.where(status: :pending).count }
+      expect(Order.where(customer: customer, bake_day: bake_day, status: :pending).count).to eq(1)
+      expect(Stripe::PaymentIntent).not_to have_received(:update)
+      expect(JSON.parse(response.body)['payment_intent_id']).to eq(pi_id)
+    end
+
+    it 'met à jour la commande pending et le montant du PI quand le panier change' do
+      create_payment_intent
+      order = Order.order(:created_at).last
+      pi_id = order.payment_intent_id
+
+      # Le panier passe à 2 unités (1100 cents).
+      post '/cart/add', params: { product_variant_id: variant.id, bake_day_id: bake_day.id, quantity: 1 }
+
+      stub_stripe_payment_intent_retrieve(id: pi_id, status: 'requires_payment_method', amount: 550)
+      stub_stripe_payment_intent_update(id: pi_id, amount: 1100)
+
+      expect { create_payment_intent }.not_to change(Order, :count)
+      order.reload
+      expect(order.total_cents).to eq(1100)
+      expect(order.order_items.sum(:qty)).to eq(2)
+      expect(Stripe::PaymentIntent).to have_received(:update).with(pi_id, hash_including(amount: 1100))
+    end
+
+    it 'ne réutilise pas et ne crée pas de doublon quand le PI est déjà succeeded (paiement vivant)' do
+      create_payment_intent
+      order = Order.order(:created_at).last
+      pi_id = order.payment_intent_id
+
+      stub_stripe_payment_intent_retrieve(id: pi_id, status: 'succeeded', amount: 550)
+      allow(Stripe::PaymentIntent).to receive(:update)
+
+      expect { create_payment_intent }.not_to change(Order, :count)
+      expect(Stripe::PaymentIntent).not_to have_received(:update)
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)['payment_intent_id']).to eq(pi_id)
+    end
+  end
+
   context 'when the bake day is full' do
     before do
       allow_any_instance_of(BakeCapacityService)

--- a/spec/services/bake_capacity_service_spec.rb
+++ b/spec/services/bake_capacity_service_spec.rb
@@ -106,6 +106,28 @@ RSpec.describe BakeCapacityService do
       end
     end
 
+    context 'when re-checking capacity for an order being updated (#124)' do
+      let(:oven_capacity_grams) { 6_000 }
+      let!(:order_being_updated) do
+        create(:order, :pending, bake_day: bake_day).tap do |o|
+          create(:order_item, order: o, product_variant: variant, qty: 5) # 5000 g déjà réservés par elle-même
+        end
+      end
+
+      it 'excludes the order own usage so a same-size update still fits' do
+        # Sans exclusion : 5000 (soi-même) + 5000 (panier) = 10 000 > 6000 → rejet à tort.
+        # Avec exclusion : 0 + 5000 = 5000 ≤ 6000 → accepté.
+        result = service.cart_fits?(cart(5), exclude_order_id: order_being_updated.id)
+        expect(result[:fits]).to be true
+      end
+
+      it 'still rejects a genuine over-reservation even when excluding the order' do
+        result = service.cart_fits?(cart(7), exclude_order_id: order_being_updated.id) # 7000 > 6000
+        expect(result[:fits]).to be false
+        expect(result[:errors].join).to include('Four')
+      end
+    end
+
     context 'when an existing order on the bake day is cancelled (ISC-24)' do
       let(:oven_capacity_grams) { 6_000 }
 

--- a/spec/services/pending_order_update_service_spec.rb
+++ b/spec/services/pending_order_update_service_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+# Mise à jour idempotente d'une commande pending existante (#124).
+RSpec.describe PendingOrderUpdateService do
+  let(:oven_capacity_grams) { 100_000 }
+  let!(:production_setting) do
+    ProductionSetting.create!(
+      oven_capacity_grams: oven_capacity_grams,
+      market_day_oven_capacity_grams: oven_capacity_grams * 2
+    )
+  end
+  let!(:mold_type) { MoldType.create!(name: "Moule test", limit: 100, position: 1) }
+  let!(:flour) { Flour.create!(name: "Farine test", kneader_limit_grams: 100_000, position: 1) }
+  let!(:product) do
+    create(:product, category: :breads, channel: "store").tap do |p|
+      ProductFlour.create!(product: p, flour: flour, percentage: 100)
+    end
+  end
+  let!(:variant) do
+    create(:product_variant, product: product, channel: "store", price_cents: 550,
+                             flour_quantity: 1_000, mold_type: mold_type)
+  end
+  let(:bake_day) { create(:bake_day, :can_order) }
+  let(:customer) { create(:customer) }
+
+  # Commande pending initiale : 1 unité (550 cents).
+  let!(:order) do
+    o = create(:order, :pending, customer: customer, bake_day: bake_day, total_cents: 550, payment_intent_id: "pi_x")
+    o.order_items.create!(product_variant: variant, qty: 1, unit_price_cents: 550)
+    o
+  end
+
+  def cart(qty)
+    [ { "product_variant_id" => variant.id, "qty" => qty } ]
+  end
+
+  it "réécrit les order_items et le total pour refléter le panier" do
+    result = described_class.new(order: order, cart_items: cart(3)).call
+
+    expect(result).to eq(order)
+    order.reload
+    expect(order.order_items.sum(:qty)).to eq(3)
+    expect(order.total_cents).to eq(1650)
+  end
+
+  it "ne double-compte pas la propre réservation de la commande sur une fournée pleine" do
+    # Four à 3000 g ; la commande réserve déjà 1000 g. La faire passer à 3 unités
+    # (3000 g) doit passer car sa propre réservation est exclue du calcul.
+    production_setting.update!(oven_capacity_grams: 3_000)
+
+    result = described_class.new(order: order, cart_items: cart(3)).call
+    expect(result).to eq(order)
+    expect(order.reload.total_cents).to eq(1650)
+  end
+
+  it "rejette une vraie sur-réservation" do
+    production_setting.update!(oven_capacity_grams: 3_000)
+
+    service = described_class.new(order: order, cart_items: cart(4)) # 4000 g > 3000 g
+    expect(service.call).to be false
+    expect(service.errors.join).to include("Four")
+    # La commande n'est pas modifiée en cas d'échec.
+    expect(order.reload.order_items.sum(:qty)).to eq(1)
+    expect(order.total_cents).to eq(550)
+  end
+
+  it "refuse un panier vide" do
+    service = described_class.new(order: order, cart_items: [])
+    expect(service.call).to be false
+    expect(service.errors.join).to include("empty")
+  end
+end

--- a/spec/support/stripe_helper.rb
+++ b/spec/support/stripe_helper.rb
@@ -14,17 +14,33 @@ module StripeHelper
     payment_intent
   end
 
-  def stub_stripe_payment_intent_retrieve(id:, status: 'succeeded', amount: 1000)
+  def stub_stripe_payment_intent_retrieve(id:, status: 'succeeded', amount: 1000, client_secret: 'pi_test_secret_123')
     payment_intent = double(
       'Stripe::PaymentIntent',
       id: id,
       status: status,
       amount: amount,
       currency: 'eur',
+      client_secret: client_secret,
       metadata: {}
     )
 
     allow(Stripe::PaymentIntent).to receive(:retrieve).with(id).and_return(payment_intent)
+    payment_intent
+  end
+
+  def stub_stripe_payment_intent_update(id:, amount:, client_secret: 'pi_test_secret_123')
+    payment_intent = double(
+      'Stripe::PaymentIntent',
+      id: id,
+      status: 'requires_payment_method',
+      amount: amount,
+      currency: 'eur',
+      client_secret: client_secret,
+      metadata: {}
+    )
+
+    allow(Stripe::PaymentIntent).to receive(:update).with(id, anything).and_return(payment_intent)
     payment_intent
   end
 


### PR DESCRIPTION
Closes #124

## Résumé

Le JS de `/checkout` rappelle `create_payment_intent` à **chaque `turbo:load`**, ce qui créait une nouvelle commande `pending` + un nouveau PaymentIntent à chaque visite/rechargement → accumulation de commandes `pending` orphelines.

Cette PR tarit l'accumulation à la source :

- **Réutilisation idempotente** : avant de créer une commande, `create_payment_intent` cherche une commande `pending` existante pour le **même client + même `bake_day`** (avec un `payment_intent_id`). Si le PaymentIntent est encore modifiable (`requires_payment_method` / `requires_confirmation` / `requires_action`), on la réutilise.
- **Mise à jour panier + Stripe** : nouveau service `PendingOrderUpdateService` qui réécrit `order_items` + `total_cents` pour refléter le panier courant, sous verrou consultatif. Quand le total change, on appelle `Stripe::PaymentIntent.update(id, amount:)` (+ metadata `cart_items`) et on renvoie le `client_secret` existant — pas de nouveau PI. Total inchangé → aucun appel Stripe d'écriture.
- **Capacité non double-comptée** : `BakeCapacityService#cart_fits?` accepte `exclude_order_id:` pour exclure la propre réservation de la commande mise à jour (sinon une simple mise à jour échouerait à tort sur une fournée proche de la limite).
- **Grâce raccourcie** : `ExpireStalePendingOrdersJob::GRACE_PERIOD` 30 → 15 min + `description` de `config/recurring.yml` mise à jour.
- **Non-régression** : le verrou consultatif + contrôle de capacité restent en place (création ET mise à jour) → garantie anti-survente préservée ; les flux `create_cash_order` / `create_invoice_order` (statut `unpaid`, sans PI) ne sont pas touchés.

### Choix retenu pour le cas « PI non réutilisable »

- **`processing` / `succeeded`** (paiement vivant/abouti, PI non modifiable) : on **ne crée pas de doublon** et on ne modifie rien — on renvoie le `client_secret` existant pour que le client reprenne le même flux (Stripe.js le redirige vers `success` si `succeeded`).
- **`canceled`** (ou erreur Stripe sur le `retrieve`) : la commande est morte/inutilisable → on retombe sur la création d'une commande fraîche + PI, pour ne jamais bloquer le client. La commande morte est laissée au job de nettoyage. C'est le fallback explicitement autorisé par l'issue.

## Testé (RSpec, vert — 586 exemples, 0 échec)

- **Request `create_payment_intent`** : 2 appels même panier → une seule commande `pending`, même PI, pas d'appel `update` ; panier modifié → commande + total mis à jour, `Stripe::PaymentIntent.update` avec le nouveau montant, pas de nouvelle commande ; PI `succeeded` → pas de doublon, pas d'`update`.
- **`PendingOrderUpdateService`** : réécriture items/total ; exclusion de la propre réservation sur fournée pleine ; rejet d'une vraie sur-réservation (commande inchangée en cas d'échec) ; panier vide refusé.
- **`BakeCapacityService`** : `exclude_order_id` exclut l'usage de la commande ; une vraie sur-réservation échoue toujours.
- **`ExpireStalePendingOrdersJob`** : réservation de 16 min traitée, de 10 min laissée (nouvelle fenêtre 15 min).
- `bin/rubocop` : 0 offense. `bin/brakeman` : 0 security warning, 0 error.

## NON testé

- **Vérification manuelle en dev** (recharger `/checkout` plusieurs fois, modifier le panier) : non effectuée — run nocturne headless, pas de session interactive. Couvert par les specs request ci-dessus qui simulent la séquence turbo:load.
- **Appels Stripe réels** : entièrement mockés (aucun réseau). Le comportement réel de `Stripe::PaymentIntent.update` (notamment metadata merge) n'est pas validé contre l'API live.
- **Comportement JS client** avec un PI `succeeded` renvoyé au rechargement (redirection Stripe.js vers success) : logique côté serveur seulement, non vérifiée dans un vrai navigateur.

## Aperçu

Aucun rendu visible modifié : changement purement serveur (logique d'idempotence du tunnel de paiement + job de nettoyage). Pas de capture d'écran.
