### PR TITLE
Admin fiche mangeur : solde du portefeuille et mouvements (#138)

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -30,6 +30,10 @@ class Admin::CustomersController < Admin::BaseController
     @orders = @customer.orders.includes(:bake_day, :payment, :wallet_transactions).order(created_at: :desc)
     @sms_messages = @customer.sms_messages.ordered_by_sent_at
     @email_messages = @customer.email_messages.ordered_by_sent_at
+    @wallet = @customer.wallet
+    # Mouvements du portefeuille en lecture seule (#138), commande préchargée pour
+    # éviter les N+1, du plus récent au plus ancien.
+    @wallet_transactions = @wallet ? @wallet.wallet_transactions.includes(:order).order(created_at: :desc) : []
   end
 
   def new

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -111,6 +111,43 @@
       </div>
     </dl>
   </div>
+
+  <% if @wallet %>
+    <%# Portefeuille (#138) — lecture seule : solde, solde disponible, alerte solde bas. %>
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <h2 class="text-lg font-medium text-gray-900 mb-4">Portefeuille</h2>
+
+      <dl class="space-y-3">
+        <div>
+          <dt class="text-sm font-medium text-gray-500">Solde</dt>
+          <dd class="mt-1 text-lg font-medium <%= @wallet.low_balance? ? 'text-red-700' : 'text-gray-900' %>">
+            <%= number_to_currency(@wallet.balance_cents / 100.0, unit: "€", separator: ",", delimiter: "") %>
+            <% if @wallet.low_balance? %>
+              <span class="ml-2 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                Solde bas
+              </span>
+            <% end %>
+          </dd>
+        </div>
+
+        <div>
+          <dt class="text-sm font-medium text-gray-500">Solde disponible</dt>
+          <dd class="mt-1 text-sm text-gray-900">
+            <%= number_to_currency(@wallet.available_balance_cents / 100.0, unit: "€", separator: ",", delimiter: "") %>
+          </dd>
+        </div>
+
+        <% committed_cents = @wallet.balance_cents - @wallet.available_balance_cents %>
+        <% if committed_cents.positive? %>
+          <div>
+            <dd class="text-xs text-gray-500">
+              <%= number_to_currency(committed_cents / 100.0, unit: "€", separator: ",", delimiter: "") %> engagés dans des commandes planifiées
+            </dd>
+          </div>
+        <% end %>
+      </dl>
+    </div>
+  <% end %>
 </div>
 
 <div class="mt-6 bg-white rounded-lg shadow-sm border border-gray-200 p-6">
@@ -285,6 +322,69 @@
     <p class="text-sm text-gray-500">Aucun e-mail pour ce mangeur.</p>
   <% end %>
 </div>
+
+<% if @wallet %>
+  <%# Mouvements du portefeuille (#138) — lecture seule, du plus récent au plus ancien. %>
+  <div class="mt-6 bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+    <h2 class="text-lg font-medium text-gray-900 mb-4">Mouvements du portefeuille</h2>
+
+    <% if @wallet_transactions.any? %>
+      <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead class="bg-gray-50">
+            <tr>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Montant</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Commande</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
+            </tr>
+          </thead>
+          <tbody class="bg-white divide-y divide-gray-200">
+            <% @wallet_transactions.each do |txn| %>
+              <tr>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                  <%= txn.created_at.strftime("%d/%m/%Y à %H:%M") %>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap">
+                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
+                    <%= case txn.transaction_type
+                        when 'top_up' then 'bg-green-100 text-green-800'
+                        when 'order_debit' then 'bg-orange-100 text-orange-800'
+                        when 'order_refund' then 'bg-blue-100 text-blue-800'
+                        else 'bg-gray-100 text-gray-800'
+                        end %>">
+                    <%= case txn.transaction_type
+                        when 'top_up' then 'Recharge'
+                        when 'order_debit' then 'Débit commande'
+                        when 'order_refund' then 'Remboursement'
+                        else txn.transaction_type
+                        end %>
+                  </span>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium <%= txn.amount_cents.negative? ? 'text-red-700' : 'text-green-700' %>">
+                  <%= "+" if txn.amount_cents.positive? %><%= number_to_currency(txn.amount_euros, unit: "€", separator: ",", delimiter: "") %>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm">
+                  <% if txn.order %>
+                    <%= link_to txn.order.order_number, admin_order_path(txn.order), class: "text-blue-600 hover:text-blue-800" %>
+                  <% else %>
+                    <span class="text-gray-400">—</span>
+                  <% end %>
+                </td>
+                <td class="px-6 py-4 text-sm text-gray-900">
+                  <%= txn.description.presence || content_tag(:span, "—", class: "text-gray-400") %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    <% else %>
+      <p class="text-sm text-gray-500">Aucun mouvement pour ce portefeuille.</p>
+    <% end %>
+  </div>
+<% end %>
 
 <div class="mt-6">
   <%= link_to "← Retour à la liste des mangeurs", admin_customers_path, class: "text-blue-600 hover:text-blue-800" %>

--- a/spec/requests/admin/customers_spec.rb
+++ b/spec/requests/admin/customers_spec.rb
@@ -62,4 +62,70 @@ RSpec.describe "Admin::Customers", type: :request do
       expect(customer.reload.cash_payment_allowed).to be(false)
     end
   end
+
+  # #138 : affichage lecture seule du portefeuille sur la fiche mangeur.
+  describe "GET /admin/customers/:id (portefeuille)" do
+    it "affiche solde, solde disponible, mouvements et la commande liée (client avec transactions)" do
+      customer = create(:customer, first_name: "Léa")
+      wallet = create(:wallet, customer: customer, balance_cents: 5000)
+      bake_day = create(:bake_day)
+      order = create(:order, customer: customer, bake_day: bake_day, total_cents: 550)
+      create(:wallet_transaction, wallet: wallet, transaction_type: :top_up, amount_cents: 2000)
+      create(:wallet_transaction, wallet: wallet, transaction_type: :order_debit, amount_cents: -550, order: order)
+
+      get admin_customer_path(customer)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Portefeuille")
+      expect(response.body).to include("50,00 €") # solde
+      expect(response.body).to include("Mouvements du portefeuille")
+      expect(response.body).to include("Recharge")
+      expect(response.body).to include("Débit commande")
+      expect(response.body).to include(order.order_number) # commande liée cliquable
+    end
+
+    it "explique la différence quand le solde disponible diffère du solde (commande planifiée engagée)" do
+      customer = create(:customer)
+      create(:wallet, customer: customer, balance_cents: 5000)
+      bake_day = create(:bake_day)
+      create(:order, :planned, customer: customer, bake_day: bake_day, total_cents: 1100)
+
+      get admin_customer_path(customer)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("39,00 €") # disponible = 5000 − 1100
+      expect(response.body).to include("engagés dans des commandes planifiées")
+    end
+
+    it "n'affiche ni carte ni section mouvements si le client n'a pas de portefeuille" do
+      customer = create(:customer) # aucun wallet
+
+      get admin_customer_path(customer)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("Portefeuille")
+      expect(response.body).not_to include("Mouvements du portefeuille")
+    end
+
+    it "affiche l'état vide des mouvements pour un portefeuille sans transaction" do
+      customer = create(:customer)
+      create(:wallet, customer: customer, balance_cents: 5000)
+
+      get admin_customer_path(customer)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Portefeuille")
+      expect(response.body).to include("Aucun mouvement pour ce portefeuille.")
+    end
+
+    it "signale visuellement un solde bas" do
+      customer = create(:customer)
+      create(:wallet, customer: customer, balance_cents: 500, low_balance_threshold_cents: 1000)
+
+      get admin_customer_path(customer)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Solde bas")
+    end
+  end
 end


### PR DESCRIPTION
Closes #138

## Résumé

Affichage **lecture seule** du portefeuille sur la fiche mangeur admin (`/admin/customers/:id`). Aucune écriture portefeuille introduite (diff limité à l'affichage + contrôleur + specs).

### Carte « Portefeuille » (dans la grille, après Statistiques)
- **Solde** (`wallet.balance_cents`) et **solde disponible** (`wallet.available_balance_cents`), formatés comme le reste de la page (`number_to_currency(unit: "€", separator: ",", delimiter: "")`).
- Quand solde ≠ disponible : ligne « X € engagés dans des commandes planifiées » (différence = commandes `planned`/`calendar` engagées).
- Si `wallet.low_balance?` : solde en rouge + badge « Solde bas ».
- Si le client n'a **pas** de portefeuille : ni carte ni section (aucune erreur, pas d'état vide superflu).

### Section « Mouvements du portefeuille » (après « E-mails envoyés »)
- Table (même style que Commandes/SMS) : **date** (`%d/%m/%Y à %H:%M`), **type** en badge coloré FR (`top_up`→Recharge vert, `order_debit`→Débit commande orange, `order_refund`→Remboursement bleu), **montant** signé (positif vert préfixé `+`, négatif rouge), **commande liée** cliquable vers `admin_order_path` (« — » sinon), **description** si présente.
- Triés du plus récent au plus ancien.
- Portefeuille sans transaction → « Aucun mouvement pour ce portefeuille. »

### Contrôleur — `Admin::CustomersController#show`
- Charge `@wallet` et `@wallet_transactions` avec `includes(:order)` (anti N+1) et `order(created_at: :desc)`. Aucune requête si pas de portefeuille.

Les modèles `Wallet` / `WalletTransaction` ne sont pas modifiés (méthodes existantes réutilisées).

## Testé
- `spec/requests/admin/customers_spec.rb` — **5 scénarios ajoutés, tous verts** (9 exemples au total dans le fichier) :
  1. client avec portefeuille + transactions → « Portefeuille », solde `50,00 €`, « Mouvements du portefeuille », « Recharge », « Débit commande », n° de commande liée ;
  2. solde ≠ disponible (commande `planned`/`calendar` de 11 €) → disponible `39,00 €` + ligne « engagés dans des commandes planifiées » ;
  3. client sans portefeuille → 200, ni « Portefeuille » ni « Mouvements du portefeuille » ;
  4. portefeuille sans transaction → carte présente + « Aucun mouvement pour ce portefeuille. » ;
  5. solde bas (`balance < threshold`) → « Solde bas » présent.
- `bundle exec rspec` : **602 verts / 1 échec pré-existant et sans rapport** — `spec/models/email_message_spec.rb:16` (enum `EmailMessage` expose un kind `ready` non mis à jour dans cette spec ; échec déjà présent sur `main`, indépendant de ce diff).
- `bin/rubocop` sur les 2 fichiers Ruby modifiés : **0 offense**.
- `bin/brakeman --no-pager` : **0 warning de sécurité**.
- **Vérifié en navigateur** (Capybara + Chrome headless) : connexion admin → fiche mangeur avec portefeuille et mouvements → cf. capture ci-dessous. Le test de capture était jetable et n'est **pas** commité.

## NON testé
- Rien de significatif : les cinq scénarios de la stratégie de test de l'issue sont couverts et la page a été rendue dans un vrai navigateur.

## 📸 Aperçu
![Fiche mangeur — carte Portefeuille + mouvements](https://github.com/les4sources/tranchesdevie2/raw/agent-screenshots/screenshots/20260709-034123-fiche-mangeur--carte-portefeuille--mouvements.png)
