### PR TITLE
Checkout : prénom vide → 422 propre au lieu de RecordInvalid (#135)

### DIFF
--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,0 +1,9 @@
+{
+  "setup": [
+    "bundle install"
+  ],
+  "teardown": [],
+  "run": [
+    "bin/dev"
+  ]
+}

--- a/Plans/reflective-plotting-storm.md
+++ b/Plans/reflective-plotting-storm.md
@@ -1,0 +1,101 @@
+# Plan — Connexion client par SMS **ou** e-mail, à parité
+
+## Context
+
+Aujourd'hui le login client est **entièrement ancré sur le numéro de téléphone** :
+
+- `Customers::SessionsController#create` normalise/valide un GSM, puis `Customer.find_or_create_by(phone_e164:)` (sessions_controller.rb:8-22).
+- L'OTP est stocké dans `PhoneVerification`, dont la colonne `phone_e164` est **NOT NULL** et validée `presence` (phone_verification.rb:6). Le code, le TTL (15 min), le compteur de tentatives (5) et le cooldown (20 s) sont tous indexés par téléphone.
+- L'e-mail n'est qu'un **secours** : il ne marche que pour un client existant ayant déjà une adresse au dossier (`allow_email_entry: false` au login), et il est présenté comme un lien discret « Tu ne reçois pas le SMS ? » sous le champ OTP (new.html.erb:75-83).
+- En base, **`email` n'est pas unique** (customer.rb:13 — seul `phone_e164` l'est).
+
+Problème réel : des clients ne reçoivent pas le SMS et restent bloqués. On veut que le client puisse se connecter **soit par SMS, soit par e-mail, au même niveau**, avec une UX impeccable.
+
+**Décisions prises avec Michael :**
+1. **Un seul champ « Téléphone ou e-mail »** : on détecte le type saisi et on envoie le code par le bon canal. Parité totale (pas de canal « principal »).
+2. **E-mail inconnu → saisir + enregistrer** : si le client choisit/saisit un e-mail qu'on ne connaît pas, on envoie le code à cette adresse et on l'**enregistre sur le compte** (même pattern que le checkout).
+
+**Défauts d'implémentation retenus (à valider) :**
+- L'e-mail devient l'**identité alternative** : on normalise en minuscules et on ajoute une unicité applicative (insensible à la casse). L'index DB unique n'est posé qu'**après audit des doublons existants** (cf. § Données).
+- Un client qui se connecte par e-mail **sans GSM** est autorisé (conséquence de la parité). Il ne recevra pas les SMS « commande prête » — voir § Conséquences.
+
+## Design — un OTP « agnostique au canal »
+
+Le cœur du changement : la vérification OTP ne doit plus être rattachée *uniquement* au téléphone, mais à un **identifiant** qui est soit un GSM, soit un e-mail.
+
+**Classification de l'identifiant (nouveau helper, dans `OtpService`)** :
+- contient `@` / matche `URI::MailTo::EMAIL_REGEXP` → **e-mail** (canal e-mail) ;
+- sinon → on tente la normalisation GSM existante (`normalize_phone` → E.164) → **téléphone** (canal SMS) ;
+- ni l'un ni l'autre → erreur « Entre un numéro de GSM ou une adresse e-mail valide ».
+
+## Changements par zone
+
+### 1. Modèle de vérification — `PhoneVerification` (+ migration)
+Fichiers : `app/models/phone_verification.rb`, nouvelle migration, `db/schema.rb`.
+- Migration : ajouter `email:string` (nullable, indexé) ; rendre `phone_e164` **nullable**.
+- Validation : exiger **au moins un** des deux (`phone_e164` ou `email`) présent, plus le format e-mail si présent.
+- Généraliser les helpers de classe à une **clé de canal** plutôt qu'au seul téléphone :
+  - `for_identifier(phone: nil, email: nil)` (remplace/complète `for_phone`),
+  - `create_for(phone: nil, email: nil)` (remplace/complète `create_for_phone`),
+  - `can_send_new?(phone: nil, email: nil)` (cooldown par identifiant).
+- Garder `for_phone`/`create_for_phone` comme alias fins pour limiter le blast-radius, ou migrer tous les appelants (peu nombreux : `OtpService`).
+- (Cosmétique, hors scope) le nom `PhoneVerification` reste — renommer serait du churn pur.
+
+### 2. Service OTP — `app/services/otp_service.rb`
+- Nouvelle API agnostique : `send_code(identifier:, allow_signup: true)` qui classe l'identifiant, crée/réutilise une vérification **par identifiant** (réutilise un code actif s'il existe, comme aujourd'hui pour faire matcher SMS et e-mail), et envoie via le bon canal :
+  - **téléphone** → `send_otp_sms` (inchangé).
+  - **e-mail** → `AuthMailer.otp(email, code, customer:)`. Résout le client par e-mail (`find_by` insensible casse). L'adresse saisie EST l'adresse d'envoi (cas « saisir + enregistrer »).
+- `verify_code(identifier:, code:)` : look-up par identifiant (phone OU email), même logique d'expiration/tentatives/destruction qu'aujourd'hui.
+- Conserver `send_otp`/`verify_otp` en **façades** déléguant à la nouvelle API pour ne pas casser les appelants existants (checkout, specs, helpers de test).
+- Réutiliser : `URI::MailTo::EMAIL_REGEXP` (déjà utilisé otp_service.rb:66), `AuthMailer.otp` (auth_mailer.rb), `send_otp_sms` (otp_service.rb:118).
+
+### 3. Contrôleur de session — `app/controllers/customers/sessions_controller.rb`
+- Accepter un seul champ `params[:identifier]` (rétro-compat : retomber sur `params[:phone_e164]` si présent).
+- Étape « envoi » : `OtpService.send_code(identifier:)` ; mémoriser l'identifiant en session (`session[:login_identifier]`) au lieu de `phone_e164` seul.
+- Étape « vérification » : `OtpService.verify_code(identifier:, code:)`. Sur succès, **résoudre le client** :
+  - identifiant = GSM → `Customer.find_or_create_by(phone_e164:)` (comportement actuel).
+  - identifiant = e-mail → `Customer.find_by("lower(email)=?", email)` ; sinon créer un client avec cet e-mail. Si l'identifiant initial était un GSM mais qu'un e-mail a été saisi en cours de route (cas « pas d'e-mail au dossier »), **enregistrer l'e-mail** sur le client résolu.
+  - Doublons d'e-mail hérités : `.order(:created_at).first` + `Rails.logger.warn` (défensif — voir § Données).
+- Garder `normalize_phone` / `valid_e164?` (réutilisés par le helper de classification).
+- **Caveat `first_name` (préexistant)** : `Customer` valide `first_name` en présence (customer.rb:12), donc `find_or_create_by` crée un enregistrement **non sauvé** (id nil) pour un tout nouveau compte sans prénom — déjà vrai aujourd'hui pour le GSM. À gérer : soit traiter le cas (rediriger vers complétion de profil), soit confirmer que les nouveaux comptes passent toujours par le checkout (qui collecte le prénom). À vérifier en test.
+
+### 4. Vue de connexion — `app/views/customers/sessions/new.html.erb`
+- Un seul champ **« Téléphone ou e-mail »** + un bouton unique **« Recevoir mon code »** (fin du modèle « SMS d'abord, e-mail en secours »).
+- Indice dynamique du canal détecté (« 📱 par SMS » / « ✉️ par e-mail ») sous le champ pendant la saisie.
+- Réécrire l'encart bleu d'info (actuellement 100 % « numéro de téléphone ») pour refléter les deux canaux.
+- Conserver le style existant (carte blanche `bg-white rounded-lg shadow-sm border`, inputs `rounded-md`, boutons). Étape OTP (champ 6 chiffres + « Vérifier le code ») inchangée dans sa structure.
+
+### 5. Stimulus — `app/javascript/controllers/`
+- `customer_session_controller.js` : un seul `sendCode()` (remplace `sendOTP`/`sendOTPByEmail`), POST `identifier` (+ `otp_code` à la vérif). Conserver le pattern fetch + DOMParser existant ; afficher le canal détecté.
+- **`phone_input_controller.js` (point UX critique)** : aujourd'hui il force le format E.164 et préfixe `+32` à la saisie — il **massacrerait un e-mail**. Le rendre conditionnel : dès que la valeur ressemble à un e-mail (présence d'une lettre/`@`), désactiver le formatage et masquer le drapeau ; ne formater que quand ça ressemble à un numéro.
+
+### 6. Checkout — `app/controllers/checkout_controller.rb`
+- `verify_phone`/`verify_otp` partagent `OtpService`. Les façades (§2) gardent le checkout fonctionnel sans changement immédiat.
+- **Recommandé (cohérence UX)** : aligner le checkout sur le même champ unique « téléphone ou e-mail ». Peut être fait dans la foulée ou en suivi — à décider. Par défaut je l'inclus pour ne pas laisser deux UX divergentes.
+
+### 7. Rate limiting — `config/initializers/rack_attack.rb`
+- Aujourd'hui seul `/checkout/verify_phone` est throttlé ; `/connexion` ne l'est pas. Ajouter des throttles sur `POST /connexion` par **identifiant** et par **IP** (mêmes seuils que checkout : 5/60s par cible, 8/60s par IP).
+
+## Données — unicité e-mail & doublons hérités
+- Ajouter à `Customer` : normalisation `before_validation` (`email = email.strip.downcase` si présent) + `validates :email, uniqueness: { case_sensitive: false, allow_nil: true }`.
+- **Avant** de poser un index unique DB : auditer les doublons existants
+  `Customer.where.not(email: [nil, ""]).group("lower(email)").having("count(*) > 1")`.
+  - Aucun doublon → ajouter l'index unique (insensible casse).
+  - Doublons présents → ne pas poser l'index dur ; rester sur la résolution défensive (`order(:created_at).first` + warn) et remonter la liste à Michael pour dédoublonnage manuel.
+
+## Conséquences à connaître
+- **Compte e-mail sans GSM** : pas de SMS « commande prête ». Les notifications passent déjà par `sms_enabled?` (customer.rb:19, vérifie présence du GSM) donc pas de crash ; mais ce client ne sera pas prévenu par SMS. Suivi possible : bascule e-mail pour la notif « prête » quand le GSM manque (hors scope de ce plan).
+
+## Vérification
+1. **Tests RSpec** (le suite tourne via `bundle exec rspec`) :
+   - Nouveau `spec/requests/customers/sessions_spec.rb` : login par GSM (SMS), par e-mail (client existant avec e-mail), par e-mail inconnu → création + sauvegarde, GSM connu sans e-mail → saisie e-mail → envoi + sauvegarde, identifiant invalide, cooldown, e-mail dupliqué (résolution défensive).
+   - Adapter `spec/services/otp_service_spec.rb` à la nouvelle API (garder la couverture e-mail existante via les façades) ; ajouter la couverture canal SMS (stub `HTTParty.post` comme dans `spec/services/sms_service_spec.rb:9-20`).
+   - Vérifier que les helpers `authenticate_customer` de `spec/requests/customers/account_spec.rb:6-12` et `calendar_spec.rb` (qui stubbent `OtpService.send_otp`/`verify_otp`) passent toujours grâce aux façades.
+   - `spec/mailers/auth_mailer_spec.rb` reste valide (envoi OTP inchangé).
+2. **Vérification visuelle réelle** (obligatoire, skill **Interceptor**) : ouvrir `/connexion`, tester (a) saisie GSM → code SMS (loggé en dev), (b) saisie e-mail → code e-mail (letter_opener en dev), (c) e-mail inconnu → champ + sauvegarde, sur desktop **et** mobile. Confirmer qu'aucun `+32` ne se colle quand on tape un e-mail.
+3. **Garde-fous** : `bin/rubocop` + `bin/brakeman --no-pager` (CI les exige sur push `main`).
+
+## Hors scope / suivis
+- Renommage `PhoneVerification` → nom générique (cosmétique).
+- Notification « commande prête » par e-mail pour les comptes sans GSM.
+- Refonte complète de l'UX checkout au-delà de l'alignement du champ unique.

--- a/Plans/synchronous-zooming-feigenbaum.md
+++ b/Plans/synchronous-zooming-feigenbaum.md
@@ -1,0 +1,132 @@
+# Plan — Réparer les confirmations d'actions destructives (bug `data-confirm` mort)
+
+## Context
+
+Ce matin (03/07/2026), les boulangers ont cliqué « Annuler la fournée » **sans aucune boîte de
+confirmation**. L'action a déclenché des remboursements Stripe irréversibles + un SMS à tous les
+clients, puis a dû être réparée à la main.
+
+Cause racine identifiée : le bouton **avait** une confirmation, écrite en `data: { confirm: … }`
+(syntaxe **Rails UJS**). Or l'app est en **Turbo/Hotwire** et **rails-ujs n'est chargé nulle part**
+(vérifié : aucune trace dans `app/javascript` ni `config/importmap.rb`). En Turbo, seul
+`data-turbo-confirm` est honoré ; `data-confirm` est donc **silencieusement ignoré** → l'action part
+au premier clic.
+
+Ce n'est pas isolé : **6 actions destructives** de l'app portent le même bug latent (dont le
+remboursement d'une commande — financier). Les autres actions destructives utilisent déjà
+correctement `turbo_confirm` (8 occurrences), ce qui prouve que le mécanisme Turbo est bien actif.
+
+Résultat visé : **toute action destructive redemande confirmation**. Deux niveaux :
+- **Immédiat (ce plan)** : réparer les 6 `data-confirm` cassés → `turbo_confirm`. Rebouche le trou
+  aujourd'hui.
+- **Renforcé (issue nocturne)** : pour l'annulation de fournée spécifiquement, une confirmation qui
+  montre l'impact chiffré + double garde (rédigée plus bas, à créer après approbation).
+
+Décision déjà prise par Michael : « Correctif now + issue » (via AskUserQuestion).
+
+---
+
+## Part A — Correctif immédiat (à exécuter après approbation)
+
+Bug : `data: { confirm: … }` (UJS, mort) → `data: { turbo_confirm: … }` (Turbo, actif).
+
+**Deux patterns selon le helper :**
+
+1. **`button_to`** — le `turbo_confirm` va sur le **formulaire** via `form:` (convention déjà
+   utilisée dans `app/views/admin/customers/show.html.erb`) :
+   ```
+   button_to "…", path, method: :delete, form: { data: { turbo_confirm: "…" } }
+   ```
+
+2. **`form_with … do |f|` + `f.submit`** — le `turbo_confirm` va sur le **`form_with`**, pas sur le
+   submit (Turbo lit l'attribut au niveau du formulaire) :
+   ```erb
+   <%= form_with url: …, method: :patch, data: { turbo_confirm: "…" } do |f| %>
+     <%= f.submit "…" %>
+   <% end %>
+   ```
+
+**Fichiers / occurrences :**
+
+| Fichier | Action | Helper | Sévérité |
+|---|---|---|---|
+| `app/views/admin/bake_days/show.html.slim:30` | Annuler la fournée | `button_to` | 🔴 **déjà corrigé** cette session |
+| `app/views/admin/bake_days/show.html.slim:31` | Supprimer la fournée | `button_to` | 🔴 **déjà corrigé** cette session |
+| `app/views/admin/orders/show.html.erb:139` | Rembourser intégralement | `form_with`+`f.submit` | 🔴 financier |
+| `app/views/admin/orders/show.html.erb:107` | Marquer comme payée | `form_with`+`f.submit` | 🟠 |
+| `app/views/admin/orders/show.html.erb:116` | Envoyer SMS « prête » | `form_with`+`f.submit` | 🟠 envoi SMS |
+| `app/views/admin/orders/show.html.erb:131` | Marquer non récupérée | `form_with`+`f.submit` | 🟡 |
+| `app/views/admin/products/show.html.slim:84` | Supprimer un variant | `button_to` | 🟠 |
+| `app/views/cart/show.html.erb:123` | Retirer un article du panier | `button_to` | 🟢 client, faible enjeu |
+
+> Les deux lignes `bake_days/show` sont **déjà** passées en `form: { data: { turbo_confirm: … } }`
+> pendant cette session (avec un texte de confirmation « suppression définitive » enrichi pour le
+> bouton Supprimer). Reste à traiter les 6 autres.
+
+**Commit + déploiement :** commit sur `main` → auto-deploy Hatchbox. Message libre FR/EN (convention
+repo), ex. `fix: confirmations d'actions destructives (data-confirm → turbo_confirm, rails-ujs absent)`.
+
+---
+
+## Part B — Issue nocturne : confirmation renforcée de l'annulation de fournée
+
+À créer via `gh issue create` (repo `tranches-de-vie`) **après approbation**, puis poser
+`agent:ready` (issue auto-suffisante ci-dessous). Périmètre volontairement limité à l'annulation de
+fournée — l'action la plus dangereuse.
+
+**Titre :** Confirmation renforcée avant annulation d'une fournée (impact chiffré + double garde)
+
+**Contexte / problème :** L'annulation d'une fournée déclenche des remboursements Stripe
+**irréversibles** + un SMS à tous les clients concernés. Une simple confirmation native (« OK »)
+reste à un clic du drame et ne montre pas ce qui va se passer. Un incident réel a eu lieu le
+03/07/2026. Le correctif `turbo_confirm` (Part A) rebouche le trou immédiat mais reste faible pour
+une action de cette gravité.
+
+**Critères d'acceptation (atomiques) :**
+- [ ] Cliquer « Annuler la fournée » ouvre un écran/modale de confirmation dédié (pas la boîte
+      native), affichant : nombre de commandes impactées, montant total à rembourser (€), ventilation
+      par mode (carte Stripe / portefeuille / non encaissé), et nombre de SMS qui seront envoyés.
+- [ ] Le bouton de confirmation final est **désactivé** tant que l'admin n'a pas saisi une garde
+      explicite (ex. retaper la date de la fournée `JJ/MM/AAAA`, ou le mot `ANNULER`).
+- [ ] Les chiffres affichés proviennent du même périmètre que `BakeDayCancellationService`
+      (statuts `PROCESSABLE_STATUSES = paid, ready, unpaid, planned`) — pas d'écart entre l'aperçu et
+      l'exécution.
+- [ ] Annuler/fermer la modale ne déclenche **aucune** action serveur.
+- [ ] Garde serveur idempotente : si la fournée n'a plus aucune commande annulable, l'action ne
+      rembourse rien et affiche un message neutre (pas d'erreur 500).
+
+**Périmètre (in/out) :**
+- IN : la seule action « Annuler la fournée » (`Admin::BakeDaysController#cancel` +
+  `app/views/admin/bake_days/show.html.slim`), un contrôleur/vue d'aperçu, éventuellement une méthode
+  d'aperçu sur `BakeDayCancellationService` (dry-run comptant sans écrire).
+- OUT : les autres confirmations (traitées en Part A), la logique de remboursement elle-même, la
+  re-collecte des paiements Stripe.
+
+**Zones de code concernées :**
+- `app/controllers/admin/bake_days_controller.rb` (`#cancel`, + éventuelle action `#confirm_cancel`)
+- `app/services/bake_day_cancellation_service.rb` (ajouter un aperçu/dry-run réutilisant
+  `PROCESSABLE_STATUSES` et `order.payment_method`)
+- `app/views/admin/bake_days/show.html.slim` (bouton) + nouvelle vue d'aperçu
+- Route `post :cancel` (+ éventuellement `get :confirm_cancel`) dans `config/routes.rb`
+
+**Stratégie de test :**
+- Spec service : l'aperçu renvoie les bons compteurs (Stripe/wallet/non payé) sans muter la DB.
+- Spec request : `GET confirm_cancel` affiche les chiffres ; `POST cancel` sans la garde saisie est
+  refusé ; avec la garde, exécute.
+- Vérif manuelle Interceptor sur le site déployé (admin protégé) : parcours complet.
+
+**Definition of Done :** critères cochés, specs vertes (`bundle exec rspec`), rubocop OK, déployé et
+vérifié sur l'admin réel via Interceptor, aucun remboursement possible sans double confirmation.
+
+---
+
+## Vérification (Part A, après exécution)
+
+1. **Statique** : `grep -rn "data: { confirm:" app/views` (via built-in Grep, pas RTK) ne renvoie
+   plus rien ; `grep -rn "turbo_confirm" app/views` couvre bien les 8 actions destructives.
+2. **Déploiement** : confirmer que Hatchbox a embarqué le dernier commit `main`.
+3. **Fonctionnel (Interceptor, mandatory)** : se connecter à l'admin déployé, ouvrir une fournée,
+   cliquer « Annuler la fournée » → **la boîte de confirmation Turbo doit apparaître** ; « Annuler »
+   dans la boîte ne doit déclencher aucune requête. Répéter le check sur « Rembourser » d'une
+   commande. Ne PAS confirmer réellement (action destructive) — vérifier seulement l'apparition du
+   dialogue et l'annulation propre.

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -1,4 +1,9 @@
 class CheckoutController < ApplicationController
+  # Prénom vide pour un nouveau client (erreur utilisateur, pas un incident) :
+  # levée AVANT le save! du client pour rendre un 422 ciblé plutôt que de laisser
+  # remonter un ActiveRecord::RecordInvalid muet vers Sentry (#135, TRANCHESDEVIE-G/H).
+  class BlankFirstNameError < StandardError; end
+
   before_action :ensure_cart_not_empty, except: [ :success ]
   before_action :ensure_bake_day_set, except: [ :success ]
   # Garde-fou (#68) : on resynchronise la ligne forfait Pizza party AVANT de
@@ -213,6 +218,11 @@ class CheckoutController < ApplicationController
       client_secret: payment_intent.client_secret,
       payment_intent_id: payment_intent.id
     }
+  rescue BlankFirstNameError
+    # Prénom vide (erreur utilisateur, pas un incident) : 422 ciblé sur le champ,
+    # jamais remonté en erreur Sentry. On log en warning pour l'observabilité.
+    Rails.logger.warn("[checkout] first_name_blank — #{checkout_sentry_context.inspect}")
+    render json: { error: "Merci d'indiquer ton prénom pour continuer.", field: "first_name" }, status: :unprocessable_entity
   rescue ActiveRecord::RecordInvalid => e
     # Échec d'enregistrement du client (first_name vide, e-mail en doublon, …) :
     # c'était un 500 muet. On le remonte avec les erreurs de validation et on
@@ -520,20 +530,27 @@ class CheckoutController < ApplicationController
       customer = Customer.find_or_initialize_by(phone_e164: phone_e164)
 
       if customer.new_record?
+        first_name = (json_params["first_name"] || params[:first_name] || session[:first_name]).to_s.strip
+        # Filet AVANT le save! : un prénom vide (ou seulement des espaces) est une
+        # erreur utilisateur — on la traite en 422 ciblé plutôt qu'en RecordInvalid
+        # muet remonté vers Sentry (#135).
+        raise BlankFirstNameError if first_name.blank?
+
         customer.assign_attributes(
-          first_name: json_params["first_name"] || params[:first_name] || session[:first_name],
-          last_name: json_params["last_name"] || params[:last_name] || session[:last_name],
-          email: json_params["email"] || params[:email] || session[:email]
+          first_name: first_name,
+          last_name: (json_params["last_name"] || params[:last_name] || session[:last_name]).to_s.strip.presence,
+          email: (json_params["email"] || params[:email] || session[:email]).to_s.strip.presence
         )
         customer.save!
       end
 
-      # Update customer info if provided
+      # Update customer info if provided (valeurs strippées : on n'écrase jamais
+      # avec des espaces seuls, cohérent avec la validation du prénom ci-dessus).
       if json_params["first_name"].present? || json_params["last_name"].present? || json_params["email"].present?
         customer.update(
-          first_name: json_params["first_name"] || customer.first_name,
-          last_name: json_params["last_name"] || customer.last_name,
-          email: json_params["email"] || customer.email
+          first_name: json_params["first_name"].to_s.strip.presence || customer.first_name,
+          last_name: json_params["last_name"].to_s.strip.presence || customer.last_name,
+          email: json_params["email"].to_s.strip.presence || customer.email
         ) if json_params.any?
       end
     end

--- a/app/views/checkout/new.html.erb
+++ b/app/views/checkout/new.html.erb
@@ -96,6 +96,7 @@
                   value: @customer.first_name,
                   class: "h-11 w-full rounded-md border border-flour-400 bg-white px-3 text-[15px] text-ink-900 shadow-[inset_0_1px_2px_rgba(74,60,38,0.06)] focus:border-sage-600 focus:outline-none focus:ring-[3px] focus:ring-[color:var(--focus-ring)]",
                   required: true %>
+              <p id="first-name-error" class="mt-1 hidden text-sm text-danger-700">Merci d'indiquer ton prénom pour continuer.</p>
             </div>
 
             <div>
@@ -361,12 +362,14 @@
       initializePaymentMethodState();
       handlePaymentMethodChange();
       setupGroupPurchaseToggle();
+      setupFirstNameGuard();
       initStripe();
     });
   } else {
     initializePaymentMethodState();
     handlePaymentMethodChange();
     setupGroupPurchaseToggle();
+    setupFirstNameGuard();
     initStripe();
   }
 
