### PR TITLE
Confirmation renforcée avant annulation d'une fournée (#133)

### DIFF
--- a/app/controllers/admin/bake_days_controller.rb
+++ b/app/controllers/admin/bake_days_controller.rb
@@ -1,5 +1,5 @@
 class Admin::BakeDaysController < Admin::BaseController
-  before_action :set_bake_day, only: [ :show, :edit, :update, :destroy, :cancel ]
+  before_action :set_bake_day, only: [ :show, :edit, :update, :destroy, :confirm_cancel, :cancel ]
 
   def index
     # Jours futurs (aujourd'hui et futurs)
@@ -89,10 +89,36 @@ class Admin::BakeDaysController < Admin::BaseController
     redirect_to admin_bake_days_path, notice: "Jour de cuisson supprimé"
   end
 
+  # Écran de confirmation renforcée avant annulation : affiche l'impact chiffré
+  # (commandes, montant à rembourser, ventilation par mode, SMS) et exige une
+  # garde délibérée avant de pouvoir déclencher l'annulation réelle (#133).
+  def confirm_cancel
+    @preview = BakeDayCancellationService.new(@bake_day).preview
+  end
+
   # Annule la fournée : rembourse tous les clients ayant payé (carte ou
   # portefeuille) et bascule leurs commandes en « annulée ».
   def cancel
-    result = BakeDayCancellationService.new(@bake_day).call
+    service = BakeDayCancellationService.new(@bake_day)
+
+    # Garde idempotente : plus aucune commande annulable → on ne rembourse rien
+    # et on n'envoie aucun SMS (pas d'erreur, message neutre).
+    unless service.preview.any_orders?
+      redirect_to admin_bake_day_path(@bake_day),
+                  notice: "Aucune commande à annuler pour cette fournée."
+      return
+    end
+
+    # Garde serveur : l'admin doit avoir retapé la date de la fournée. Sans elle,
+    # aucune action (aucun remboursement, aucun SMS) — on renvoie vers l'écran.
+    unless cancellation_confirmed?
+      redirect_to confirm_cancel_admin_bake_day_path(@bake_day),
+                  alert: "Confirmation invalide : la fournée n'a pas été annulée. " \
+                         "Retapez la date exacte pour confirmer."
+      return
+    end
+
+    result = service.call
 
     if result.success?
       redirect_to admin_bake_day_path(@bake_day), notice: cancellation_summary(result)
@@ -104,6 +130,13 @@ class Admin::BakeDaysController < Admin::BaseController
   end
 
   private
