### PR TITLE
Checkout : gating bouton payer + validation_error en warning (#136)

### DIFF
--- a/app/views/checkout/new.html.erb
+++ b/app/views/checkout/new.html.erb
@@ -442,12 +442,8 @@
       
       // Monter l'element de paiement (operation synchrone)
       paymentElement.mount('#payment-element');
-      
-      // Activer le bouton lorsque l'element de paiement est monte
+
       const submitButton = document.getElementById('submit-payment');
-      if (submitButton) {
-        submitButton.disabled = false;
-      }
 
       // Retirer les anciens gestionnaires d'événements pour éviter les doublons
       const newSubmitButton = submitButton.cloneNode(true);
@@ -455,11 +451,38 @@
 
       const paymentIntentId = data.payment_intent_id;
       const successUrl = '<%= success_checkout_index_url %>';
+      const payLabel = 'Payer <%= number_to_currency(@total_cents / 100.0, unit: "€", separator: ",", delimiter: "") %>';
+      const paymentMessage = document.getElementById('payment-message');
+
+      // #136 : le bouton reste désactivé tant que le Payment Element n'est pas
+      // complet (moyen de paiement sélectionné/renseigné). Sans ce garde, un clic
+      // « payer » prématuré renvoyait une validation_error Stripe remontée en error.
+      let paymentComplete = false;
+      newSubmitButton.disabled = true;
+
+      paymentElement.on('change', (event) => {
+        paymentComplete = event.complete === true;
+        newSubmitButton.disabled = !paymentComplete;
+        // L'utilisateur corrige : on masque un éventuel message d'erreur précédent.
+        if (paymentMessage && paymentComplete) {
+          paymentMessage.classList.add('hidden');
+        }
+      });
 
       // Ajouter un gestionnaire de clic pour la soumission du paiement
       newSubmitButton.addEventListener('click', async (e) => {
         e.preventDefault();
-        
+
+        // Garde-fou : si l'élément n'est pas complet (bouton réactivé autrement),
+        // on court-circuite avec un message inline plutôt que d'appeler Stripe.
+        if (!paymentComplete) {
+          if (paymentMessage) {
+            paymentMessage.textContent = 'Veuillez sélectionner et compléter votre moyen de paiement.';
+            paymentMessage.classList.remove('hidden');
+          }
+          return;
+        }
+
         newSubmitButton.disabled = true;
         newSubmitButton.textContent = 'Traitement...';
 
@@ -477,9 +500,12 @@
         if (error) {
           // LE "moment du paiement" : échec de confirmPayment (carte/Bancontact/
           // 3DS/réseau). Purement client-side → invisible jusqu'ici. On le remonte.
+          // Une validation_error (élément incomplet) est une erreur utilisateur
+          // attendue → level warning, pas error, pour ne pas polluer le signal.
+          const isValidationError = error.type === 'validation_error';
           if (window.Sentry) {
             window.Sentry.captureMessage('[checkout] confirm_payment_failed', {
-              level: 'error',
+              level: isValidationError ? 'warning' : 'error',
               extra: {
                 step: 'confirmPayment',
                 message: error.message,
@@ -490,13 +516,12 @@
               }
             });
           }
-          const paymentMessage = document.getElementById('payment-message');
           if (paymentMessage) {
             paymentMessage.textContent = error.message;
             paymentMessage.classList.remove('hidden');
           }
           newSubmitButton.disabled = false;
-          newSubmitButton.textContent = 'Payer <%= number_to_currency(@total_cents / 100.0, unit: "€", separator: ",", delimiter: "") %>';
+          newSubmitButton.textContent = payLabel;
         }
       });
     })


### PR DESCRIPTION
Closes #136

Fixes TRANCHESDEVIE-J

## Résumé

4 utilisateurs distincts (02→06/07) ont cliqué « payer » **avant d'avoir complété leur moyen de paiement** dans le Payment Element Stripe. `stripe.confirmPayment` renvoyait alors une `validation_error` (`code: incomplete_payment_method`), remontée en **error** vers Sentry — alors que c'est un comportement utilisateur attendu, pas un incident.

Fix **100 % front**, dans l'IIFE existante de `app/views/checkout/new.html.erb` (aucun `let/const` top-level ajouté) :

- **Gating du bouton** : après le mount, le bouton « payer » reste **désactivé** ; il n'est activé que lorsque le Payment Element émet `change` avec `complete: true` (`paymentElement.on('change', …)`). Fini le clic prématuré.
- **Garde-fou** : si le bouton est cliqué alors que l'élément n'est pas complet (réactivation par un autre chemin), on **court-circuite** `confirmPayment` et on affiche un message inline au lieu d'appeler Stripe.
- **Message d'erreur** : le message Stripe (`error.message`, déjà localisé FR) s'affiche dans `#payment-message` près du bouton, et le bouton redevient cliquable. Le message se masque dès que l'utilisateur complète l'élément.
- **Bruit Sentry** — **choix retenu** : une `confirmPayment` de type `validation_error` est remontée en **warning** ; tous les autres types (`api_error`, `card_error`, `invalid_request_error`, …) restent en **error**. On garde une trace (utile pour mesurer la friction UX) sans polluer le signal des vraies pannes.

Le parcours nominal (élément complété → `confirmPayment` → redirection `/checkout/success`) est inchangé.

## Testé
- `bundle exec rspec spec/requests/checkout_spec.rb` (rend `/checkout/new`) : **11 verts** → le template compile et rend sans erreur ERB après modification du script inline.
- `bundle exec rspec` : **597 verts / 1 échec pré-existant et sans rapport** — `spec/models/email_message_spec.rb:16` (enum `EmailMessage` expose un kind `ready` non mis à jour dans cette spec ; échec déjà présent sur `main`, indépendant de ce diff qui ne touche qu'une vue).
- `bin/rubocop` : aucun fichier `.rb` modifié (0 offense).
- `bin/brakeman --no-pager` : **0 warning de sécurité**.

## NON testé
- **Comportement JS non exécuté automatiquement** : gating du bouton, écoute `change`, court-circuit, niveau Sentry `warning`. Le Payment Element est un iframe Stripe et le harness system-specs (Capybara + stub Stripe.js) n'est pas encore mergé (PR ouverte #126). Ces changements ont été vérifiés par lecture, pas par navigateur.
- Reste dans l'IIFE (aucun `let/const` top-level hors IIFE) — vérifié par lecture.

## 📸 Aperçu
Capture d'écran **non produite** : `/checkout/new` est derrière le tunnel (session OTP vérifiée + panier + jour de cuisson) et les états visibles (bouton désactivé, message inline) dépendent de l'iframe Stripe et d'interactions JS. Sans le harness Capybara/stub-Stripe de la PR #126 (non mergée), un rendu headless fiable n'est pas reproductible ici.