@@ -381,7 +384,46 @@
         stripeInitialized = false; // Reinitialiser le drapeau pour autoriser une nouvelle initialisation
         initializePaymentMethodState();
         handlePaymentMethodChange();
+        setupFirstNameGuard();
         initStripe();
+      }
+    });
+  }
+
+  // Prénom obligatoire (#135) : helpers de validation côté client. On considère
+  // un prénom composé uniquement d'espaces comme vide, comme le serveur (strip).
+  function isFirstNameBlank() {
+    const input = document.getElementById('customer_first_name');
+    return ((input?.value) || '').trim() === '';
+  }
+
+  function showFirstNameError() {
+    const msg = document.getElementById('first-name-error');
+    if (msg) msg.classList.remove('hidden');
+    const input = document.getElementById('customer_first_name');
+    if (input) input.focus();
+  }
+
+  function clearFirstNameError() {
+    const msg = document.getElementById('first-name-error');
+    if (msg) msg.classList.add('hidden');
+  }
+
+  // Quand le champ prénom devient valide, on (re)crée le PaymentIntent et on
+  // monte le Payment Element — car il n'a pas pu l'être au chargement si le
+  // prénom était vide. Idempotent tant que l'élément n'est pas déjà monté.
+  function setupFirstNameGuard() {
+    const input = document.getElementById('customer_first_name');
+    if (!input || input.dataset.guardBound === 'true') return;
+    input.dataset.guardBound = 'true';
+
+    input.addEventListener('input', () => {
+      if (!isFirstNameBlank()) clearFirstNameError();
+    });
+
+    input.addEventListener('blur', () => {
+      if (currentPaymentMethod === 'online' && !isFirstNameBlank() && !paymentElement) {
+        initializePayment();
       }
     });
   }