+
+  # Garde délibérée : l'admin doit retaper la date de la fournée au format
+  # JJ/MM/AAAA. Rattache la confirmation à CETTE fournée précise (un clic
+  # distrait ou une confirmation générique ne suffit plus).
+  def cancellation_confirmed?
+    params[:confirmation].to_s.strip == @bake_day.baked_on.strftime("%d/%m/%Y")
+  end
 
   def cancellation_summary(result)
     parts = [ "Fournée annulée : #{result.refunded_count} remboursement(s) " \

--- a/app/javascript/controllers/cancel_guard_controller.js
+++ b/app/javascript/controllers/cancel_guard_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Garde délibérée avant annulation d'une fournée (#133).
+// Le bouton de confirmation reste désactivé tant que l'admin n'a pas retapé
+// EXACTEMENT la date attendue (JJ/MM/AAAA) dans le champ de garde.
+export default class extends Controller {
+  static targets = ["input", "submit"]
+  static values = { expected: String }
+
+  connect() {
+    this.validate()
+  }
+
+  validate() {
+    const typed = this.inputTarget.value.trim()
+    this.submitTarget.disabled = typed !== this.expectedValue
+  }
+}

--- a/app/services/bake_day_cancellation_service.rb
+++ b/app/services/bake_day_cancellation_service.rb
@@ -35,10 +35,86 @@ class BakeDayCancellationService
     end
   end
 
+  # Aperçu (dry-run) de ce qu'une annulation ferait, SANS rien écrire en base.
+  # Alimente l'écran de confirmation chiffré : il partage exactement la même
+  # source (`PROCESSABLE_STATUSES` + `Order#payment_method`) que `#call`, donc
+  # aucun écart n'est possible entre l'aperçu et l'exécution réelle.
+  Preview = Struct.new(
+    :orders_count,
+    :stripe_count,
+    :stripe_cents,
+    :wallet_count,
+    :wallet_cents,
+    :manual_refund_count,
+    :unpaid_count,
+    :refund_cents,
+    :sms_count,
+    keyword_init: true
+  ) do
+    def any_orders?
+      orders_count.positive?
+    end
+
+    # Total « non encaissé en ligne » : commandes sans trace Stripe/portefeuille
+    # (payées hors-ligne à rembourser à la main + jamais encaissées).
+    def non_online_count
+      manual_refund_count + unpaid_count
+    end
+
+    def refund_euros
+      refund_cents / 100.0
+    end
+
+    def stripe_euros
+      stripe_cents / 100.0
+    end
+
+    def wallet_euros
+      wallet_cents / 100.0
+    end
+  end
+
   attr_reader :bake_day
 
   def initialize(bake_day)
     @bake_day = bake_day
+  end
+
+  def preview
+    stripe_count = wallet_count = 0
+    stripe_cents = wallet_cents = 0
+    manual_refund_count = unpaid_count = sms_count = 0
+
+    preview_orders.each do |order|
+      sms_count += 1 if order.customer.sms_enabled?
+
+      case order.payment_method
+      when :stripe
+        stripe_count += 1
+        stripe_cents += order.total_cents
+      when :wallet
+        wallet_count += 1
+        wallet_cents += order.total_cents
+      else
+        if order.payment_received?
+          manual_refund_count += 1
+        else
+          unpaid_count += 1
+        end
+      end
+    end
+
+    Preview.new(
+      orders_count: stripe_count + wallet_count + manual_refund_count + unpaid_count,
+      stripe_count: stripe_count,
+      stripe_cents: stripe_cents,
+      wallet_count: wallet_count,
+      wallet_cents: wallet_cents,
+      manual_refund_count: manual_refund_count,
+      unpaid_count: unpaid_count,
+      refund_cents: stripe_cents + wallet_cents,
+      sms_count: sms_count
+    )
   end
 
   def call
@@ -65,6 +141,13 @@ class BakeDayCancellationService
 
   def orders
     bake_day.orders.where(status: PROCESSABLE_STATUSES)
+  end
+
+  # Même périmètre que `orders`, mais avec les associations nécessaires au
+  # calcul du dry-run préchargées (évite les N+1 sur `payment_method`,
+  # `payment_received?` et `customer.sms_enabled?`).
+  def preview_orders
+    orders.includes(:payment, :wallet_transactions, :customer)
   end
 
   def process(order)

--- a/app/views/admin/bake_days/confirm_cancel.html.slim
+++ b/app/views/admin/bake_days/confirm_cancel.html.slim
@@ -1,0 +1,65 @@
+- content_for :title, "Annuler la fournée du #{@bake_day.baked_on.strftime('%d/%m/%Y')}"
+- content_for :layout, "admin"
+- expected_date = @bake_day.baked_on.strftime("%d/%m/%Y")
+
+.mx-auto.max-w-2xl.space-y-6.px-4.py-6.sm:px-6
+  div
+    = link_to admin_bake_day_path(@bake_day), class: "inline-flex items-center gap-1 text-sm font-semibold text-slate-500 hover:text-slate-700"
+      | ← Retour à la fournée
+    h1.mt-2.text-2xl.font-bold.text-slate-900
+      | Annuler la fournée du #{expected_date}
+    p.mt-1.text-sm.text-slate-500
+      | Cette action est irréversible : elle rembourse les clients (carte ou portefeuille) et les prévient par SMS.
+
+  - if @preview.any_orders?
+    .rounded-2xl.border-2.border-rose-200.bg-rose-50.p-5.sm:p-6
+      h2.text-sm.font-semibold.uppercase.tracking-wide.text-rose-700 Impact de l'annulation
+      dl.mt-4.grid.gap-4.sm:grid-cols-2
+        .rounded-xl.bg-white.p-4.shadow-sm
+          dt.text-sm.text-slate-500 Commandes impactées
+          dd.mt-1.text-2xl.font-bold.text-slate-900 = @preview.orders_count
+        .rounded-xl.bg-white.p-4.shadow-sm
+          dt.text-sm.text-slate-500 Montant total à rembourser
+          dd.mt-1.text-2xl.font-bold.text-rose-700
+            = number_to_currency(@preview.refund_euros, unit: "€", separator: ",", delimiter: " ", format: "%n %u")
+        .rounded-xl.bg-white.p-4.shadow-sm
+          dt.text-sm.text-slate-500 SMS envoyés aux clients
+          dd.mt-1.text-2xl.font-bold.text-slate-900 = @preview.sms_count
+
+      .mt-4.rounded-xl.bg-white.p-4.shadow-sm
+        p.text-sm.font-semibold.text-slate-700 Ventilation par mode
+        dl.mt-3.space-y-2.text-sm
+          .flex.items-center.justify-between
+            dt.text-slate-600
+              | Carte (Stripe)
+              span.ml-1.text-slate-400 = "· #{@preview.stripe_count} commande#{'s' if @preview.stripe_count > 1}"
+            dd.font-semibold.text-slate-900
+              = number_to_currency(@preview.stripe_euros, unit: "€", separator: ",", delimiter: " ", format: "%n %u")
+          .flex.items-center.justify-between
+            dt.text-slate-600
+              | Portefeuille
+              span.ml-1.text-slate-400 = "· #{@preview.wallet_count} commande#{'s' if @preview.wallet_count > 1}"
+            dd.font-semibold.text-slate-900
+              = number_to_currency(@preview.wallet_euros, unit: "€", separator: ",", delimiter: " ", format: "%n %u")
+          .flex.items-center.justify-between
+            dt.text-slate-600
+              | Non encaissé en ligne
+              span.ml-1.text-slate-400 = "· #{@preview.non_online_count} commande#{'s' if @preview.non_online_count > 1}"
+            dd.font-semibold.text-slate-900 —
+        - if @preview.manual_refund_count.positive?
+          p.mt-3.text-xs.text-amber-700
+            | Dont #{@preview.manual_refund_count} payée#{'s' if @preview.manual_refund_count > 1} hors-ligne : remboursement à effectuer à la main.
+
+    = form_with url: cancel_admin_bake_day_path(@bake_day), method: :post, data: { controller: "cancel-guard", "cancel-guard-expected-value": expected_date } do |form|
+      .mt-6.rounded-2xl.border.border-slate-200.bg-white.p-5.shadow-sm.sm:p-6
+        label.block.text-sm.font-semibold.text-slate-700 for="cancel-guard-input"
+          | Pour confirmer, retapez la date de la fournée (#{expected_date})
+        = text_field_tag :confirmation, nil, id: "cancel-guard-input", autocomplete: "off", placeholder: "JJ/MM/AAAA", class: "mt-2 block w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900 focus:border-rose-500 focus:ring-rose-500", data: { "cancel-guard-target": "input", action: "input->cancel-guard#validate" }
+        .mt-5.flex.flex-wrap.items-center.gap-3
+          button.inline-flex.items-center.justify-center.gap-2.rounded-full.bg-rose-600.px-5.py-2.5.text-sm.font-semibold.text-white.hover:bg-rose-700.disabled:cursor-not-allowed.disabled:opacity-40 type="submit" data-cancel-guard-target="submit"
+            | Annuler définitivement la fournée
+          = link_to "Ne rien faire", admin_bake_day_path(@bake_day), class: "inline-flex items-center justify-center gap-2 rounded-full border border-slate-300 px-5 py-2.5 text-sm font-semibold text-slate-700 hover:bg-slate-50"
+  - else
+    .rounded-2xl.border.border-slate-200.bg-white.p-6.text-center.shadow-sm
+      p.text-slate-600 Aucune commande annulable pour cette fournée.
+      = link_to "Retour à la fournée", admin_bake_day_path(@bake_day), class: "mt-4 inline-flex items-center justify-center gap-2 rounded-full border border-slate-300 px-5 py-2.5 text-sm font-semibold text-slate-700 hover:bg-slate-50"

--- a/app/views/admin/bake_days/show.html.slim
+++ b/app/views/admin/bake_days/show.html.slim
@@ -27,7 +27,7 @@
         = link_to "Modifier", edit_admin_bake_day_path(@bake_day), class: "inline-flex items-center justify-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-white whitespace-nowrap"
         button.inline-flex.items-center.justify-center.gap-2.rounded-full.border.border-slate-300.px-4.py-2.text-sm.font-semibold.text-slate-700.hover:bg-white.whitespace-nowrap type="button" data-action="dashboard-export#print"
           | Imprimer la feuille
-        = button_to "Annuler la fournée", cancel_admin_bake_day_path(@bake_day), method: :post, form: { data: { turbo_confirm: "Annuler cette fournée ? Toutes les commandes payées seront remboursées (carte ou portefeuille) et les clients prévenus par SMS. Action irréversible." } }, class: "inline-flex items-center justify-center gap-2 rounded-full border border-amber-300 px-4 py-2 text-sm font-semibold text-amber-700 hover:bg-amber-50 whitespace-nowrap"
+        = link_to "Annuler la fournée", confirm_cancel_admin_bake_day_path(@bake_day), class: "inline-flex items-center justify-center gap-2 rounded-full border border-amber-300 px-4 py-2 text-sm font-semibold text-amber-700 hover:bg-amber-50 whitespace-nowrap"
         = button_to "Supprimer", admin_bake_day_path(@bake_day), method: :delete, form: { data: { turbo_confirm: "Supprimer ce jour de cuisson ? Cette action est définitive." } }, class: "inline-flex items-center justify-center gap-2 rounded-full border border-rose-300 px-4 py-2 text-sm font-semibold text-rose-700 hover:bg-rose-50 whitespace-nowrap"
 
   .grid.gap-4.sm:gap-6.lg:grid-cols-3

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,6 +174,7 @@ Rails.application.routes.draw do
 
     resources :bake_days, only: [ :index, :show, :new, :create, :edit, :update, :destroy ] do
       member do
+        get :confirm_cancel
         post :cancel
       end
     end

--- a/spec/requests/admin/bake_days_spec.rb
+++ b/spec/requests/admin/bake_days_spec.rb
@@ -25,4 +25,75 @@ RSpec.describe "Admin::BakeDays", type: :request do
       expect(response.body).to include("Commandes par client")
     end
   end
+
+  # #133 : l'annulation d'une fournée passe par un écran de confirmation chiffré
+  # + une garde délibérée (retaper la date). Aucune annulation possible sans elle.
+  describe "confirmation renforcée avant annulation (#133)" do
+    let(:bake_day) { create(:bake_day, :cut_off_passed) }
+    let(:expected_date) { bake_day.baked_on.strftime("%d/%m/%Y") }
+
+    before { allow(SmsService).to receive(:send_bake_cancelled).and_return(true) }
+
+    def wallet_paid_order(total_cents: 1100)
+      customer = create(:customer)
+      wallet = create(:wallet, customer: customer, balance_cents: 0)
+      order = create(:order, :paid, customer: customer, bake_day: bake_day, total_cents: total_cents)
+      create(:wallet_transaction, :order_debit, wallet: wallet, order: order)
+      order
+    end
+
+    describe "GET /admin/bake_days/:id/confirm_cancel" do
+      it "affiche l'impact chiffré de l'annulation" do
+        wallet_paid_order(total_cents: 2000)
+
+        get confirm_cancel_admin_bake_day_path(bake_day)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Impact de l'annulation")
+        expect(response.body).to include("Portefeuille")
+        expect(response.body).to include(expected_date)
+      end
+    end
+
+    describe "POST /admin/bake_days/:id/cancel" do
+      it "refuse d'annuler sans la garde saisie (aucun remboursement, aucun SMS)" do
+        order = wallet_paid_order
+
+        expect(SmsService).not_to receive(:send_bake_cancelled)
+        post cancel_admin_bake_day_path(bake_day), params: { confirmation: "" }
+
+        expect(response).to redirect_to(confirm_cancel_admin_bake_day_path(bake_day))
+        expect(order.reload.status).to eq("paid")
+        expect(order.customer.wallet.reload.balance_cents).to eq(0)
+      end
+
+      it "refuse d'annuler avec une garde erronée" do
+        order = wallet_paid_order
+
+        post cancel_admin_bake_day_path(bake_day), params: { confirmation: "31/12/1999" }
+
+        expect(response).to redirect_to(confirm_cancel_admin_bake_day_path(bake_day))
+        expect(order.reload.status).to eq("paid")
+      end
+
+      it "annule la fournée quand la date exacte est retapée" do
+        order = wallet_paid_order
+
+        expect(SmsService).to receive(:send_bake_cancelled).with(order, refunded: true)
+        post cancel_admin_bake_day_path(bake_day), params: { confirmation: expected_date }
+
+        expect(response).to redirect_to(admin_bake_day_path(bake_day))
+        expect(order.reload.status).to eq("cancelled")
+        expect(order.customer.wallet.reload.balance_cents).to eq(1100)
+      end
+
+      it "reste neutre s'il n'y a plus aucune commande annulable" do
+        post cancel_admin_bake_day_path(bake_day), params: { confirmation: expected_date }
+
+        expect(response).to redirect_to(admin_bake_day_path(bake_day))
+        follow_redirect!
+        expect(response.body).to include("Aucune commande à annuler")
+      end
+    end
+  end
 end

--- a/spec/services/bake_day_cancellation_service_spec.rb
+++ b/spec/services/bake_day_cancellation_service_spec.rb
@@ -190,4 +190,52 @@ RSpec.describe BakeDayCancellationService do
       end
     end
   end
+
+  describe "#preview" do
+    it "counts every cohort and totals the online refund, without touching the DB" do
+      stripe = stripe_order(total_cents: 1000)
+      wallet_order(total_cents: 2000, balance_cents: 0)
+      manual = create(:order, :paid, :payment_paid, bake_day: bake_day)
+      create(:order, :unpaid, bake_day: bake_day)
+
+      preview = described_class.new(bake_day).preview
+
+      expect(preview.orders_count).to eq(4)
+      expect(preview.stripe_count).to eq(1)
+      expect(preview.stripe_cents).to eq(1000)
+      expect(preview.wallet_count).to eq(1)
+      expect(preview.wallet_cents).to eq(2000)
+      expect(preview.manual_refund_count).to eq(1)
+      expect(preview.unpaid_count).to eq(1)
+      expect(preview.refund_cents).to eq(3000)
+      expect(preview.non_online_count).to eq(2)
+
+      # Aucune mutation : la commande Stripe reste payée, aucun remboursement émis.
+      expect(Stripe::Refund).not_to receive(:create)
+      expect(stripe.reload.status).to eq("paid")
+      expect(manual.reload.status).to eq("paid")
+    end
+
+    it "counts SMS only for customers who accept them" do
+      wallet_order(balance_cents: 0)
+      silent_customer = create(:customer, :with_sms_disabled)
+      create(:order, :unpaid, customer: silent_customer, bake_day: bake_day)
+
+      preview = described_class.new(bake_day).preview
+
+      expect(preview.orders_count).to eq(2)
+      expect(preview.sms_count).to eq(1)
+    end
+
+    it "ignores already-finished orders and reports nothing to do" do
+      create(:order, :picked_up, bake_day: bake_day)
+      create(:order, :cancelled, bake_day: bake_day)
+
+      preview = described_class.new(bake_day).preview
+
+      expect(preview.orders_count).to eq(0)
+      expect(preview.any_orders?).to be(false)
+      expect(preview.refund_cents).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
Closes #133

## Résumé

L'annulation d'une fournée (remboursements Stripe irréversibles + SMS à tous les clients) ne pouvait être déclenchée que par une boîte native « OK/Annuler » — trop faible pour une action de cette gravité (cf. l'incident du 03/07/2026). Cette PR remplace ce garde-fou par une **confirmation renforcée chiffrée + double garde**.

**Ce qui change :**

- **Aperçu (dry-run) dans le service** — `BakeDayCancellationService#preview` compte l'impact **sans rien écrire** en base et renvoie une struct `Preview` : nombre de commandes, montant total à rembourser (€), ventilation par mode (Stripe / portefeuille / non encaissé) et nombre de SMS. Il réutilise **exactement la même source** que `#call` : `PROCESSABLE_STATUSES` + `Order#payment_method` → aucun écart possible entre l'aperçu et l'exécution réelle.
- **Écran de confirmation dédié** — `GET /admin/bake_days/:id/confirm_cancel` (nouvelle vue Slim, FR) affiche l'impact chiffré. Le bouton « Annuler la fournée » de la page fournée pointe désormais vers cet écran (plus de POST direct).
- **Double garde** — le bouton de confirmation final reste **désactivé** tant que l'admin n'a pas retapé la **date exacte de la fournée** (`JJ/MM/AAAA`). Garde côté client via un petit contrôleur Stimulus (`cancel_guard`) **et** garde **serveur** dans `#cancel` (`cancellation_confirmed?`) : un POST sans la bonne date ne rembourse rien et n'envoie aucun SMS.
- **Idempotence** — si la fournée n'a plus aucune commande annulable, `#cancel` renvoie un message neutre (pas d'erreur 500, pas de SMS parasite).
- Fermer/quitter l'écran (« Ne rien faire ») ne déclenche **aucune** action serveur.

La logique de remboursement (`#cancel_and_refund`) est **inchangée**.

## Testé

- **Spec service** (`spec/services/bake_day_cancellation_service_spec.rb`) — `#preview` : compteurs Stripe/portefeuille/manuel/non-payé + total €, comptage des SMS (uniquement clients qui les acceptent), exclusion des commandes déjà finalisées, et **absence de mutation** de la DB.
- **Spec request** (`spec/requests/admin/bake_days_spec.rb`) — l'écran de confirmation affiche les chiffres ; `POST cancel` **sans** garde ou avec une date erronée est refusé (aucun remboursement, aucun SMS, redirection vers l'écran) ; **avec** la date exacte, l'annulation s'exécute ; cas idempotent « aucune commande » → message neutre.
- `bundle exec rspec` : **vert** sur tout le périmètre touché (25/25 sur les 2 fichiers). La suite complète a **1 échec préexistant sur `main`** sans aucun lien avec cette PR (`spec/models/email_message_spec.rb` — `EmailMessage.kinds` inclut `ready`).
- `bin/rubocop` : **vert** (fichiers Ruby modifiés). `bin/brakeman --no-pager` : **0 alerte de sécurité**.
- Capture d'écran ci-dessous : rendu réel de l'écran authentifié via un test système Capybara (login admin), avec un jeu de données mixte (1 Stripe + 3 portefeuille).

## NON testé

- **Garde côté client (Stimulus)** : le désactivage/activage temps réel du bouton n'est pas couvert par un test JS automatisé (pas de suite JS dans le projet). La garde **serveur** — la vraie barrière de sécurité — est, elle, testée. Le rendu de l'écran est vérifié par capture.
- Le rubocop ne couvre pas le fichier `.js` (exclu de la config du projet).
- Pas de vérification sur l'admin de **production** déployé (règle : ne jamais confirmer une vraie fournée de prod). À valider par Michael après merge/déploiement Hatchbox.

## 📸 Aperçu

![Écran de confirmation renforcée avant annulation de fournée](https://github.com/les4sources/tranchesdevie2/raw/agent-screenshots/screenshots/20260704-032908-cran-de-confirmation-renforce-avant-annulation-d.png)
