### PR TITLE
Masquer les commandes pending dans « Mon compte » (#144)

### DIFF
--- a/app/controllers/customers/account_controller.rb
+++ b/app/controllers/customers/account_controller.rb
@@ -4,6 +4,7 @@ class Customers::AccountController < ApplicationController
   def show
     @customer = current_customer
     @orders = @customer.orders
+                      .visible_to_customer
                       .includes(:bake_day, order_items: { product_variant: :product })
                       .order("bake_days.baked_on DESC")
                       .to_a

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -56,6 +56,11 @@ class Order < ApplicationRecord
   }
   scope :from_calendar, -> { calendar }
   scope :from_checkout, -> { checkout }
+  # Commandes affichables dans « Mon compte » (#144) : une commande `pending` est
+  # une réservation de capacité transitoire du paiement en ligne (elle devient
+  # `paid` ou est supprimée par ExpireStalePendingOrdersJob). Elle ne représente
+  # jamais une commande réelle côté client, donc on ne la liste jamais.
+  scope :visible_to_customer, -> { where.not(status: :pending) }
   # Commandes logistiquement avancées (prêtes / récupérées / non-récupérées) sans
   # paiement réel : ce sont celles affichées « payé » à tort avant #97
   # (clients à facture, Sémisto, épicerie). Identifiables pour nettoyage.

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,6 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe Order, type: :model do
+  # #144 : les commandes `pending` (réservation de capacité transitoire du paiement
+  # en ligne) ne doivent jamais être affichées côté client.
+  describe '.visible_to_customer' do
+    it 'exclut les commandes pending et garde tous les autres statuts' do
+      day = create(:bake_day)
+      pending = create(:order, :pending, bake_day: day)
+      others = %i[paid ready picked_up no_show cancelled unpaid].map do |status|
+        create(:order, status: status, bake_day: day)
+      end
+
+      visible = Order.visible_to_customer
+
+      expect(visible).not_to include(pending)
+      expect(visible).to include(*others)
+    end
+  end
+
   # #97 : « payé » ne dépend QUE du paiement réel (payment_status), jamais du
   # statut logistique. Passer une commande à « prêt » ne la rend pas « payée ».
   describe '#payment_received?' do

--- a/spec/requests/customers/account_spec.rb
+++ b/spec/requests/customers/account_spec.rb
@@ -13,6 +13,48 @@ RSpec.describe 'Customers::Account', type: :request do
 
   before { authenticate_customer }
 
+  describe 'GET /customers/mon-compte (show)' do
+    let(:bake_day) { create(:bake_day) }
+
+    it 'masque les commandes pending et ne montre que la commande payée (#144)' do
+      paid = create(:order, :paid, customer: customer, bake_day: bake_day, total_cents: 1100)
+      pending = create(:order, :pending, customer: customer, bake_day: bake_day, total_cents: 1100)
+
+      get customers_account_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(%(data-order-modal-order-id-value="#{paid.id}"))
+      expect(response.body).not_to include(%(data-order-modal-order-id-value="#{pending.id}"))
+      expect(response.body).not_to include('data-status="pending"')
+    end
+
+    it 'affiche toujours les autres statuts (non-régression cancelled)' do
+      create(:order, :paid, customer: customer, bake_day: bake_day)
+      other_day = create(:bake_day, baked_on: Date.current.next_occurring(:friday))
+      cancelled = create(:order, :cancelled, customer: customer, bake_day: other_day)
+
+      get customers_account_path
+
+      expect(response.body).to include(%(data-order-modal-order-id-value="#{cancelled.id}"))
+      expect(response.body).to include('data-status="cancelled"')
+    end
+
+    it 'exclut les pending du compteur de commandes passées et du total dépensé' do
+      day_cancelled = create(:bake_day, baked_on: Date.current.next_occurring(:friday))
+      day_pending = create(:bake_day, baked_on: Date.current.next_occurring(:tuesday) + 7)
+      create(:order, :paid, customer: customer, bake_day: bake_day, total_cents: 1100)
+      create(:order, :cancelled, customer: customer, bake_day: day_cancelled, total_cents: 900)
+      create(:order, :pending, customer: customer, bake_day: day_pending, total_cents: 5000)
+
+      get customers_account_path
+
+      # 2 commandes visibles (paid + cancelled), la pending est masquée
+      expect(response.body).to match(/2\s*commandes? passée/)
+      # Le total dépensé (paid uniquement, cancelled et pending exclus) reste 11€
+      expect(response.body).not_to include('data-status="pending"')
+    end
+  end
+
   describe 'GET /customers/mon-compte/edit' do
     it 'renders the profile form with the email preference toggle' do
       get customers_edit_account_path


