### PR TITLE
E2E : harness system specs + mock Stripe.js + checkout critique + CI (#126)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,50 @@ jobs:
       - name: Lint code for consistent style
         run: bin/rubocop -f github
 
+  system:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/tranchesdevie_test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      # Chrome est préinstallé sur les runners ubuntu-latest ; Selenium Manager
+      # récupère le chromedriver compatible au runtime.
+      - name: Set up Chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
+
+      - name: Prepare the test database
+        run: bin/rails db:test:prepare
+
+      - name: Build CSS (Tailwind) for asset rendering
+        run: bin/rails tailwindcss:build
+
+      - name: Run system specs
+        run: bundle exec rspec spec/system/
+

--- a/app/views/layouts/_stripe_test_stub.html.erb
+++ b/app/views/layouts/_stripe_test_stub.html.erb
@@ -1,0 +1,32 @@
+<%# Shim Stripe.js pour les tests système (#126).
+    Remplace le vrai https://js.stripe.com/v3/ afin qu'AUCUN appel réseau ne parte
+    vers Stripe pendant les system specs. Reproduit juste ce que le JS de checkout
+    utilise : Stripe(key).elements({clientSecret}).create('payment').mount(...) et
+    stripe.confirmPayment({confirmParams:{return_url}}) qui se résout sans erreur et
+    déclenche la navigation vers la return_url (comme le vrai redirect Stripe). %>
+<script>
+  window.Stripe = function (publishableKey) {
+    return {
+      elements: function (options) {
+        return {
+          create: function (type) {
+            return {
+              mount: function (selector) {
+                var el = document.querySelector(selector);
+                if (el) { el.setAttribute("data-stripe-mock-mounted", "true"); }
+              },
+              unmount: function () {}
+            };
+          }
+        };
+      },
+      confirmPayment: function (options) {
+        var returnUrl = options && options.confirmParams && options.confirmParams.return_url;
+        return Promise.resolve({}).then(function (result) {
+          if (returnUrl) { window.location.href = returnUrl; }
+          return result;
+        });
+      }
+    };
+  };
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,17 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
-    <%= csrf_meta_tags %>
+    <%# En prod/dev, csrf_meta_tags rend le vrai token. En test, la protection CSRF
+        est désactivée (allow_forgery_protection = false) → csrf_meta_tags ne rend
+        RIEN, ce qui fait planter le JS lisant meta[name="csrf-token"].content
+        (connexion OTP, checkout). On injecte alors un meta factice — jamais vérifié
+        côté serveur — pour que les system specs pilotent le vrai JS (#126). %>
+    <% if protect_against_forgery? %>
+      <%= csrf_meta_tags %>
+    <% else %>
+      <meta name="csrf-param" content="authenticity_token">
+      <meta name="csrf-token" content="test-token">
+    <% end %>
     <%= csp_meta_tag %>
     <meta name="stripe-key" content="<%= ENV['STRIPE_PUBLIC_KEY'] %>">
 
@@ -19,7 +29,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
 
     <!-- Charger Stripe.js globalement pour eviter les erreurs "Stripe is not defined" avec Turbo -->
-    <script src="https://js.stripe.com/v3/"></script>
+    <%# En test système, on ne charge PAS le vrai Stripe.js (aucun appel réseau) :
+        un shim window.Stripe est injecté à la place (cf. #126). %>
+    <% if Rails.env.test? %>
+      <%= render "layouts/stripe_test_stub" %>
+    <% else %>
+      <script src="https://js.stripe.com/v3/"></script>
+    <% end %>
 
     <%= render "layouts/sentry_browser" %>
 

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -1,0 +1,51 @@
+# Helpers partagés pour les system specs du storefront (#126).
+#
+# Ils posent le harness dont dépendent les parcours navigateur : stub OTP,
+# mock Stripe (serveur via les helpers de stripe_helper.rb + client via le shim
+# window.Stripe injecté par layouts/_stripe_test_stub en env test), et
+# authentification d'un client via le vrai flux OTP de /connexion.
+module SystemHelpers
+  # Neutralise l'envoi/vérification OTP (SMS + e-mail) pour les deux points
+  # d'entrée : /connexion (send_code/verify_code) et le checkout (send_otp/verify_otp).
+  # Aucun SMS ni e-mail réel n'est émis.
+  def stub_customer_otp(code: "123456")
+    allow(OtpService).to receive(:send_code).and_return({ success: true, channel: :sms })
+    allow(OtpService).to receive(:verify_code) do |args|
+      { success: args[:code].to_s == code }
+    end
+    allow(OtpService).to receive(:send_otp).and_return({ success: true })
+    allow(OtpService).to receive(:verify_otp) do |_phone, entered|
+      { success: entered.to_s == code }
+    end
+  end
+
+  # Stub Stripe côté serveur, en RÉUTILISANT les helpers de spec/support/stripe_helper.rb
+  # (pas de duplication). `create` réserve un PaymentIntent modifiable ; `retrieve`
+  # (appelé par la page success) le renvoie `processing` pour ne pas déclencher la
+  # finalisation d'encaissement (hors périmètre de ce harness — couverte ailleurs).
+  # Retourne l'id du PaymentIntent stubbé.
+  def stub_stripe_checkout(total_cents:)
+    intent = stub_stripe_payment_intent_create(amount: total_cents)
+    stub_stripe_payment_intent_retrieve(id: intent.id, status: "processing", amount: total_cents)
+    intent.id
+  end
+
+  # Authentifie un client via le VRAI parcours OTP de /connexion (UI navigateur,
+  # OtpService stubé). Réutilisable par tous les parcours. Suppose que le client
+  # existe déjà (identifiant reconnu → connexion directe).
+  def sign_in_customer(customer, code: "123456")
+    stub_customer_otp(code: code)
+    visit customer_login_path
+    fill_in "identifier", with: customer.phone_e164
+    find("#send-otp-btn").click
+    find("#otp-input-section:not(.hidden)", wait: 5)
+    fill_in "otp_code", with: code
+    find("#verify-otp-btn").click
+    # sign_in redirige hors de /connexion : on attend d'avoir quitté la page de login.
+    expect(page).to have_no_current_path(customer_login_path, wait: 5)
+  end
+end
+
+RSpec.configure do |config|
+  config.include SystemHelpers, type: :system
+end

--- a/spec/system/checkout_flow_spec.rb
+++ b/spec/system/checkout_flow_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+# Parcours d'achat critique de bout en bout (#126) — fondation du harness system
+# specs. Un client authentifié parcourt le catalogue, ajoute un produit, choisit
+# un jour de cuisson, et « paie » (Stripe.js mocké côté client + Stripe stubé côté
+# serveur) jusqu'à la page de confirmation. Aucun appel réseau réel vers Stripe.
+RSpec.describe "Parcours checkout", type: :system do
+  let!(:production_setting) do
+    ProductionSetting.create!(oven_capacity_grams: 1_000_000, market_day_oven_capacity_grams: 2_000_000)
+  end
+  let!(:product) { create(:product, category: :breads, channel: "store", name: "Pain de campagne") }
+  let!(:variant) do
+    create(:product_variant, product: product, channel: "store", name: "800 g",
+                             price_cents: 550, flour_quantity: 500)
+  end
+  let!(:bake_day) { create(:bake_day, :can_order) }
+  let!(:customer) { create(:customer, phone_e164: "+32470112233", first_name: "Camille", last_name: "Dupont") }
+
+  before do
+    allow(OrderNotificationService).to receive(:send_confirmation)
+  end
+
+  # Déroule le parcours complet et renvoie une fois sur la page de confirmation.
+  def run_checkout_journey
+    sign_in_customer(customer)
+    stub_stripe_checkout(total_cents: 550)
+
+    # Catalogue → fiche produit → ajout au panier (le JS renvoie vers /catalogue).
+    visit root_path
+    click_link "Pain de campagne"
+    expect(page).to have_current_path(product_path(product))
+    click_button "Ajouter dans mon panier"
+    expect(page).to have_current_path(catalog_path, wait: 5)
+
+    # Panier → choix du jour de cuisson (fetch AJAX qui pose session[:bake_day_id]).
+    visit cart_path
+    bake_day_radio = find("input[name='bake_day_id'][value='#{bake_day.id}']")
+    bake_day_radio.click
+    expect(bake_day_radio).to be_checked
+
+    # On atteint réellement le checkout (preuve que la session porte bien le jour).
+    click_link "Valider la commande"
+    expect(page).to have_current_path(new_checkout_path, wait: 5)
+
+    # Section paiement affichée (client connecté → OTP déjà validé) : on attend que
+    # le PaymentIntent soit initialisé et le bouton activé, puis on « paie ».
+    find("#submit-payment:not([disabled])", wait: 10).click
+  end
+
+  it "mène un client jusqu'à la page de confirmation avec une commande créée" do
+    run_checkout_journey
+
+    expect(page).to have_text("Commande confirmée", wait: 10)
+
+    order = Order.find_by(customer: customer, bake_day: bake_day)
+    expect(order).to be_present
+    expect(order.order_items.sum(:qty)).to eq(1)
+    # Le serveur a bien utilisé le stub Stripe (aucun appel réseau réel). Le JS de
+    # /checkout réinitialise le paiement à chaque turbo:load, d'où plusieurs appels
+    # possibles — on vérifie donc « au moins une fois ».
+    expect(Stripe::PaymentIntent).to have_received(:create).at_least(:once)
+  end
+
+  it "fonctionne aussi en viewport mobile", mobile: true do
+    run_checkout_journey
+
+    expect(page).to have_text("Commande confirmée", wait: 10)
+    expect(Order.find_by(customer: customer, bake_day: bake_day)).to be_present
+  end
+end


### PR DESCRIPTION
Closes #126

Sous-issue fondation de l'epic #125 : pose le harness de system specs dont dépendent les autres sous-issues.

## Résumé

Le storefront n'avait aucun test navigateur. Cette PR met en place :

- **`spec/system/`** avec le **parcours d'achat critique de bout en bout** (`checkout_flow_spec.rb`), en desktop **et** en viewport mobile (`mobile: true`).
- **Helpers partagés** (`spec/support/system_helpers.rb`), réutilisables par les prochains parcours :
  - `stub_customer_otp` — neutralise l'OTP pour les deux points d'entrée (`/connexion` → `send_code`/`verify_code` et le checkout → `send_otp`/`verify_otp`).
  - `sign_in_customer(customer)` — authentifie un client via le **vrai flux OTP** de `/connexion` (UI navigateur, OtpService stubé). C'est l'étape « vérification téléphone » du parcours.
  - `stub_stripe_checkout(total_cents:)` — mock Stripe **serveur** qui **réutilise** `spec/support/stripe_helper.rb` (`stub_stripe_payment_intent_create` + `_retrieve`), sans duplication.
- **Mock Stripe.js (client)** : `app/views/layouts/_stripe_test_stub.html.erb`, injecté **à la place** du vrai `js.stripe.com` uniquement en env test (cf. `application.html.erb`). Le shim expose `Stripe(key).elements().create().mount()` et `confirmPayment({confirmParams:{return_url}})` qui se résout sans erreur et déclenche la navigation vers la `return_url` — exactement ce que le JS de checkout utilise. **Aucun appel réseau réel vers Stripe** (ni serveur via WebMock/stubs, ni client via le shim).
- **Meta CSRF factice en env test** : la protection CSRF est désactivée en test (`allow_forgery_protection = false`), donc `csrf_meta_tags` ne rendait rien et le JS lisant `meta[name="csrf-token"].content` (connexion, checkout) plantait. On injecte un meta factice, jamais vérifié côté serveur, pour piloter le vrai JS. Prod/dev inchangés (`protect_against_forgery?` → vrai token).
- **Job CI `system`** (`.github/workflows/ci.yml`) : service **PostgreSQL 16**, **Chrome** (`browser-actions/setup-chrome`), `db:test:prepare`, build Tailwind, puis `bundle exec rspec spec/system/`. Tourne sur push `main` et sur les PRs comme les jobs existants, et **fait échouer la PR** si un spec casse.

### Parcours couvert

Client connecté (OTP) → catalogue `/` → fiche produit `/productions/:id` → ajout au panier → `/panier` → choix du jour de cuisson → checkout → « paiement » (Stripe mocké) → `/checkout/success`. Le spec asserte qu'une `Order` est créée et atteignable, et que le serveur a bien utilisé le stub Stripe.

> Choix d'ordonnancement : l'authentification (OTP via `/connexion`) est faite **au début** du parcours plutôt qu'inline sur le checkout. Résultat identique du point de vue métier (OTP exercé, client vérifié), mais nettement plus robuste : un client connecté arrive directement sur la section paiement du checkout.

## Testé (local, vert)

- `bundle exec rspec spec/system/` → **2 exemples, 0 échec** (desktop + mobile), via Selenium Chrome headless réel.
- `bundle exec rspec` (suite complète) → **577 exemples, 0 échec** (le shim CSRF/layout ne casse aucune vue/request spec).
- `bin/rubocop` → **355 fichiers, 0 offense**.

## NON testé / limites honnêtes

- **`bin/brakeman`** : impossible de capturer sa sortie dans l'environnement headless du run nocturne (le wrapper d'environnement supprime son stdout / n'écrit pas le fichier `-o`). Les changements de cette PR sont pourtant **sans surface sécurité** : vues ERB à contenu statique (meta CSRF factice, shim JS statique), specs et YAML CI. La base était propre (0 warning / 0 error). À confirmer par le job CI `scan_ruby` sur la PR.
- **Le job CI `system` lui-même** n'a pas encore tourné (première exécution à l'ouverture de la PR). Points à surveiller au premier run : disponibilité de Chrome sur `ubuntu-latest` (Selenium Manager récupère chromedriver au runtime) et le build Tailwind. Le spec est vert en local avec le même driver.
- **Finalisation d'encaissement** (`pending → paid` sur la page success) : volontairement hors périmètre du harness — `retrieve` est stubé `processing`, donc la commande reste `pending`. Cette transition est déjà couverte par les request/job specs existants.

## Aperçu

Pas de nouveau rendu utilisateur : cette PR ajoute de l'**infra de test + CI** (system specs, mock Stripe.js de test, job CI). Aucune capture d'écran applicative pertinente — le parcours visible qu'elle exerce (catalogue → paiement → confirmation) existe déjà et n'est pas modifié.
