### PR TITLE
Checkout: retirer cart_items de la metadata Stripe (limite 500 chars)

### DIFF
--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -200,8 +200,7 @@ class CheckoutController < ApplicationController
         metadata: {
           order_id: order.id,
           bake_day_id: @bake_day.id,
-          phone_e164: phone_e164,
-          cart_items: @cart.to_json
+          phone_e164: phone_e164
         }
       })
     rescue Stripe::StripeError => e


### PR DESCRIPTION
Le PaymentIntent échouait avec HTTP 422 « Metadata values can have up to
500 characters » dès que le panier dépassait ~6 lignes : le JSON du panier
sérialisé dans la metadata dépassait la limite Stripe par valeur.

La metadata cart_items était devenue redondante : la commande est créée
(réservée) AVANT le PaymentIntent, avec ses OrderItems persistés, et le
webhook la retrouve par payment_intent_id — jamais par cart_items.