### PR TITLE
Rapport payouts : rapports d'erreur non cachés + auto-debits couverts (#137)

### DIFF
--- a/app/services/stripe_payout_report_service.rb
+++ b/app/services/stripe_payout_report_service.rb
@@ -82,7 +82,14 @@ class StripePayoutReportService
   end
 
   def call
-    Rails.cache.fetch(cache_key, expires_in: CACHE_TTL) { build_report }
+    cached = Rails.cache.read(cache_key)
+    return cached if cached
+
+    report = build_report
+    # On ne met JAMAIS en cache un rapport d'erreur : une erreur Stripe transitoire
+    # ne doit pas geler la page pendant tout le TTL (le prochain appel réessaie).
+    Rails.cache.write(cache_key, report, expires_in: CACHE_TTL) if report.error.nil?
+    report
   end
 
   private

--- a/spec/services/stripe_payout_report_service_spec.rb
+++ b/spec/services/stripe_payout_report_service_spec.rb
@@ -61,6 +61,25 @@ RSpec.describe StripePayoutReportService do
 
       expect(Stripe::BalanceTransaction).not_to have_received(:list)
     end
+
+    # Un payout "auto-debit" (Stripe reprend de l'argent, ex. après remboursements)
+    # a un montant NÉGATIF. L'ancienne version crashait dessus via
+    # BalanceTransaction.list(payout:) ; désormais on lit `payout.amount` et on
+    # l'affiche comme une ligne dédiée à montant négatif, sans exception (#137).
+    it "affiche un versement auto-debit (montant négatif) sans lever d'exception" do
+      stub_payout_list([
+        stub_payout(id: "po_normal", amount: 9_750, arrival_date: Date.new(2026, 5, 10)),
+        stub_payout(id: "po_autodebit", amount: -3_200, arrival_date: Date.new(2026, 5, 18))
+      ])
+
+      report = described_class.new(start_date: start_date, end_date: end_date).call
+
+      expect(report.error).to be_nil
+      expect(report.payouts.map(&:stripe_id)).to eq(%w[po_normal po_autodebit])
+      expect(report.payouts.map(&:net_cents)).to eq([ 9_750, -3_200 ])
+      # Le total net tient compte de la reprise (auto-debit) : 9750 − 3200.
+      expect(report.total_net_paid_cents).to eq(6_550)
+    end
   end
 
   # --- Activité en ligne de la période (notre base) ---------------------------
@@ -167,6 +186,23 @@ RSpec.describe StripePayoutReportService do
       described_class.new(start_date: start_date, end_date: end_date).call
 
       expect(Stripe::Payout).to have_received(:list).once
+    end
+
+    it "ne met JAMAIS en cache un rapport d'erreur (le prochain appel réessaie)" do
+      memory_store = ActiveSupport::Cache::MemoryStore.new
+      allow(Rails).to receive(:cache).and_return(memory_store)
+
+      # 1er appel : Stripe échoue → rapport d'erreur, NON mis en cache.
+      allow(Stripe::Payout).to receive(:list).and_raise(Stripe::APIConnectionError.new("boom"))
+      first = described_class.new(start_date: start_date, end_date: end_date).call
+      expect(first.error).to be_present
+
+      # 2e appel : Stripe répond → le service NE sert PAS l'erreur cachée, il réessaie.
+      stub_payout_list([ stub_payout(id: "po_ok", amount: 9_750) ])
+      second = described_class.new(start_date: start_date, end_date: end_date).call
+
+      expect(second.error).to be_nil
+      expect(second.payouts.map(&:stripe_id)).to eq(%w[po_ok])
     end
   end
 end


### PR DESCRIPTION
Closes #137

Fixes TRANCHESDEVIE-E

## Résumé

L'issue vise le crash `Stripe::InvalidRequestError: The payout reconciliation report is not supported for auto-debits`, levé par `BalanceTransaction.list(payout:)` dans `build_payout_row`/`fetch_balance_transactions`.

**Constat en démarrant** : cet appel n'existe **plus**. Le commit `39ea5c2` (« Reporting versements : reconciliation niveau période — compte auto-debits ») a refactoré le service en **v2** : il ne détaille plus chaque versement via `BalanceTransaction.list`, il lit uniquement `payout.amount` depuis `Stripe::Payout.list`. Le crash décrit (lignes `:154-156` de l'issue) est donc déjà corrigé sur `main`.

Restaient toutefois **deux critères d'acceptation non satisfaits**, traités ici :

1. **Le cache ne mémorise plus un rapport d'erreur.** `call` faisait `Rails.cache.fetch(key) { build_report }` — or `build_report` rescue les erreurs Stripe et renvoie un `empty_report` porteur d'un `error`. Ce rapport d'erreur était donc **mis en cache pendant tout le TTL (5 min)** : une erreur Stripe transitoire gelait la page. Désormais `call` lit le cache, et n'y **écrit que si `report.error.nil?`** ; sinon le prochain appel réessaie.

2. **Choix d'affichage des auto-debits documenté + couvert.** Un payout auto-debit a un `amount` **négatif** (Stripe reprend de l'argent, ex. après remboursements). `fetch_payouts` les liste comme les autres et `build_payout_row` lit `payout.amount` : ils s'affichent donc en **ligne dédiée à montant négatif**, et le `total_net_paid_cents` en tient compte (reprise déduite). C'est l'option « ligne dédiée » de l'issue (pas d'exclusion). Un test le verrouille.

Aucune modification de `RefundService` ni du contrôleur (hors périmètre).

## Testé
- `spec/services/stripe_payout_report_service_spec.rb` (2 specs ajoutées) + `spec/requests/admin/payouts_report_spec.rb` : **18 verts**
  - versement auto-debit (`amount: -3_200`) → rapport sans erreur, ligne à `net_cents: -3_200`, total net `9_750 − 3_200 = 6_550` ;
  - 1er appel Stripe en échec (rapport d'erreur, **non caché**) puis 2e appel OK → le service **réessaie** et renvoie le vrai rapport (ne sert pas l'erreur cachée) ;
  - la spec de cache existante (un seul appel Stripe pour deux exécutions identiques réussies) reste verte.
- `bundle exec rspec` : **599 verts / 1 échec pré-existant et sans rapport** — `spec/models/email_message_spec.rb:16` (enum `EmailMessage` expose un kind `ready` non mis à jour dans cette spec ; échec déjà présent sur `main`, indépendant de ce diff).
- `bin/rubocop` sur les 2 fichiers : **0 offense**.
- `bin/brakeman --no-pager` : **0 warning de sécurité**.

## NON testé
- Pas de test navigateur : ce diff est backend (logique de cache + reporting). Le rendu de la vue payouts (`/admin/reports/payouts`, derrière l'auth admin) n'est pas modifié — les versements négatifs y sont formatés par le `number_to_currency` déjà en place.

## 📸 Aperçu
Aucun rendu visible modifié (changement de logique de cache + specs). Les auto-debits s'affichent via le rendu existant de la vue payouts, inchangé par ce diff.