@@ -396,7 +438,17 @@
     if (currentPaymentMethod !== 'online') {
       return;
     }
-    
+
+    // Bloquer la création du PaymentIntent tant que le prénom est vide (ou
+    // seulement des espaces) : sinon le serveur tente de créer un client sans
+    // prénom et lève un RecordInvalid (#135). On affiche un message inline et on
+    // réessaiera quand le champ sera rempli (cf. setupFirstNameGuard).
+    if (isFirstNameBlank()) {
+      showFirstNameError();
+      return;
+    }
+    clearFirstNameError();
+
     fetch('<%= create_payment_intent_checkout_index_path %>', {
       method: 'POST',
       headers: {

--- a/spec/requests/checkout_first_name_spec.rb
+++ b/spec/requests/checkout_first_name_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+# #135 (Sentry TRANCHESDEVIE-G/H) : un nouveau client (OTP vérifié, sans compte)
+# ne doit jamais faire remonter un RecordInvalid muet quand le prénom arrive vide.
+# La création du PaymentIntent est refusée proprement (422 ciblé) et le parcours
+# nominal (prénom rempli) reste inchangé.
+RSpec.describe 'Checkout — prénom obligatoire pour un nouveau client', type: :request do
+  let(:bake_day) { create(:bake_day, :can_order) }
+  let!(:product) { create(:product, channel: 'store') }
+  let!(:variant) { create(:product_variant, product: product, channel: 'store', price_cents: 550) }
+  let(:new_phone) { '+32470111222' }
+
+  before do
+    allow(OrderNotificationService).to receive(:send_confirmation)
+
+    # OTP vérifié pour un numéro SANS compte client : le flux checkout laisse
+    # session[:customer_id] à nil tant que le prénom n'est pas fourni.
+    allow(OtpService).to receive(:send_otp).and_return({ success: true, channel: :sms })
+    allow(OtpService).to receive(:verify_otp).and_return({ success: true })
+
+    post '/cart/add', params: { product_variant_id: variant.id, bake_day_id: bake_day.id, quantity: 1 }
+    post '/checkout/verify_phone', params: { phone_e164: new_phone }
+    post '/checkout/verify_otp', params: { code: '123456' } # sans first_name : aucun client créé
+  end
+
+  def create_payment_intent(body)
+    post '/checkout/create_payment_intent', params: body.to_json,
+         headers: { 'CONTENT_TYPE' => 'application/json' }
+  end
+
+  it 'part bien d\'un nouveau client sans compte' do
+    expect(Customer.find_by(phone_e164: new_phone)).to be_nil
+  end
+
+  context 'quand le prénom est vide' do
+    it 'répond 422 ciblé, ne crée ni client ni commande, sans RecordInvalid' do
+      expect(Stripe::PaymentIntent).not_to receive(:create)
+
+      expect do
+        create_payment_intent(first_name: '')
+      end.to change(Order, :count).by(0).and change(Customer, :count).by(0)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      body = JSON.parse(response.body)
+      expect(body['field']).to eq('first_name')
+      expect(body['error']).to include('prénom')
+    end
+
+    it 'ne remonte aucune erreur (RecordInvalid) vers Sentry' do
+      expect_any_instance_of(CheckoutController)
+        .not_to receive(:capture_checkout_issue)
+
+      create_payment_intent(first_name: '')
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+
+  context 'quand le prénom ne contient que des espaces' do
+    it 'est traité comme vide (422 ciblé, aucun client créé)' do
+      expect do
+        create_payment_intent(first_name: '   ')
+      end.to change(Order, :count).by(0).and change(Customer, :count).by(0)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)['field']).to eq('first_name')
+    end
+  end
+
+  context 'quand le prénom est rempli (parcours nominal)' do
+    before { stub_stripe_payment_intent_create(amount: 550) }
+
+    it 'crée le client et réserve une commande pending avec un PaymentIntent' do
+      expect do
+        create_payment_intent(first_name: '  Léa  ')
+      end.to change { Order.where(status: :pending).count }.by(1)
+        .and change(Customer, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to include('client_secret', 'payment_intent_id')
+
+      customer = Customer.find_by(phone_e164: new_phone)
+      expect(customer.first_name).to eq('Léa') # espaces retirés
+    end
+  end
+end


### PR DESCRIPTION
Closes #135

Fixes TRANCHESDEVIE-G
Fixes TRANCHESDEVIE-H

## Résumé

Un nouveau client (OTP vérifié, sans compte) pouvait déclencher un `create_payment_intent` avec un `first_name` vide → `Customer#save!` levait `ActiveRecord::RecordInvalid` (« First name doit être rempli(e) »), remonté en **error** vers Sentry (17 événements côté G, 5 utilisateurs côté H).

### Côté serveur — `app/controllers/checkout_controller.rb`
- `find_or_create_customer` **strip** le prénom résolu (`json_params` → `params` → `session`) et lève un `CheckoutController::BlankFirstNameError` **AVANT** `save!` si le prénom est vide (ou uniquement des espaces).
- `create_payment_intent` rescue ce cas **avant** le rescue `RecordInvalid` et répond un **422 ciblé** `{ error: "Merci d'indiquer ton prénom pour continuer.", field: "first_name" }`, loggé en `warn` (jamais en erreur Sentry — c'est une erreur utilisateur, pas un incident). La validation modèle `Customer` reste en filet de sécurité.
- Le bloc « update customer info » strippe désormais aussi les valeurs (plus d'écrasement par des espaces seuls) — cohérent avec la validation du prénom.

### Côté client — `app/views/checkout/new.html.erb` (dans l'IIFE existante, aucun `let/const` top-level ajouté)
- Message inline `#first-name-error` sous le champ « Ton prénom * ».
- `initializePayment()` n'appelle plus `create_payment_intent` si le prénom est vide (`.trim()`), affiche le message et met le focus.
- `setupFirstNameGuard()` : au `blur`, (re)crée le PaymentIntent et monte le Payment Element dès que le prénom devient valide — nécessaire car l'init auto au chargement de page arrivait avant que le client saisisse son nom (cause racine du prénom vide). Nettoyage du message au `input`.

## Testé
- Nouvelle spec `spec/requests/checkout_first_name_spec.rb` (nouveau client OTP-vérifié sans compte) : **5 exemples verts**
  - prénom vide → 422 `field: first_name`, **aucun** `Order`/`Customer` créé, **aucun** appel `capture_checkout_issue` (donc pas d'erreur Sentry) ni `Stripe::PaymentIntent.create` ;
  - espaces seuls → même comportement ;
  - parcours nominal (`"  Léa  "`) → client créé (`first_name == "Léa"`, strippé), commande `pending` + PaymentIntent, 200 avec `client_secret`.
- `bundle exec rspec` : **602 verts / 1 échec pré-existant et sans rapport** — `spec/models/email_message_spec.rb:16` (enum `EmailMessage` expose désormais un kind `ready` non mis à jour dans cette spec). Vérifié : cet échec existe déjà sur `main` avant ce diff.
- `bin/rubocop app/controllers/checkout_controller.rb spec/requests/checkout_first_name_spec.rb` : **0 offense**.
- `bin/brakeman --no-pager` : **0 warning de sécurité**.

## NON testé
- **Comportement JS réel non exécuté automatiquement** (message inline, gating du bouton, re-init au `blur`) : le harness system-specs Capybara + stub Stripe.js n'est pas encore mergé (il vit dans la PR ouverte #126). Ces changements front ont été vérifiés par lecture, pas par navigateur.
- Reste dans l'IIFE (aucun `let/const` top-level hors IIFE) — vérifié par lecture.

## 📸 Aperçu
Capture d'écran **non produite** : la page `/checkout/new` est derrière le tunnel (session OTP vérifiée + panier + jour de cuisson) et l'état visible ajouté (`#first-name-error`) n'apparaît qu'après une validation JS. Sans le harness Capybara/stub-Stripe de la PR #126 (non mergée), un rendu headless fiable de cet état n'est pas reproductible ici. Le changement de rendu se limite à un `<p>` d'erreur conditionnel sous un champ existant.