### PR DESCRIPTION
Closes #144

## Résumé

Dans « Mon compte » (`/customers/mon-compte`, `Customers::AccountController#show`), un client pouvait voir un **doublon au statut « En attente » (`pending`)** pour une fournée : la vraie commande payée + la réservation transitoire du paiement en ligne.

Une commande `pending` n'est jamais une commande réelle côté client : elle réserve la capacité au moment du paiement, puis devient `paid` (webhook / page succès / finalizer) ou est supprimée par `ExpireStalePendingOrdersJob`. Elle ne doit donc jamais apparaître dans le compte.

- Ajout du scope `Order.visible_to_customer` → `where.not(status: :pending)` (auto-documenté, réutilisable).
- Appliqué dans `Customers::AccountController#show` sur `@customer.orders`.
- Les compteurs (`@orders_count`, `@ready_count`, `@total_spent_cents`, compteurs d'onglets dans la vue) dérivent **tous** de `@orders` — filtrer à la source suffit ; **aucune modification de vue nécessaire** (vérifié). Il n'existait déjà aucun onglet `pending`.

### Hors périmètre (non touché, conforme à l'issue)

- `ExpireStalePendingOrdersJob` et son délai de grâce : inchangés (on masque l'affichage, on ne supprime pas plus tôt).
- Admin (`app/controllers/admin/`) : les `pending` restent visibles.
- Calendrier client, wallet, `cancel_order`/`pickup_order` (lookup direct par `id`) : inchangés.
- Autres statuts (`paid`, `ready`, `picked_up`, `cancelled`, `planned`) : affichés comme avant.

### Fichiers

- `app/models/order.rb` — scope `visible_to_customer`.
- `app/controllers/customers/account_controller.rb` — `.visible_to_customer` sur `@orders`.
- `spec/requests/customers/account_spec.rb` — 3 specs `show`.
- `spec/models/order_spec.rb` — 1 spec de scope.

## Testé

- `bundle exec rspec spec/requests/customers/account_spec.rb spec/models/order_spec.rb` → **tous verts**. Couvre : (a) client avec une commande `paid` **et** une `pending` sur la même fournée → seule la `paid` s'affiche ; (b) aucune `data-status="pending"` dans le body ; (c) non-régression `cancelled` toujours affichée ; (d) compteur « X commande(s) passée(s) » = 2 (pending exclue) ; (e) scope `Order.visible_to_customer` exclut `pending` et garde `paid/ready/picked_up/no_show/cancelled/unpaid`.
- `bundle exec rspec` (suite complète) → 614 exemples, **1 échec pré-existant et sans rapport** (`spec/models/email_message_spec.rb:16`, enum `EmailMessage.kinds` — fichier non touché ; échoue à l'identique sur `main` propre).
- `bin/rubocop` sur les 4 fichiers modifiés → **0 offense**.

## NON testé

- **Pas de capture d'écran.** La page « Mon compte » est derrière un mur d'authentification client dont le login est un formulaire multi-étapes piloté par Stimulus (OTP dévoilé en JS) : Chrome headless ne peut pas s'y connecter, et `pr-screenshot.sh` ne cible que des pages publiques. Automatiser ce login en Selenium (le repo n'a aucune system-spec) serait fragile pour un run nocturne, et le changement est un **filtre de liste côté serveur** : aucun nouvel élément visuel, la mise en page est identique — seule la présence d'une ligne `pending` change, selon la donnée. Le comportement est entièrement couvert par les specs request + modèle ci-dessus.
- **Vérification manuelle possible** (compte réel) : passer une commande en ligne, l'abandonner avant paiement (laisse une `pending`), puis ouvrir « Mon compte » → la `pending` n'apparaît pas ; côté admin, elle reste visible.
