### PR TITLE
Points de retrait : choix client, activation par fournée, répartition boulangers + PDF par lieu (#148)

### DIFF
--- a/app/controllers/admin/bake_days_controller.rb
+++ b/app/controllers/admin/bake_days_controller.rb
@@ -1,5 +1,5 @@
 class Admin::BakeDaysController < Admin::BaseController
-  before_action :set_bake_day, only: [ :show, :edit, :update, :destroy, :confirm_cancel, :cancel ]
+  before_action :set_bake_day, only: [ :show, :edit, :update, :destroy, :confirm_cancel, :cancel, :pickup_sheet ]
 
   def index
     # Jours futurs (aujourd'hui et futurs)
@@ -43,6 +43,9 @@ class Admin::BakeDaysController < Admin::BaseController
 
   def new
     @bake_day = BakeDay.new
+    # Le lieu par défaut est pré-coché (il sera de toute façon ouvert à la
+    # création — cf. BakeDay#open_default_pickup_location).
+    @bake_day.pickup_location_ids = [ PickupLocation.default_location&.id ].compact
   end
 
   def create
@@ -87,6 +90,18 @@ class Admin::BakeDaysController < Admin::BaseController
   def destroy
     @bake_day.destroy
     redirect_to admin_bake_days_path, notice: "Jour de cuisson supprimé"
+  end
+
+  # Feuille d'émargement PDF d'un point de retrait pour cette fournée (#148).
+  # Un lieu supprimé reste imprimable tant qu'il porte des commandes.
+  def pickup_sheet
+    pickup_location = PickupLocation.find(params[:pickup_location_id])
+    service = PickupSheetPdfService.new(@bake_day, pickup_location)
+
+    send_data service.render,
+      filename: service.filename,
+      type: "application/pdf",
+      disposition: "attachment"
   end
 
   # Écran de confirmation renforcée avant annulation : affiche l'impact chiffré
@@ -154,6 +169,7 @@ class Admin::BakeDaysController < Admin::BaseController
   end
 
   def bake_day_params
-    params.require(:bake_day).permit(:baked_on, :cut_off_at, :internal_note, :market_day, baking_artisan_ids: [])
+    params.require(:bake_day).permit(:baked_on, :cut_off_at, :internal_note, :market_day,
+      baking_artisan_ids: [], pickup_location_ids: [])
   end
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -205,6 +205,7 @@ class Admin::OrdersController < Admin::BaseController
     params.require(:order).permit(
       :customer_id,
       :bake_day_id,
+      :pickup_location_id,
       :status,
       :payment_status,
       :requires_invoice,

--- a/app/controllers/admin/pickup_locations_controller.rb
+++ b/app/controllers/admin/pickup_locations_controller.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# CRUD des points de retrait (#148). La suppression est un soft delete : le lieu
+# disparaît des sélecteurs client mais reste lisible sur les commandes passées.
+#
+# Le cochage lieu ↔ fournée est bidirectionnel : il se fait ici (depuis la fiche
+# du lieu, sur les fournées à venir) et depuis la fiche d'une fournée
+# (Admin::BakeDaysController).
+class Admin::PickupLocationsController < Admin::BaseController
+  before_action :set_pickup_location, only: [ :edit, :update, :destroy ]
+
+  def index
+    @pickup_locations = PickupLocation.not_deleted.ordered
+  end
+
+  def new
+    @pickup_location = PickupLocation.new
+  end
+
+  def create
+    @pickup_location = PickupLocation.new(pickup_location_params)
+
+    if @pickup_location.save
+      redirect_to admin_pickup_locations_path, notice: "Point de retrait créé"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @pickup_location.update(pickup_location_params)
+      redirect_to admin_pickup_locations_path, notice: "Point de retrait mis à jour"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if @pickup_location.default?
+      redirect_to admin_pickup_locations_path,
+        alert: "Le point de retrait par défaut ne peut pas être supprimé."
+      return
+    end
+
+    @pickup_location.soft_delete!
+    redirect_to admin_pickup_locations_path, notice: "Point de retrait supprimé"
+  end
+
+  private
+
+  def set_pickup_location
+    @pickup_location = PickupLocation.not_deleted.find(params[:id])
+  end
+
+  def pickup_location_params
+    params.require(:pickup_location).permit(:name, :description, :default, :position, bake_day_ids: [])
+  end
+end

--- a/app/controllers/api/v1/pickup_locations_controller.rb
+++ b/app/controllers/api/v1/pickup_locations_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class PickupLocationsController < BaseController
+      def index
+        render_collection(PickupLocation.not_deleted.ordered, PickupLocationSerializer)
+      end
+
+      # Un lieu supprimé (soft delete) reste consultable : des commandes le
+      # référencent encore.
+      def show
+        render_resource(PickupLocation.find(params[:id]), PickupLocationSerializer)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/resource_catalog.rb
+++ b/app/controllers/api/v1/resource_catalog.rb
@@ -57,6 +57,7 @@ module Api
             id: "integer", baked_on: "date", cut_off_at: "datetime", can_order: "boolean",
             market_day: "boolean", internal_note: "string|null", total_breads_count: "integer",
             total_sales_euros: "number", oven_capacity_grams: "integer", artisans: "array (détail)",
+            pickup_locations: "array<pickup_location> — lieux de retrait ouverts sur cette fournée (détail)",
             capacity: "object {molds,kneader,oven,fill_percentage,fully_booked} (détail)",
             created_at: "datetime", updated_at: "datetime"
           },
@@ -83,7 +84,9 @@ module Api
             source: "enum: checkout|calendar|admin", total_cents: "integer", total_euros: "number",
             requires_invoice: "boolean", payment_method: "enum: stripe|wallet|null",
             payment_received: "boolean", paid_at: "datetime|null", customer_id: "integer",
-            bake_day_id: "integer", items: "array<order_item>", payment: "object|null (détail)",
+            bake_day_id: "integer", pickup_location_id: "integer",
+            pickup_location: "object {id,name,description} (lieu de retrait)",
+            items: "array<order_item>", payment: "object|null (détail)",
             created_at: "datetime", updated_at: "datetime"
           },
           filters: {
@@ -137,6 +140,18 @@ module Api
           key: "mold_types", singular: "mold_type", title: "Types de moules", pii: false, collection: true,
           description: "Types de moules avec limite d'unités par jour de fournée.",
           fields: { id: "integer", name: "string", limit: "integer", position: "integer", created_at: "datetime", updated_at: "datetime" }
+        },
+        {
+          key: "pickup_locations", singular: "pickup_location", title: "Points de retrait", pii: false, collection: true,
+          description: "Lieux où le client récupère sa commande. Chaque fournée n'ouvre qu'un sous-ensemble de lieux " \
+                       "(« Marché d'Anhée » les jours de marché, par exemple). Un seul lieu est le lieu par défaut. " \
+                       "La collection masque les lieux supprimés ; leur fiche reste consultable car des commandes les référencent.",
+          fields: {
+            id: "integer", name: "string", description: "string|null (affichée au client)",
+            default: "boolean (lieu par défaut, un seul)", position: "integer (ordre d'affichage)",
+            deleted: "boolean (supprimé — masqué des sélecteurs client)",
+            created_at: "datetime", updated_at: "datetime"
+          }
         },
         {
           key: "ingredients", singular: "ingredient", title: "Ingrédients", pii: false, collection: true,

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -4,6 +4,13 @@ class CheckoutController < ApplicationController
   # remonter un ActiveRecord::RecordInvalid muet vers Sentry (#135, TRANCHESDEVIE-G/H).
   class BlankFirstNameError < StandardError; end
 
+  # Point de retrait inconnu ou supprimé (#148). Erreur utilisateur (page périmée,
+  # requête forgée) → 422 ciblé, jamais un 500. Le lieu simplement « non ouvert
+  # sur la fournée » est lui rejeté par OrderCreationService.
+  class UnknownPickupLocationError < StandardError; end
+
+  PICKUP_LOCATION_ERROR = "Le point de retrait choisi n'est pas disponible.".freeze
+
   # Espace de nommage du verrou consultatif « paiement portefeuille » (forme à
   # deux entiers). Postgres traite pg_advisory_xact_lock(int8) et (int4,int4)
   # dans des espaces DISTINCTS : aucune collision possible avec le verrou
@@ -48,6 +55,11 @@ class CheckoutController < ApplicationController
     @wallet = @customer&.persisted? ? @customer.wallet : nil
     @wallet_available_cents = @wallet&.available_balance_cents || 0
     @wallet_payment_available = @wallet.present? && @total_cents.positive? && @wallet_available_cents >= @total_cents
+
+    # Points de retrait ouverts sur la fournée choisie (#148). Le lieu par défaut
+    # est pré-sélectionné.
+    @pickup_locations = @bake_day.open_pickup_locations
+    @selected_pickup_location = @pickup_locations.find(&:default?) || @pickup_locations.first
   end
 
   def verify_phone
@@ -189,7 +201,8 @@ class CheckoutController < ApplicationController
       bake_day: @bake_day,
       cart_items: @cart,
       payment_method: "online",
-      group_name: json_params["group_name"]
+      group_name: json_params["group_name"],
+      pickup_location: requested_pickup_location(json_params)
     )
     order = service.call
 
@@ -230,6 +243,8 @@ class CheckoutController < ApplicationController
       client_secret: payment_intent.client_secret,
       payment_intent_id: payment_intent.id
     }
+  rescue UnknownPickupLocationError
+    render json: { error: PICKUP_LOCATION_ERROR }, status: :unprocessable_entity
   rescue BlankFirstNameError
     # Prénom vide (erreur utilisateur, pas un incident) : 422 ciblé sur le champ,
     # jamais remonté en erreur Sentry. On log en warning pour l'observabilité.
@@ -338,7 +353,8 @@ class CheckoutController < ApplicationController
       bake_day: bake_day,
       cart_items: cart_items,
       payment_method: "cash",
-      group_name: json_params["group_name"]
+      group_name: json_params["group_name"],
+      pickup_location: requested_pickup_location(json_params)
     )
 
     order = service.call
@@ -365,6 +381,8 @@ class CheckoutController < ApplicationController
       success: true,
       order_token: order.public_token
     }
+  rescue UnknownPickupLocationError
+    render json: { success: false, error: PICKUP_LOCATION_ERROR }, status: :unprocessable_entity
   rescue StandardError => e
     Rails.logger.error("Error creating cash order: #{e.message}")
     Rails.logger.error(e.backtrace.join("\n"))
@@ -413,6 +431,10 @@ class CheckoutController < ApplicationController
       return
     end
 
+    # Résolu AVANT la transaction : une levée sous le verrou consultatif ne doit
+    # pas remonter au travers du rollback.
+    pickup_location = requested_pickup_location(json_params)
+
     paid_order = nil
     wallet_error = nil
 
@@ -438,7 +460,8 @@ class CheckoutController < ApplicationController
           bake_day: @bake_day,
           cart_items: session[:cart] || [],
           payment_method: "wallet",
-          group_name: json_params["group_name"]
+          group_name: json_params["group_name"],
+          pickup_location: pickup_location
         )
         created = service.call
 
@@ -484,6 +507,8 @@ class CheckoutController < ApplicationController
     session[:email] = nil
 
     render json: { success: true, order_token: order.public_token }
+  rescue UnknownPickupLocationError
+    render json: { success: false, error: PICKUP_LOCATION_ERROR }, status: :unprocessable_entity
   rescue BlankFirstNameError
     # Prénom vide (erreur utilisateur) : 422 ciblé, comme le tunnel Stripe (#135/#143).
     Rails.logger.warn("[checkout] first_name_blank (wallet) — #{checkout_sentry_context.inspect}")
@@ -621,6 +646,16 @@ class CheckoutController < ApplicationController
     return nil unless payment_intent_id.present?
 
     Order.uncached { Order.find_by(payment_intent_id: payment_intent_id) }
+  end
+
+  # Point de retrait demandé par le client (#148). Absent → nil, et le modèle
+  # retombe alors sur le lieu par défaut de la fournée. Inconnu ou supprimé →
+  # on lève, plutôt que de retomber silencieusement sur un autre lieu.
+  def requested_pickup_location(json_params)
+    id = json_params["pickup_location_id"]
+    return nil if id.blank?
+
+    PickupLocation.not_deleted.find_by(id: id) || raise(UnknownPickupLocationError)
   end
 
   def ensure_cart_not_empty

--- a/app/controllers/customers/calendar_controller.rb
+++ b/app/controllers/customers/calendar_controller.rb
@@ -21,6 +21,12 @@ module Customers
                                        .merge(Product.not_deleted.active.store_channel)
                                        .includes(product: { product_images: :image_attachment })
                                        .order("products.category ASC, products.position ASC, products.name ASC")
+
+      # Points de retrait ouverts, par fournée (#148) : la modale d'une date ne
+      # propose que les lieux ouverts ce jour-là.
+      @pickup_locations_by_bake_day = @bake_days.index_with { |bake_day| bake_day.open_pickup_locations.to_a }
+      # Pré-remplissage : dernier lieu choisi par le client, à défaut le lieu par défaut.
+      @preferred_pickup_location = current_customer.last_pickup_location || PickupLocation.default_location
     end
 
     def mark_intro_seen
@@ -48,7 +54,8 @@ module Customers
         result = PlannedOrderService.upsert(
           customer: current_customer,
           bake_day: bake_day,
-          items: items.map { |item| item.permit(:product_variant_id, :qty).to_h.symbolize_keys }
+          items: items.map { |item| item.permit(:product_variant_id, :qty).to_h.symbolize_keys },
+          pickup_location: requested_pickup_location
         )
 
         if result[:error]
@@ -57,13 +64,25 @@ module Customers
           render json: {
             success: true,
             order_id: result[:order].id,
-            total_cents: result[:order].total_cents
+            total_cents: result[:order].total_cents,
+            pickup_location_id: result[:order].pickup_location_id
           }
         end
       end
     end
 
     private
+
+    # Point de retrait demandé pour cette date (#148). Absent → nil : le service
+    # conserve alors le lieu déjà choisi (ou retombe sur le lieu par défaut à la
+    # création). Un lieu inconnu ou supprimé est ignoré ici et rejeté par le
+    # service s'il n'est pas ouvert sur la fournée.
+    def requested_pickup_location
+      id = params[:pickup_location_id]
+      return nil if id.blank?
+
+      PickupLocation.not_deleted.find_by(id: id)
+    end
 
     def authenticate_customer!
       unless customer_signed_in?

--- a/app/javascript/controllers/calendar_controller.js
+++ b/app/javascript/controllers/calendar_controller.js
@@ -1,13 +1,17 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["modal", "modalTitle", "modalItems", "modalTotal", "productList", "toast", "balanceIndicator", "saveBtn", "modalForm", "modalSuccess"]
+  static targets = ["modal", "modalTitle", "modalItems", "modalTotal", "productList", "toast", "balanceIndicator", "saveBtn", "modalForm", "modalSuccess", "pickupLocation"]
   static values = {
     updateUrl: { type: String, default: "/calendrier/update_day" },
     walletBalance: { type: Number, default: 0 },
     committed: { type: Number, default: 0 },
     reloadUrl: { type: String, default: "/portefeuille/recharger" },
-    skipWallet: { type: Boolean, default: false }
+    skipWallet: { type: Boolean, default: false },
+    // Lieux de retrait ouverts, indexés par id de fournée (#148).
+    pickupLocations: { type: Object, default: {} },
+    // Dernier lieu choisi par le client (à défaut, le lieu par défaut).
+    preferredPickupLocation: { type: String, default: "" }
   }
 
   connect() {
@@ -44,6 +48,7 @@ export default class extends Controller {
 
     this.currentBakeDayId = bakeDayId
     this.currentItems = this.loadExistingItems(bakeDayId)
+    this.currentPickupLocationId = this.resolvePickupLocationId(bakeDayId)
 
     // Calculate original total of this order (to exclude from committed)
     this.currentOrderOriginalTotal = this.calculateItemsTotal(this.currentItems)
@@ -56,6 +61,70 @@ export default class extends Controller {
 
     this.renderModal()
     this.showModal()
+  }
+
+  // Lieux de retrait ouverts sur cette date (#148).
+  pickupLocationsFor(bakeDayId) {
+    return this.pickupLocationsValue[String(bakeDayId)] || []
+  }
+
+  // Lieu pré-sélectionné pour une date : celui déjà choisi sur la commande
+  // planifiée, sinon le dernier lieu choisi par le client (ou le lieu par
+  // défaut) — et seulement s'il est ouvert sur cette date.
+  resolvePickupLocationId(bakeDayId) {
+    const open = this.pickupLocationsFor(bakeDayId)
+    if (open.length === 0) return ""
+
+    const bakeDayEl = document.querySelector(`[data-bake-day-id="${bakeDayId}"]`)
+    const candidates = [bakeDayEl?.dataset.orderPickupLocationId, this.preferredPickupLocationValue]
+
+    for (const candidate of candidates) {
+      if (candidate && open.some(l => String(l.id) === String(candidate))) return String(candidate)
+    }
+    return String(open[0].id)
+  }
+
+  renderPickupLocations() {
+    if (!this.hasPickupLocationTarget) return
+
+    const open = this.pickupLocationsFor(this.currentBakeDayId)
+
+    if (open.length === 0) {
+      this.pickupLocationTarget.innerHTML = ""
+      return
+    }
+
+    const choices = open.map(location => {
+      const checked = String(location.id) === String(this.currentPickupLocationId) ? "checked" : ""
+      const description = location.description
+        ? `<span class="block text-[13px] text-ink-500">${this.escapeHtml(location.description)}</span>`
+        : ""
+
+      return `
+        <label class="flex cursor-pointer items-start gap-2 rounded-md border border-flour-400 bg-white p-2.5 transition hover:border-sage-600">
+          <input type="radio" name="calendar_pickup_location" value="${location.id}" ${checked}
+                 class="mt-0.5 h-[18px] w-[18px] accent-sage-600"
+                 data-action="change->calendar#selectPickupLocation">
+          <span>
+            <span class="block text-sm font-semibold text-ink-900">${this.escapeHtml(location.name)}</span>
+            ${description}
+          </span>
+        </label>`
+    }).join("")
+
+    this.pickupLocationTarget.innerHTML = `
+      <p class="mb-2 text-sm font-semibold text-ink-900">Point de retrait</p>
+      <div class="space-y-2">${choices}</div>`
+  }
+
+  selectPickupLocation(event) {
+    this.currentPickupLocationId = event.target.value
+  }
+
+  escapeHtml(value) {
+    const div = document.createElement("div")
+    div.textContent = value
+    return div.innerHTML
   }
 
   loadExistingItems(bakeDayId) {
@@ -84,6 +153,8 @@ export default class extends Controller {
 
   renderModal() {
     if (!this.hasModalTarget) return
+
+    this.renderPickupLocations()
 
     if (this.hasProductListTarget) {
       // Group variants by category then by product name
@@ -253,7 +324,8 @@ export default class extends Controller {
         },
         body: JSON.stringify({
           bake_day_id: this.currentBakeDayId,
-          items: this.currentItems
+          items: this.currentItems,
+          pickup_location_id: this.currentPickupLocationId
         })
       })
 
@@ -489,7 +561,11 @@ export default class extends Controller {
         },
         body: JSON.stringify({
           bake_day_id: bakeDayId,
-          items: existingItems
+          items: existingItems,
+          // Glisser-déposer : pas de modale, donc pas de choix explicite. On
+          // conserve le lieu déjà choisi sur cette date (à défaut, le lieu
+          // habituel du client).
+          pickup_location_id: this.resolvePickupLocationId(bakeDayId)
         })
       })
 

--- a/app/javascript/controllers/order_modal_controller.js
+++ b/app/javascript/controllers/order_modal_controller.js
@@ -168,6 +168,14 @@ export default class extends Controller {
           <p class="text-gray-900">${new Date(bakeDay.baked_on).toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit', year: 'numeric' })}</p>
         </div>
 
+        ${order.pickup_location ? `
+          <div>
+            <h4 class="text-sm font-medium text-gray-500 mb-1">Point de retrait</h4>
+            <p class="text-gray-900 font-semibold">${order.pickup_location.name}</p>
+            ${order.pickup_location.description ? `<p class="text-sm text-gray-500">${order.pickup_location.description}</p>` : ""}
+          </div>
+        ` : ""}
+
         <div>
           <h4 class="text-sm font-medium text-gray-500 mb-2">Articles</h4>
           <div class="space-y-2">

--- a/app/models/bake_day.rb
+++ b/app/models/bake_day.rb
@@ -17,13 +17,36 @@ class BakeDay < ApplicationRecord
   has_many :orders, dependent: :restrict_with_error
   has_many :bake_day_artisans, dependent: :destroy
   has_many :baking_artisans, through: :bake_day_artisans, source: :artisan
+  has_many :bake_day_pickup_locations, dependent: :destroy
+  has_many :pickup_locations, through: :bake_day_pickup_locations
 
   validates :baked_on, presence: true, uniqueness: true
   validates :cut_off_at, presence: true
+  validate :pickup_locations_in_use_still_open
+
+  after_save :sync_pickup_locations
 
   scope :future, -> { where("baked_on >= ?", Date.current) }
   scope :past, -> { where("baked_on < ?", Date.current) }
   scope :ordered, -> { order(:baked_on) }
+
+  # Lieux de retrait proposables au client sur cette fournée : les lieux ouverts,
+  # non supprimés, dans l'ordre d'affichage.
+  def open_pickup_locations
+    pickup_locations.not_deleted.ordered
+  end
+
+  # Le setter d'ActiveRecord écrirait les jointures IMMÉDIATEMENT, avant même la
+  # validation — un lieu déjà commandé serait donc décoché en base avant qu'on
+  # puisse le refuser. On met les ids en attente, on valide, puis on applique en
+  # `after_save` (cf. `sync_pickup_locations`).
+  def pickup_location_ids=(ids)
+    @staged_pickup_location_ids = Array(ids).reject(&:blank?).map(&:to_i)
+  end
+
+  def pickup_location_ids
+    @staged_pickup_location_ids || super
+  end
 
   def can_order?
     Time.current < cut_off_at
@@ -64,5 +87,72 @@ class BakeDay < ApplicationRecord
       cut_off_date = date - days_before.days
       Time.zone.parse("#{cut_off_date} 18:00:00")
     end
+  end
+
+  private
+
+  # Ids réellement ouverts en base (indépendamment des ids mis en attente par le
+  # formulaire), source de vérité pour détecter un décochage.
+  def persisted_pickup_location_ids
+    return [] if new_record?
+
+    BakeDayPickupLocation.where(bake_day_id: id).pluck(:pickup_location_id)
+  end
+
+  # Refus bloquant : on ne retire pas d'une fournée un lieu auquel des commandes
+  # de cette même fournée sont déjà rattachées (elles deviendraient incohérentes).
+  def pickup_locations_in_use_still_open
+    return if @staged_pickup_location_ids.nil? || new_record?
+
+    removed_ids = persisted_pickup_location_ids - @staged_pickup_location_ids
+    return if removed_ids.empty?
+
+    PickupLocation.where(id: removed_ids).each do |location|
+      count = orders.where(pickup_location_id: location.id).count
+      next if count.zero?
+
+      errors.add(
+        :pickup_locations,
+        "« #{location.name} » ne peut pas être retiré de cette fournée : " \
+        "#{pluralize(count, 'commande y est rattachée', 'commandes y sont rattachées')}."
+      )
+    end
+  end
+
+  # `ActionView::Helpers::TextHelper#pluralize` n'est pas disponible dans un
+  # modèle ; on garde la même forme (nombre + libellé accordé) sans l'inclure.
+  def pluralize(count, singular, plural)
+    "#{count} #{count == 1 ? singular : plural}"
+  end
+
+  # Applique les lieux mis en attente (une fois la validation passée), puis
+  # garantit qu'à la création le lieu par défaut est toujours ouvert.
+  def sync_pickup_locations
+    staged = @staged_pickup_location_ids
+    @staged_pickup_location_ids = nil
+
+    apply_staged_pickup_locations(staged) if staged
+    open_default_pickup_location if saved_change_to_id?
+
+    association(:bake_day_pickup_locations).reset
+    association(:pickup_locations).reset
+  end
+
+  def apply_staged_pickup_locations(staged_ids)
+    scope = BakeDayPickupLocation.where(bake_day_id: id)
+    scope.where.not(pickup_location_id: staged_ids).destroy_all
+
+    already_open = BakeDayPickupLocation.where(bake_day_id: id).pluck(:pickup_location_id)
+    (staged_ids - already_open).each do |location_id|
+      BakeDayPickupLocation.create!(bake_day_id: id, pickup_location_id: location_id)
+    end
+  end
+
+  # À la création d'une fournée, le lieu par défaut est automatiquement coché.
+  def open_default_pickup_location
+    default = PickupLocation.default_location
+    return unless default
+
+    BakeDayPickupLocation.find_or_create_by!(bake_day_id: id, pickup_location_id: default.id)
   end
 end

--- a/app/models/bake_day_pickup_location.rb
+++ b/app/models/bake_day_pickup_location.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Jointure « ce lieu de retrait est ouvert sur cette fournée » (#148).
+# Calquée sur BakeDayArtisan.
+class BakeDayPickupLocation < ApplicationRecord
+  belongs_to :bake_day
+  belongs_to :pickup_location
+
+  validates :pickup_location_id, uniqueness: { scope: :bake_day_id }
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -44,6 +44,19 @@ class Customer < ApplicationRecord
     groups.maximum(:discount_percent) || 0
   end
 
+  # Dernier point de retrait choisi par le client (#148) : sert à pré-remplir le
+  # sélecteur du calendrier. On ignore les commandes annulées et les lieux
+  # supprimés. Retombe sur nil — l'appelant utilise alors le lieu par défaut.
+  def last_pickup_location
+    orders.where.not(status: :cancelled)
+          .where.not(pickup_location_id: nil)
+          .order(created_at: :desc)
+          .joins(:pickup_location)
+          .merge(PickupLocation.not_deleted)
+          .first
+          &.pickup_location
+  end
+
   # Returns the group with the highest discount (for display purposes).
   # When multiple groups have discounts, this is the one that determines the applied rate.
   def best_discount_group

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -30,6 +30,7 @@ class Order < ApplicationRecord
 
   belongs_to :customer
   belongs_to :bake_day
+  belongs_to :pickup_location
   has_many :order_items, dependent: :destroy
   has_many :wallet_transactions
   has_one :payment, dependent: :destroy
@@ -41,11 +42,13 @@ class Order < ApplicationRecord
   validates :order_number, presence: true, uniqueness: true
   validates :status, presence: true
   validates :requires_invoice, inclusion: { in: [ true, false ] }
+  validate :pickup_location_open_on_bake_day
 
   COMPLETED_STATUSES = %w[paid ready picked_up].freeze
 
   before_validation :generate_public_token, on: :create
   before_validation :generate_order_number, on: :create
+  before_validation :assign_default_pickup_location, on: :create
 
   scope :recent, -> { order(created_at: :desc) }
   scope :by_bake_day, ->(bake_day) { where(bake_day: bake_day) }
@@ -417,6 +420,28 @@ class Order < ApplicationRecord
   end
 
   private
+
+  # Toute commande a un point de retrait (#148). Les chemins qui n'en fournissent
+  # pas (création admin, reprise d'une commande historique) retombent sur le lieu
+  # par défaut de la fournée — « Les 4 Sources » dans les faits.
+  def assign_default_pickup_location
+    return if pickup_location_id.present?
+
+    open_locations = bake_day ? bake_day.open_pickup_locations.to_a : []
+    fallback = open_locations.find(&:default?) || open_locations.first || PickupLocation.default_location
+
+    self.pickup_location_id = fallback&.id
+  end
+
+  # Une commande ne peut pas être retirée dans un lieu qui n'est pas ouvert sur
+  # sa fournée. Garde-fou serveur : le sélecteur client masque déjà ces lieux,
+  # mais une requête forgée ou une page périmée doit être rejetée ici.
+  def pickup_location_open_on_bake_day
+    return if pickup_location_id.blank? || bake_day.nil?
+    return if bake_day.pickup_location_ids.include?(pickup_location_id)
+
+    errors.add(:pickup_location, "n'est pas disponible pour cette fournée")
+  end
 
   # Encaissement réel (par opposition au `status` logistique) : un paiement
   # Stripe abouti, ou un débit du portefeuille.

--- a/app/models/pickup_location.rb
+++ b/app/models/pickup_location.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+# Point de retrait d'une commande (#148). Chaque fournée ouvre un sous-ensemble
+# de lieux : « Les 4 Sources » (le lieu par défaut) est ouvert partout, tandis
+# que « Marché d'Anhée » n'existe que les jours de marché.
+#
+# Suppression = soft delete (comme MoldType) : un lieu retiré disparaît des
+# sélecteurs client mais reste lisible sur les commandes passées qui le
+# référencent. Aucun `default_scope` n'est posé, c'est ce qui rend cette lecture
+# possible — filtrer explicitement avec `not_deleted` dans les sélecteurs.
+class PickupLocation < ApplicationRecord
+  has_soft_deletion
+
+  has_many :bake_day_pickup_locations, dependent: :destroy
+  has_many :bake_days, through: :bake_day_pickup_locations
+  has_many :orders, dependent: :restrict_with_error
+
+  validates :name, presence: true, uniqueness: { conditions: -> { where(deleted_at: nil) } }
+  validate :single_default_location
+  validate :bake_days_in_use_still_open
+
+  after_save :sync_bake_days
+
+  scope :not_deleted, -> { where(deleted_at: nil) }
+  scope :ordered, -> { order(position: :asc, name: :asc) }
+
+  # Le lieu par défaut (« Les 4 Sources ») : pré-sélectionné au checkout, ouvert
+  # automatiquement sur chaque nouvelle fournée. Peut être nil sur une base neuve
+  # (aucun lieu créé) — les appelants doivent le tolérer.
+  def self.default_location
+    not_deleted.find_by(default: true)
+  end
+
+  # Seules les fournées à venir sont cochables depuis la fiche d'un lieu : on ne
+  # rouvre ni ne ferme un lieu sur une fournée déjà cuite.
+  def self.assignable_bake_days
+    BakeDay.future.ordered
+  end
+
+  # Même raison que dans BakeDay : le setter d'ActiveRecord écrirait les
+  # jointures avant validation. On met en attente, on valide, puis on applique.
+  def bake_day_ids=(ids)
+    @staged_bake_day_ids = Array(ids).reject(&:blank?).map(&:to_i)
+  end
+
+  def bake_day_ids
+    @staged_bake_day_ids || super
+  end
+
+  private
+
+  # Un seul lieu par défaut à la fois (doublé d'un index unique partiel en base).
+  def single_default_location
+    return unless default? && deleted_at.nil?
+
+    conflicting = PickupLocation.not_deleted.where(default: true)
+    conflicting = conflicting.where.not(id: id) if persisted?
+    return unless conflicting.exists?
+
+    errors.add(:default, "ne peut être coché que sur un seul point de retrait")
+  end
+
+  def assignable_bake_day_ids
+    self.class.assignable_bake_days.pluck(:id)
+  end
+
+  def persisted_bake_day_ids
+    return [] if new_record?
+
+    BakeDayPickupLocation.where(pickup_location_id: id).pluck(:bake_day_id)
+  end
+
+  # Symétrique de la garde de BakeDay : on ne ferme pas ce lieu sur une fournée
+  # dont des commandes l'utilisent déjà.
+  def bake_days_in_use_still_open
+    return if @staged_bake_day_ids.nil? || new_record?
+
+    removed_ids = (persisted_bake_day_ids & assignable_bake_day_ids) - @staged_bake_day_ids
+
+    BakeDay.where(id: removed_ids).ordered.each do |bake_day|
+      count = Order.where(bake_day_id: bake_day.id, pickup_location_id: id).count
+      next if count.zero?
+
+      errors.add(
+        :bake_days,
+        "la fournée du #{I18n.l(bake_day.baked_on)} ne peut pas être retirée : " \
+        "#{count} commande(s) y sont rattachée(s) à ce point de retrait."
+      )
+    end
+  end
+
+  # Réconcilie les jointures UNIQUEMENT dans le périmètre cochable (fournées à
+  # venir). Les fournées passées ne figurent pas dans le formulaire : leur
+  # rattachement doit survivre à un enregistrement, sans quoi l'historique des
+  # commandes perdrait son lieu de retrait.
+  def sync_bake_days
+    staged = @staged_bake_day_ids
+    @staged_bake_day_ids = nil
+    return if staged.nil?
+
+    assignable = assignable_bake_day_ids
+
+    BakeDayPickupLocation
+      .where(pickup_location_id: id, bake_day_id: assignable - staged)
+      .destroy_all
+
+    already_open = BakeDayPickupLocation.where(pickup_location_id: id).pluck(:bake_day_id)
+    ((staged & assignable) - already_open).each do |bake_day_id|
+      BakeDayPickupLocation.create!(pickup_location_id: id, bake_day_id: bake_day_id)
+    end
+
+    association(:bake_day_pickup_locations).reset
+    association(:bake_days).reset
+  end
+end

--- a/app/presenters/admin/bake_day_dashboard.rb
+++ b/app/presenters/admin/bake_day_dashboard.rb
@@ -9,6 +9,7 @@ module Admin
     def orders
       @orders ||= bake_day.orders
                            .includes(:customer,
+                                     :pickup_location,
                                      order_items: {
                                        product_variant: [
                                          :mold_type,
@@ -90,6 +91,33 @@ module Admin
           statuses: customer_orders.group_by(&:status).transform_values(&:count)
         }
       end.sort_by { |entry| [ entry[:customer].last_name.to_s.downcase, entry[:customer].first_name.to_s.downcase ] }
+    end
+
+    # Répartition par point de retrait (#148) : ce que les boulangers utilisent
+    # pour ventiler les produits entre les lieux le jour de la fournée.
+    #
+    # Renvoie une entrée par lieu OUVERT sur la fournée (même sans commande, pour
+    # que l'absence soit explicite), plus tout lieu qui porte des commandes sans
+    # être ouvert (cas d'un lieu supprimé depuis) — sans quoi ces commandes
+    # disparaîtraient silencieusement du tableau.
+    def pickup_location_breakdown
+      @pickup_location_breakdown ||= begin
+        orders_by_location = production_orders.group_by(&:pickup_location)
+
+        locations = (bake_day.open_pickup_locations.to_a + orders_by_location.keys.compact).uniq
+
+        locations.map do |location|
+          location_orders = orders_by_location[location] || []
+
+          {
+            pickup_location: location,
+            orders: location_orders.sort_by { |order| order.customer.full_name.to_s.downcase },
+            orders_count: location_orders.size,
+            total_cents: location_orders.sum(&:total_cents),
+            variant_stats: variant_stats_for(location_orders)
+          }
+        end.sort_by { |entry| [ entry[:pickup_location].position || 0, entry[:pickup_location].name.downcase ] }
+      end
     end
 
     def status_distribution
@@ -240,6 +268,22 @@ module Admin
     end
 
     private
+
+    # Récapitulatif agrégé des articles par variante, sur un sous-ensemble de
+    # commandes (celles d'un point de retrait). Même forme que `variant_stats`.
+    def variant_stats_for(subset_orders)
+      subset_orders
+        .flat_map(&:order_items)
+        .group_by(&:product_variant)
+        .map do |variant, items|
+          {
+            variant: variant,
+            product: variant.product,
+            units_count: items.sum(&:qty)
+          }
+        end
+        .sort_by { |stat| [ stat[:product].name.downcase, stat[:variant].name.downcase ] }
+    end
 
     PRODUCTION_STATUSES = %i[unpaid paid ready picked_up planned].freeze
 

--- a/app/serializers/api/v1/bake_day_serializer.rb
+++ b/app/serializers/api/v1/bake_day_serializer.rb
@@ -24,6 +24,9 @@ module Api
 
         if detail?
           data[:artisans] = object.baking_artisans.map { |a| { id: a.id, name: a.name } }
+          data[:pickup_locations] = object.open_pickup_locations.map do |location|
+            { id: location.id, name: location.name, description: location.description, default: location.default? }
+          end
           data[:capacity] = capacity_hash
         end
 

--- a/app/serializers/api/v1/order_serializer.rb
+++ b/app/serializers/api/v1/order_serializer.rb
@@ -17,18 +17,32 @@ module Api
           paid_at: iso(object.paid_at),
           customer_id: object.customer_id,
           bake_day_id: object.bake_day_id,
+          pickup_location_id: object.pickup_location_id,
+          pickup_location: pickup_location_summary,
           items: object.order_items.map { |item| OrderItemSerializer.new(item, context).as_json },
           created_at: iso(object.created_at),
           updated_at: iso(object.updated_at),
           _links: {
             self: path("orders", object.id),
             customer: path("customers", object.customer_id),
-            bake_day: path("bake_days", object.bake_day_id)
+            bake_day: path("bake_days", object.bake_day_id),
+            pickup_location: path("pickup_locations", object.pickup_location_id)
           }
         }
 
         data[:payment] = PaymentSerializer.one(object.payment, context) if detail?
         data
+      end
+
+      private
+
+      # Résumé du lieu de retrait, inclus directement pour éviter un aller-retour
+      # à l'agent sur le cas le plus courant (savoir où va la commande).
+      def pickup_location_summary
+        location = object.pickup_location
+        return nil unless location
+
+        { id: location.id, name: location.name, description: location.description }
       end
     end
   end

--- a/app/serializers/api/v1/pickup_location_serializer.rb
+++ b/app/serializers/api/v1/pickup_location_serializer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class PickupLocationSerializer < BaseSerializer
+      def as_json
+        {
+          id: object.id,
+          name: object.name,
+          description: object.description,
+          default: object.default?,
+          position: object.position,
+          deleted: object.deleted_at.present?,
+          created_at: iso(object.created_at),
+          updated_at: iso(object.updated_at),
+          _links: { self: path("pickup_locations", object.id) }
+        }
+      end
+    end
+  end
+end

--- a/app/services/order_creation_service.rb
+++ b/app/services/order_creation_service.rb
@@ -1,7 +1,7 @@
 class OrderCreationService
   attr_reader :order, :errors
 
-  def initialize(customer:, bake_day:, cart_items:, payment_intent_id: nil, payment_method: "online", skip_capacity_check: false, group_name: nil)
+  def initialize(customer:, bake_day:, cart_items:, payment_intent_id: nil, payment_method: "online", skip_capacity_check: false, group_name: nil, pickup_location: nil)
     @customer = customer
     @bake_day = bake_day
     @cart_items = cart_items
@@ -9,6 +9,7 @@ class OrderCreationService
     @payment_method = payment_method
     @skip_capacity_check = skip_capacity_check
     @group_name = group_name.presence
+    @pickup_location = pickup_location
     @errors = []
   end
 
@@ -30,13 +31,16 @@ class OrderCreationService
         end
       end
 
+      # `pickup_location` nil → le modèle retombe sur le lieu par défaut de la
+      # fournée (cf. Order#assign_default_pickup_location).
       @order = Order.create!(
         customer: @customer,
         bake_day: @bake_day,
         total_cents: calculate_total,
         payment_intent_id: @payment_intent_id,
         status: initial_status,
-        group_name: @group_name
+        group_name: @group_name,
+        pickup_location: @pickup_location
       )
 
       create_order_items
@@ -53,6 +57,13 @@ class OrderCreationService
     @errors << "Bake day cut-off has passed" unless BakeDayService.can_order_for?(@bake_day.baked_on)
     @errors << "Cart is empty" if @cart_items.empty?
     @errors << "Customer is required" unless @customer
+
+    # Garde-fou serveur (#148) : un lieu non ouvert sur la fournée est rejeté ici,
+    # proprement, plutôt que de laisser la validation du modèle lever un
+    # RecordInvalid (500) au moment du `create!`.
+    if @pickup_location && !@bake_day.pickup_location_ids.include?(@pickup_location.id)
+      @errors << "Le point de retrait choisi n'est pas disponible pour cette fournée"
+    end
 
     # Check if order with same payment_intent_id already exists (idempotency)
     # Only check for online payments (cash orders don't have payment_intent_id)

--- a/app/services/pickup_sheet_pdf_service.rb
+++ b/app/services/pickup_sheet_pdf_service.rb
@@ -1,0 +1,146 @@
+require "prawn"
+require "prawn/table"
+
+# Feuille d'émargement d'un point de retrait pour une fournée (#148).
+#
+# Sert aux boulangers le jour du retrait : une ligne par client, avec le détail
+# de sa commande et une case à cocher AU STYLO quand il vient récupérer. Il n'y a
+# volontairement aucun pointage en ligne : le PDF ne change aucun statut.
+#
+# Même contrat public qu'InvoicePdfService (`#render` → String binaire,
+# `#filename`) et mêmes constantes de charte.
+#
+# Usage :
+#   pdf = PickupSheetPdfService.new(bake_day, pickup_location).render
+class PickupSheetPdfService
+  BRAND_COLOR = "7C2D12".freeze   # terracotta (cf. e-mails / factures)
+  MUTED_COLOR = "8A8178".freeze
+  LIGHT_FILL = "FAF7F2".freeze
+
+  DOCUMENT_TITLE = "Feuille de retrait".freeze
+
+  # Mêmes statuts que le tableau de bord de fournée : ce qui est réellement
+  # produit et donc à remettre au client.
+  PRODUCTION_STATUSES = %i[unpaid paid ready picked_up planned].freeze
+
+  def initialize(bake_day, pickup_location)
+    @bake_day = bake_day
+    @pickup_location = pickup_location
+  end
+
+  def render
+    document.render
+  end
+
+  def filename
+    "retrait-#{@pickup_location.name.parameterize}-#{@bake_day.baked_on.strftime('%Y-%m-%d')}.pdf"
+  end
+
+  # Commandes de CE lieu pour CETTE fournée, triées par nom de client.
+  def orders
+    @orders ||= @bake_day.orders
+      .where(pickup_location_id: @pickup_location.id, status: PRODUCTION_STATUSES)
+      .includes(:customer, order_items: { product_variant: :product })
+      .to_a
+      .sort_by { |order| customer_name(order).downcase }
+  end
+
+  private
+
+  def document
+    pdf = Prawn::Document.new(page_size: "A4", margin: 40)
+    pdf.font_families.update(default: pdf.font_families["Helvetica"])
+
+    render_header(pdf)
+    render_table(pdf)
+    render_footer(pdf)
+
+    pdf
+  end
+
+  def render_header(pdf)
+    pdf.fill_color BRAND_COLOR
+    pdf.text BakeryDetails::NAME, size: 22, style: :bold
+    pdf.fill_color "000000"
+    pdf.move_down 6
+
+    pdf.text DOCUMENT_TITLE, size: 16, style: :bold
+    pdf.move_down 8
+
+    pdf.text @pickup_location.name, size: 14, style: :bold
+    if @pickup_location.description.present?
+      pdf.fill_color MUTED_COLOR
+      pdf.text @pickup_location.description, size: 9
+      pdf.fill_color "000000"
+    end
+
+    pdf.move_down 4
+    pdf.text "Fournée du #{I18n.l(@bake_day.baked_on)}", size: 11
+    pdf.move_down 14
+  end
+
+  def render_table(pdf)
+    if orders.empty?
+      pdf.fill_color MUTED_COLOR
+      pdf.text "Aucune commande à retirer sur ce point pour cette fournée.", size: 10
+      pdf.fill_color "000000"
+      return
+    end
+
+    # 1re colonne : la case à cocher. Volontairement sans libellé — les polices
+    # PDF intégrées (Windows-1252) ne portent pas de glyphe « ✓ ».
+    header = [ "", "Client", "Téléphone", "Commande", "Total" ]
+    body = orders.map do |order|
+      [ "", customer_name(order), order.customer.phone_e164.to_s, items_label(order), euros(order.total_cents) ]
+    end
+
+    pdf.table(
+      [ header ] + body,
+      width: pdf.bounds.width,
+      header: true,
+      column_widths: column_widths(pdf),
+      cell_style: { size: 9, padding: [ 6, 6 ], borders: [ :bottom ], border_color: "EEEEEE" }
+    ) do |t|
+      t.row(0).font_style = :bold
+      t.row(0).background_color = LIGHT_FILL
+      t.row(0).text_color = "333333"
+      t.column(4).align = :right
+
+      # Case à cocher vide : le boulanger coche au stylo au moment du retrait.
+      t.column(0).align = :center
+      t.rows(1..-1).column(0).borders = [ :bottom, :left, :right, :top ]
+      t.rows(1..-1).column(0).border_color = "999999"
+      t.rows(1..-1).column(0).height = 22
+    end
+  end
+
+  def column_widths(pdf)
+    total = pdf.bounds.width
+    [ 24, 110, 90, total - 224 - 70, 70 ]
+  end
+
+  def render_footer(pdf)
+    pdf.move_down 18
+    pdf.fill_color MUTED_COLOR
+    pdf.text "#{orders.size} commande(s) · Cocher la case à la remise de la commande.", size: 9
+    pdf.fill_color "000000"
+  end
+
+  def customer_name(order)
+    order.customer.full_name.presence || "Client ##{order.customer_id}"
+  end
+
+  # Détail de la commande : « 2 × Pain de campagne (1 kg) ».
+  def items_label(order)
+    order.order_items.map do |item|
+      variant = item.product_variant
+      product_name = variant.product&.name || "Produit supprimé"
+      "#{item.qty} × #{product_name} (#{variant.name})"
+    end.join("\n")
+  end
+
+  def euros(cents)
+    formatted = format("%.2f", cents / 100.0).tr(".", ",")
+    "#{formatted} €"
+  end
+end

--- a/app/services/planned_order_service.rb
+++ b/app/services/planned_order_service.rb
@@ -1,14 +1,22 @@
 class PlannedOrderService
   class << self
-    def upsert(customer:, bake_day:, items:)
+    def upsert(customer:, bake_day:, items:, pickup_location: nil)
       return { error: "Cut-off dépassé" } if bake_day.cut_off_passed?
       return { error: "Aucun produit sélectionné" } if items.blank?
+
+      if pickup_location && !bake_day.pickup_location_ids.include?(pickup_location.id)
+        return { error: "Le point de retrait choisi n'est pas disponible pour cette fournée" }
+      end
 
       order = customer.orders.find_or_initialize_by(
         bake_day: bake_day,
         status: :planned,
         source: :calendar
       )
+
+      # Le lieu n'est écrasé que s'il est explicitement fourni : une mise à jour
+      # qui ne touche que les articles conserve le lieu déjà choisi (#148).
+      order.pickup_location = pickup_location if pickup_location
 
       Order.transaction do
         order.order_items.destroy_all if order.persisted?

--- a/app/views/admin/bake_days/_pickup_locations.html.slim
+++ b/app/views/admin/bake_days/_pickup_locations.html.slim
@@ -1,0 +1,21 @@
+/ Points de retrait ouverts sur cette fournée (#148). Partial partagé par `new`
+/ et `edit`, qui sont sinon dupliquées.
+/
+/ Un lieu déjà utilisé par des commandes de cette fournée ne peut pas être
+/ décoché : la validation du modèle refuse l'enregistrement et le formulaire est
+/ ré-affiché avec le nombre de commandes concernées.
+.mb-4
+  span.block.text-gray-700.font-medium.mb-2 Points de retrait ouverts sur cette fournée
+  - locations = PickupLocation.not_deleted.ordered
+  - if locations.any?
+    .grid.grid-cols-1.sm:grid-cols-2.lg:grid-cols-3.gap-2
+      = f.collection_check_boxes :pickup_location_ids, locations, :id, :name do |b|
+        label.flex.items-center.gap-2.rounded-md.border.border-gray-200.px-3.py-2.cursor-pointer.hover:bg-gray-50
+          = b.check_box class: "rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+          = b.text
+    p.mt-2.text-xs.text-gray-500
+      | Le lieu par défaut est toujours ouvert à la création d'une fournée.
+  - else
+    p.text-sm.text-gray-500
+      | Aucun point de retrait défini.
+      =< link_to "En créer un", new_admin_pickup_location_path, class: "text-blue-600 hover:underline"

--- a/app/views/admin/bake_days/edit.html.slim
+++ b/app/views/admin/bake_days/edit.html.slim
@@ -24,6 +24,8 @@ h1.text-2xl.font-bold.mb-6 Modifier le jour de cuisson
       = f.check_box :market_day, class: "rounded border-gray-300 text-blue-600 focus:ring-blue-500"
       span.text-gray-700.font-medium Jour de marché (capacité four étendue)
 
+  = render "pickup_locations", f: f, bake_day: @bake_day
+
   .flex.gap-3
     = f.submit "Mettre à jour le jour de cuisson", class: "bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
     = link_to "Annuler", admin_bake_day_path(@bake_day), class: "inline-block text-gray-600 hover:underline py-2 px-4"

--- a/app/views/admin/bake_days/new.html.slim
+++ b/app/views/admin/bake_days/new.html.slim
@@ -21,6 +21,8 @@ h1.text-2xl.font-bold.mb-6 Nouveau jour de cuisson
       = f.check_box :market_day, class: "rounded border-gray-300 text-blue-600 focus:ring-blue-500"
       span.text-gray-700.font-medium Jour de marché (capacité four étendue)
 
+  = render "pickup_locations", f: f, bake_day: @bake_day
+
   .flex.gap-3
     = f.submit "Créer le jour de cuisson", class: "bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
     = link_to "Annuler", admin_bake_days_path, class: "inline-block text-gray-600 hover:underline py-2 px-4"

--- a/app/views/admin/bake_days/show.html.slim
+++ b/app/views/admin/bake_days/show.html.slim
@@ -313,8 +313,72 @@
         | Articles & variantes
       button.rounded-full.bg-gray-100.px-4.py-2.text-sm.font-semibold.text-slate-600 type="button" data-dashboard-tabs-target="tab" data-tab="timeline" data-action="dashboard-tabs#show"
         | Flux des commandes
+      button.rounded-full.bg-gray-100.px-4.py-2.text-sm.font-semibold.text-slate-600 type="button" data-dashboard-tabs-target="tab" data-tab="pickup" data-action="dashboard-tabs#show"
+        | Par point de retrait
       button.rounded-full.bg-gray-100.px-4.py-2.text-sm.font-semibold.text-slate-600 type="button" data-dashboard-tabs-target="tab" data-tab="flags" data-action="dashboard-tabs#show"
         | Drapeaux
+
+    / Répartition par point de retrait (#148) : commandes + récapitulatif agrégé
+    / des articles pour chaque lieu, et la feuille d'émargement PDF à imprimer.
+    .mt-6.hidden data-dashboard-tabs-target="panel" data-panel="pickup"
+      - if @dashboard.pickup_location_breakdown.any?
+        .space-y-6
+          - @dashboard.pickup_location_breakdown.each do |entry|
+            - location = entry[:pickup_location]
+            .rounded-xl.border.border-slate-200.overflow-hidden
+              .flex.flex-wrap.items-center.justify-between.gap-3.border-b.border-slate-200.bg-slate-50.px-4.py-3
+                div
+                  p.font-semibold.text-slate-900
+                    = location.name
+                    - if location.deleted_at.present?
+                      span.ml-2.rounded-full.bg-amber-100.px-2.py-0.5.text-xs.font-semibold.text-amber-700 Lieu supprimé
+                  - if location.description.present?
+                    p.text-xs.text-slate-500 = location.description
+                  p.mt-1.text-xs.text-slate-500
+                    = "#{pluralize(entry[:orders_count], 'commande')} · #{number_to_currency(entry[:total_cents] / 100.0, unit: '€', format: '%n %u')}"
+                = link_to pickup_sheet_admin_bake_day_path(@bake_day, pickup_location_id: location.id),
+                  class: "rounded-md bg-indigo-600 px-3 py-2 text-xs font-semibold text-white hover:bg-indigo-700"
+                  | Feuille de retrait (PDF)
+
+              - if entry[:orders].any?
+                .grid.grid-cols-1.gap-4.p-4.lg:grid-cols-2
+                  / Récapitulatif agrégé : ce qui permet de répartir les produits.
+                  div
+                    p.mb-2.text-xs.font-semibold.uppercase.tracking-wide.text-slate-500 Articles à préparer pour ce lieu
+                    .overflow-x-auto.rounded-lg.border.border-slate-100
+                      table.min-w-full.divide-y.divide-slate-100.text-sm
+                        thead.bg-slate-50.text-xs.uppercase.tracking-wide.text-slate-500
+                          tr
+                            th.px-3.py-2.text-left Article
+                            th.px-3.py-2.text-right Quantité
+                        tbody.divide-y.divide-slate-50.bg-white
+                          - entry[:variant_stats].each do |stat|
+                            tr
+                              td.px-3.py-2.text-slate-700
+                                | #{stat[:product].name} (#{stat[:variant].name})
+                              td.px-3.py-2.text-right.font-semibold.text-slate-900 = stat[:units_count]
+
+                  / Détail des commandes du lieu.
+                  div
+                    p.mb-2.text-xs.font-semibold.uppercase.tracking-wide.text-slate-500 Commandes
+                    .space-y-2
+                      - entry[:orders].each do |order|
+                        .rounded-lg.border.border-slate-100.p-3
+                          .flex.items-start.justify-between.gap-3
+                            div
+                              p.text-sm.font-semibold.text-slate-900 = order.customer.full_name
+                              p.text-xs.text-slate-500 = order.order_number
+                            p.text-sm.font-semibold.text-slate-900.whitespace-nowrap
+                              = number_to_currency(order.total_cents / 100.0, unit: "€", format: "%n %u")
+                          ul.mt-2.space-y-0.5
+                            - order.order_items.each do |item|
+                              li.text-xs.text-slate-600
+                                | #{item.qty} × #{item.product_variant.product&.name || 'Produit supprimé'} (#{item.product_variant.name})
+              - else
+                p.px-4.py-6.text-center.text-sm.text-slate-500
+                  | Aucune commande sur ce point de retrait pour cette fournée.
+      - else
+        p.text-center.text-sm.text-slate-500 Aucun point de retrait ouvert sur cette fournée.
 
     .mt-6.hidden data-dashboard-tabs-target="panel" data-panel="products"
       .flex.flex-wrap.items-center.justify-between.gap-3 data-controller="dashboard-filter"

--- a/app/views/admin/bake_days/show.html.slim
+++ b/app/views/admin/bake_days/show.html.slim
@@ -334,8 +334,10 @@
                       span.ml-2.rounded-full.bg-amber-100.px-2.py-0.5.text-xs.font-semibold.text-amber-700 Lieu supprimé
                   - if location.description.present?
                     p.text-xs.text-slate-500 = location.description
+                  / `pluralize` n'accorde pas en locale fr (aucune règle d'inflexion
+                  / française) : on passe le pluriel explicitement.
                   p.mt-1.text-xs.text-slate-500
-                    = "#{pluralize(entry[:orders_count], 'commande')} · #{number_to_currency(entry[:total_cents] / 100.0, unit: '€', format: '%n %u')}"
+                    = "#{pluralize(entry[:orders_count], 'commande', 'commandes')} · #{number_to_currency(entry[:total_cents] / 100.0, unit: '€', format: '%n %u')}"
                 = link_to pickup_sheet_admin_bake_day_path(@bake_day, pickup_location_id: location.id),
                   class: "rounded-md bg-indigo-600 px-3 py-2 text-xs font-semibold text-white hover:bg-indigo-700"
                   | Feuille de retrait (PDF)

--- a/app/views/admin/orders/edit.html.erb
+++ b/app/views/admin/orders/edit.html.erb
@@ -44,6 +44,19 @@
                      { include_blank: "Sélectionner un jour" },
                      class: "mt-1 #{admin_input_class}" %>
       </div>
+
+      <%# Point de retrait (#148) : restreint aux lieux ouverts sur la fournée de
+          cette commande. Si la fournée est changée ci-dessus, la liste ne se met
+          pas à jour dynamiquement — la validation du modèle refuse alors un lieu
+          incohérent à l'enregistrement. %>
+      <div>
+        <%= f.label :pickup_location_id, "Point de retrait", class: "block text-sm font-medium text-gray-700" %>
+        <% pickup_options = @order.bake_day.open_pickup_locations.map { |location| [location.name, location.id] } %>
+        <%= f.select :pickup_location_id,
+                     options_for_select(pickup_options, @order.pickup_location_id),
+                     { include_blank: "Sélectionner un point de retrait" },
+                     class: "mt-1 #{admin_input_class}" %>
+      </div>
     </div>
 
     <div class="mt-8">

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -49,6 +49,19 @@
         <dt class="text-sm font-medium text-gray-500">Jour de cuisson</dt>
         <dd class="mt-1 text-sm text-gray-900"><%= @order.bake_day.baked_on.strftime("%d/%m/%Y") %></dd>
         <dd class="text-sm text-gray-600">Date limite : <%= @order.bake_day.cut_off_at.strftime("%d/%m/%Y à %H:%M") %></dd>
+
+        <% if @order.pickup_location %>
+          <dt class="mt-4 text-sm font-medium text-gray-500">Point de retrait</dt>
+          <dd class="mt-1 text-sm text-gray-900">
+            <%= @order.pickup_location.name %>
+            <% if @order.pickup_location.deleted_at.present? %>
+              <span class="ml-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700">supprimé</span>
+            <% end %>
+          </dd>
+          <% if @order.pickup_location.description.present? %>
+            <dd class="text-sm text-gray-600"><%= @order.pickup_location.description %></dd>
+          <% end %>
+        <% end %>
       </div>
 
       <div>

--- a/app/views/admin/pickup_locations/_form.html.slim
+++ b/app/views/admin/pickup_locations/_form.html.slim
@@ -1,0 +1,45 @@
+= form_with model: [:admin, pickup_location], local: true, class: "bg-white shadow-sm rounded-lg border border-gray-200 p-6 space-y-6" do |f|
+  - if pickup_location.errors.any?
+    .rounded-md.bg-red-50.p-4
+      h2.text-sm.font-semibold.text-red-800 Correction requise
+      ul.mt-2.list-disc.list-inside.text-sm.text-red-700
+        - pickup_location.errors.full_messages.each do |message|
+          li= message
+
+  .grid.grid-cols-1.md:grid-cols-3.gap-6
+    .space-y-2.md:col-span-2
+      = f.label :name, "Nom", class: "block text-sm font-medium text-gray-700"
+      = f.text_field :name, class: admin_input_class
+    .space-y-2
+      = f.label :position, "Ordre d'affichage", class: "block text-sm font-medium text-gray-700"
+      = f.number_field :position, class: admin_input_class
+
+  .space-y-2
+    = f.label :description, "Description affichée au client", class: "block text-sm font-medium text-gray-700"
+    = f.text_area :description, rows: 3, class: admin_input_class
+    p.text-xs.text-gray-500 Courte phrase affichée sous le nom du lieu, au checkout et dans le calendrier.
+
+  .space-y-2
+    label.flex.items-center.gap-2.cursor-pointer
+      = f.check_box :default, class: "rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+      span.text-sm.font-medium.text-gray-700 Point de retrait par défaut
+    p.text-xs.text-gray-500
+      | Un seul lieu peut être par défaut. Il est pré-sélectionné au checkout et automatiquement ouvert sur chaque nouvelle fournée.
+
+  / Cochage bidirectionnel (#148) : on ouvre/ferme ce lieu sur les fournées à venir.
+  / Les fournées passées ne sont pas listées — leur rattachement est conservé tel quel.
+  .space-y-2
+    span.block.text-sm.font-medium.text-gray-700 Fournées à venir sur lesquelles ce lieu est ouvert
+    - assignable = PickupLocation.assignable_bake_days
+    - if assignable.any?
+      .mt-2.grid.grid-cols-1.sm:grid-cols-2.lg:grid-cols-3.gap-2
+        = f.collection_check_boxes :bake_day_ids, assignable, :id, ->(bake_day) { l(bake_day.baked_on, format: :long) } do |b|
+          label.flex.items-center.gap-2.rounded-md.border.border-gray-200.px-3.py-2.cursor-pointer.hover:bg-gray-50
+            = b.check_box class: "rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            = b.text
+    - else
+      p.text-sm.text-gray-500 Aucune fournée à venir.
+
+  .flex.justify-end.space-x-3
+    = link_to "Annuler", admin_pickup_locations_path, class: "px-4 py-2 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+    = f.submit "Enregistrer", class: "px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 cursor-pointer"

--- a/app/views/admin/pickup_locations/edit.html.slim
+++ b/app/views/admin/pickup_locations/edit.html.slim
@@ -1,0 +1,10 @@
+- content_for :title, "Modifier le point de retrait"
+- content_for :layout, "admin"
+
+.mb-6.flex.justify-between.items-center
+  .flex.items-center.gap-3
+    = link_to "Paramètres", admin_settings_path, class: "px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200"
+    = link_to "Points de retrait", admin_pickup_locations_path, class: "px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200"
+  h1.text-2xl.font-bold.text-gray-900 Modifier le point de retrait&nbsp;: #{@pickup_location.name}
+
+= render "form", pickup_location: @pickup_location

--- a/app/views/admin/pickup_locations/index.html.slim
+++ b/app/views/admin/pickup_locations/index.html.slim
@@ -1,0 +1,41 @@
+- content_for :title, "Points de retrait"
+- content_for :layout, "admin"
+
+.mb-6.flex.justify-between.items-center
+  .flex.items-center.gap-3
+    = link_to "Paramètres", admin_settings_path, class: "px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200"
+    h1.text-2xl.font-bold.text-gray-900 Points de retrait
+  = link_to "Nouveau point de retrait", new_admin_pickup_location_path, class: "px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+
+.bg-white.shadow-sm.rounded-lg.border.border-gray-200.overflow-hidden
+  - if @pickup_locations.any?
+    .overflow-x-auto
+      table.min-w-full.divide-y.divide-gray-200
+        thead.bg-gray-100
+          tr
+            th.px-4.py-3.text-left.text-xs.font-medium.text-gray-700.uppercase Ordre
+            th.px-4.py-3.text-left.text-xs.font-medium.text-gray-700.uppercase Nom
+            th.px-4.py-3.text-left.text-xs.font-medium.text-gray-700.uppercase Description
+            th.px-4.py-3.text-left.text-xs.font-medium.text-gray-700.uppercase Par défaut
+            th.px-4.py-3.text-left.text-xs.font-medium.text-gray-700.uppercase Fournées à venir
+            th.px-4.py-3.text-left.text-xs.font-medium.text-gray-700.uppercase Actions
+        tbody.divide-y.divide-gray-200
+          - @pickup_locations.each do |pickup_location|
+            tr
+              td.px-4.py-3.text-sm.text-gray-600 = pickup_location.position
+              td.px-4.py-3.text-sm.text-gray-900.font-medium = pickup_location.name
+              td.px-4.py-3.text-sm.text-gray-600 = pickup_location.description.presence || "—"
+              td.px-4.py-3.text-sm
+                - if pickup_location.default?
+                  span.inline-flex.items-center.rounded-full.bg-green-100.px-2.py-1.text-xs.font-semibold.text-green-800 Par défaut
+                - else
+                  span.text-gray-400 —
+              td.px-4.py-3.text-sm.text-gray-600
+                = pickup_location.bake_days.merge(BakeDay.future).count
+              td.px-4.py-3.text-sm
+                = link_to "Modifier", edit_admin_pickup_location_path(pickup_location), class: "text-blue-600 hover:text-blue-800 mr-3"
+                - unless pickup_location.default?
+                  = button_to "Supprimer", admin_pickup_location_path(pickup_location), method: :delete, data: { turbo_confirm: "Supprimer ce point de retrait ? Les commandes passées continueront de l'afficher." }, class: "text-red-600 hover:text-red-800", form: { class: "inline" }
+  - else
+    .px-4.py-8.text-center.text-sm.text-gray-500
+      | Aucun point de retrait défini

--- a/app/views/admin/pickup_locations/new.html.slim
+++ b/app/views/admin/pickup_locations/new.html.slim
@@ -1,0 +1,10 @@
+- content_for :title, "Nouveau point de retrait"
+- content_for :layout, "admin"
+
+.mb-6.flex.justify-between.items-center
+  .flex.items-center.gap-3
+    = link_to "Paramètres", admin_settings_path, class: "px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200"
+    = link_to "Points de retrait", admin_pickup_locations_path, class: "px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200"
+  h1.text-2xl.font-bold.text-gray-900 Nouveau point de retrait
+
+= render "form", pickup_location: @pickup_location

--- a/app/views/admin/settings/index.html.slim
+++ b/app/views/admin/settings/index.html.slim
@@ -31,6 +31,12 @@
           svg.w-5.h-5 fill="none" stroke="currentColor" viewBox="0 0 24 24"
             path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"
     li
+      = link_to admin_pickup_locations_path, class: "flex items-center justify-between px-4 py-4 hover:bg-gray-50"
+        span.text-sm.font-medium.text-gray-900 Points de retrait
+        span.text-gray-400
+          svg.w-5.h-5 fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"
+    li
       = link_to edit_admin_settings_production_setting_path, class: "flex items-center justify-between px-4 py-4 hover:bg-gray-50"
         span.text-sm.font-medium.text-gray-900 Capacités de production
         span.text-gray-400

--- a/app/views/checkout/new.html.erb
+++ b/app/views/checkout/new.html.erb
@@ -126,6 +126,28 @@
       <h2 class="px-6 pb-3 pt-4 font-script text-2xl font-bold text-ink-900">Paiement</h2>
       <div class="px-6 pb-6 pt-1">
 
+      <!-- Point de retrait (#148) : uniquement les lieux ouverts sur la fournée choisie. -->
+      <div class="mb-4 rounded-md border border-flour-300 bg-flour-100 p-4">
+        <p class="mb-2 text-sm font-medium text-ink-700">Où récupérez-vous votre commande&nbsp;?</p>
+        <div class="space-y-2" id="pickup_location_choices">
+          <% @pickup_locations.each do |location| %>
+            <label class="flex cursor-pointer items-start gap-2 rounded-md border border-flour-400 bg-white p-3 transition hover:border-sage-600">
+              <input type="radio"
+                     name="pickup_location_id"
+                     value="<%= location.id %>"
+                     class="mt-0.5 h-[18px] w-[18px] accent-sage-600"
+                     <%= "checked" if location == @selected_pickup_location %>>
+              <span>
+                <span class="block text-sm font-semibold text-ink-900"><%= location.name %></span>
+                <% if location.description.present? %>
+                  <span class="block text-[13px] text-ink-500"><%= location.description %></span>
+                <% end %>
+              </span>
+            </label>
+          <% end %>
+        </div>
+      </div>
+
       <div class="mb-4 rounded-md border border-flour-300 bg-flour-100 p-4">
         <label class="flex items-center gap-2 text-sm font-medium text-ink-700">
           <input type="checkbox" id="group_purchase_checkbox" class="h-[18px] w-[18px] rounded accent-sage-600">
@@ -345,6 +367,12 @@
     });
   }
 
+  // Point de retrait choisi (#148) : envoyé sur les 3 chemins de paiement.
+  function pickupLocationValue() {
+    const checked = document.querySelector('input[name="pickup_location_id"]:checked');
+    return checked ? checked.value : '';
+  }
+
   // Achat pour un groupe « 4 Sources » (#99) : valeur envoyée à la commande.
   function groupNameValue() {
     const cb = document.getElementById('group_purchase_checkbox');
@@ -498,7 +526,8 @@
         first_name: document.getElementById('customer_first_name')?.value || '',
         last_name: document.getElementById('customer_last_name')?.value || '',
         email: document.getElementById('customer_email')?.value || '',
-        group_name: groupNameValue()
+        group_name: groupNameValue(),
+        pickup_location_id: pickupLocationValue()
       })
     })
     .then(response => {
@@ -664,7 +693,8 @@
             first_name: document.getElementById('customer_first_name')?.value || '',
             last_name: document.getElementById('customer_last_name')?.value || '',
             email: document.getElementById('customer_email')?.value || '',
-            group_name: groupNameValue()
+            group_name: groupNameValue(),
+            pickup_location_id: pickupLocationValue()
           })
         });
 
@@ -724,7 +754,8 @@
             first_name: document.getElementById('customer_first_name')?.value || '',
             last_name: document.getElementById('customer_last_name')?.value || '',
             email: document.getElementById('customer_email')?.value || '',
-            group_name: groupNameValue()
+            group_name: groupNameValue(),
+            pickup_location_id: pickupLocationValue()
           })
         });
 

--- a/app/views/customers/account/show.html.erb
+++ b/app/views/customers/account/show.html.erb
@@ -160,7 +160,7 @@
                    class="flex cursor-pointer items-center justify-between gap-3 rounded-md px-3 py-3 transition hover:bg-flour-100"
                    data-action="click->order-modal#open"
                    data-order-modal-order-id-value="<%= order.id %>"
-                   data-order-modal-order-data-value="<%= order.to_json(include: { bake_day: { only: [ :id, :baked_on, :cut_off_at ] }, order_items: { include: { product_variant: { include: :product } } }, customer: { include: { group: { only: [ :id, :name, :discount_percent ] } } } }) %>">
+                   data-order-modal-order-data-value="<%= order.to_json(include: { bake_day: { only: [ :id, :baked_on, :cut_off_at ] }, pickup_location: { only: [ :id, :name, :description ] }, order_items: { include: { product_variant: { include: :product } } }, customer: { include: { group: { only: [ :id, :name, :discount_percent ] } } } }) %>">
                 <div class="flex min-w-0 items-center gap-3">
                   <span class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full <%= tone[0] %> <%= tone[1] %>"><%= lucide tone[2], size: 18, color: "currentColor" %></span>
                   <div class="min-w-0">

--- a/app/views/customers/calendar/show.html.erb
+++ b/app/views/customers/calendar/show.html.erb
@@ -7,6 +7,8 @@
      data-calendar-skip-wallet-value="<%= current_customer.skip_wallet_check? %>"
      data-calendar-intro-auto-open-value="<%= current_customer.calendar_intro_seen_at.nil? %>"
      data-calendar-intro-mark-seen-url-value="<%= calendar_intro_seen_path %>"
+     data-calendar-pickup-locations-value="<%= @pickup_locations_by_bake_day.map { |bake_day, locations| [bake_day.id, locations.map { |l| { id: l.id, name: l.name, description: l.description } }] }.to_h.to_json %>"
+     data-calendar-preferred-pickup-location-value="<%= @preferred_pickup_location&.id %>"
 >
   <div class="mb-7 flex flex-wrap items-end justify-between gap-3">
     <div>
@@ -90,6 +92,7 @@
                  data-bake-date="<%= l(bake_day.baked_on, format: '%A %d/%m').downcase %>"
                  <% if order %>
                  data-order-items="<%= order.order_items.map { |i| { product_variant_id: i.product_variant_id, qty: i.qty } }.to_json %>"
+                 data-order-pickup-location-id="<%= order&.pickup_location_id %>"
                  <% end %>
                  <% if can_order %>
                  data-action="dragover->calendar#dragOver dragleave->calendar#dragLeave drop->calendar#drop"
@@ -204,6 +207,7 @@
              data-bake-date="<%= l(bake_day.baked_on, format: '%A %d/%m').downcase %>"
              <% if order %>
              data-order-items="<%= order.order_items.map { |i| { product_variant_id: i.product_variant_id, qty: i.qty } }.to_json %>"
+                 data-order-pickup-location-id="<%= order&.pickup_location_id %>"
              <% end %>>
           <div class="flex items-start justify-between">
             <div class="flex items-center gap-3">
@@ -272,6 +276,9 @@
             <div class="max-h-[50vh] space-y-3 overflow-y-auto" data-calendar-target="productList">
               <!-- Products will be rendered here by Stimulus -->
             </div>
+
+            <!-- Point de retrait (#148) : rempli par Stimulus, limité aux lieux ouverts sur cette date -->
+            <div class="mt-4 border-t border-flour-300 pt-4" data-calendar-target="pickupLocation"></div>
 
             <!-- Total -->
             <div class="mt-4 flex items-center justify-between border-t border-flour-300 pt-4">

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -31,6 +31,16 @@
         <p class="text-ink-700"><%= @order.bake_day.baked_on.strftime("%d/%m/%Y") %></p>
       </div>
 
+      <% if @order.pickup_location %>
+        <div class="mb-6">
+          <h2 class="mb-3 font-sans text-sm font-semibold uppercase tracking-wide text-ink-500">Point de retrait</h2>
+          <p class="font-semibold text-ink-900"><%= @order.pickup_location.name %></p>
+          <% if @order.pickup_location.description.present? %>
+            <p class="text-sm text-ink-500"><%= @order.pickup_location.description %></p>
+          <% end %>
+        </div>
+      <% end %>
+
       <div class="mb-6">
         <h2 class="mb-3 font-sans text-sm font-semibold uppercase tracking-wide text-ink-500">Articles</h2>
         <div class="space-y-1">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,7 @@ Rails.application.routes.draw do
       resources :groups, only: [ :index, :show ]
       resources :flours, only: [ :index, :show ]
       resources :mold_types, only: [ :index, :show ]
+      resources :pickup_locations, only: [ :index, :show ]
       resources :ingredients, only: [ :index, :show ]
       resources :artisans, only: [ :index, :show ]
       resource :production_setting, only: [ :show ]
@@ -177,8 +178,15 @@ Rails.application.routes.draw do
       member do
         get :confirm_cancel
         post :cancel
+        # Feuille d'émargement PDF d'un point de retrait (#148), paramétrée par
+        # ?pickup_location_id= — même pattern que Admin::InvoicesController.
+        get :pickup_sheet
       end
     end
+
+    # Points de retrait (#148) : CRUD + cochage des fournées ouvertes.
+    resources :pickup_locations, path: "points-de-retrait",
+      only: [ :index, :new, :create, :edit, :update, :destroy ]
 
     get "parametres", to: "settings#index", as: :settings
     scope path: "parametres", as: "settings", module: "settings" do

--- a/db/migrate/20260714010000_create_pickup_locations.rb
+++ b/db/migrate/20260714010000_create_pickup_locations.rb
@@ -1,0 +1,29 @@
+class CreatePickupLocations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :pickup_locations do |t|
+      t.string :name, null: false
+      t.text :description
+      t.boolean :default, null: false, default: false
+      t.integer :position, null: false, default: 0
+      t.datetime :deleted_at
+
+      t.timestamps
+    end
+
+    add_index :pickup_locations, :deleted_at
+    # Un seul lieu par défaut à la fois (les lieux supprimés ne comptent pas).
+    add_index :pickup_locations, :default, unique: true,
+      where: "\"default\" = true AND deleted_at IS NULL",
+      name: "index_pickup_locations_on_single_default"
+
+    create_table :bake_day_pickup_locations do |t|
+      t.references :bake_day, null: false, foreign_key: true
+      t.references :pickup_location, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :bake_day_pickup_locations, [ :bake_day_id, :pickup_location_id ],
+      unique: true, name: "index_bake_day_pickup_locations_on_pair"
+  end
+end

--- a/db/migrate/20260714010001_add_pickup_location_to_orders.rb
+++ b/db/migrate/20260714010001_add_pickup_location_to_orders.rb
@@ -1,0 +1,64 @@
+class AddPickupLocationToOrders < ActiveRecord::Migration[8.0]
+  # Rattachement rétroactif : jusqu'ici toute commande était implicitement
+  # retirée aux 4 Sources. On crée le lieu par défaut, on l'ouvre sur toutes les
+  # fournées existantes, on backfill les commandes, et SEULEMENT ensuite on pose
+  # la contrainte NOT NULL (sans quoi la migration échouerait sur une base ayant
+  # déjà des commandes).
+  #
+  # Les modèles ne sont pas utilisés ici (une migration doit rester valable même
+  # si le code applicatif évolue) : tout passe par du SQL.
+  def up
+    add_reference :orders, :pickup_location, null: true, foreign_key: true
+
+    seed_pickup_locations
+    open_default_on_every_bake_day
+    backfill_orders
+
+    change_column_null :orders, :pickup_location_id, false
+  end
+
+  def down
+    remove_reference :orders, :pickup_location, foreign_key: true
+  end
+
+  private
+
+  def seed_pickup_locations
+    execute(<<~SQL.squish)
+      INSERT INTO pickup_locations (name, description, "default", position, created_at, updated_at)
+      SELECT 'Les 4 Sources',
+             'Retrait à la boulangerie des 4 Sources, sur le site de Bauche.',
+             true, 0, NOW(), NOW()
+      WHERE NOT EXISTS (SELECT 1 FROM pickup_locations WHERE name = 'Les 4 Sources')
+    SQL
+
+    execute(<<~SQL.squish)
+      INSERT INTO pickup_locations (name, description, "default", position, created_at, updated_at)
+      SELECT 'Marché d''Anhée',
+             'Retrait sur notre étal, les jours de marché à Anhée.',
+             false, 1, NOW(), NOW()
+      WHERE NOT EXISTS (SELECT 1 FROM pickup_locations WHERE name = 'Marché d''Anhée')
+    SQL
+  end
+
+  def open_default_on_every_bake_day
+    execute(<<~SQL.squish)
+      INSERT INTO bake_day_pickup_locations (bake_day_id, pickup_location_id, created_at, updated_at)
+      SELECT bake_days.id, #{default_location_id_sql}, NOW(), NOW()
+      FROM bake_days
+      ON CONFLICT DO NOTHING
+    SQL
+  end
+
+  def backfill_orders
+    execute(<<~SQL.squish)
+      UPDATE orders
+      SET pickup_location_id = #{default_location_id_sql}
+      WHERE pickup_location_id IS NULL
+    SQL
+  end
+
+  def default_location_id_sql
+    "(SELECT id FROM pickup_locations WHERE \"default\" = true AND deleted_at IS NULL LIMIT 1)"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_03_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_14_010001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -76,6 +76,16 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_03_120000) do
     t.index ["artisan_id"], name: "index_bake_day_artisans_on_artisan_id"
     t.index ["bake_day_id", "artisan_id"], name: "index_bake_day_artisans_on_bake_day_id_and_artisan_id", unique: true
     t.index ["bake_day_id"], name: "index_bake_day_artisans_on_bake_day_id"
+  end
+
+  create_table "bake_day_pickup_locations", force: :cascade do |t|
+    t.bigint "bake_day_id", null: false
+    t.bigint "pickup_location_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["bake_day_id", "pickup_location_id"], name: "index_bake_day_pickup_locations_on_pair", unique: true
+    t.index ["bake_day_id"], name: "index_bake_day_pickup_locations_on_bake_day_id"
+    t.index ["pickup_location_id"], name: "index_bake_day_pickup_locations_on_pickup_location_id"
   end
 
   create_table "bake_days", force: :cascade do |t|
@@ -268,11 +278,13 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_03_120000) do
     t.integer "payment_status", default: 0, null: false
     t.integer "invoice_status", default: 0, null: false
     t.string "group_name"
+    t.bigint "pickup_location_id", null: false
     t.index ["bake_day_id"], name: "index_orders_on_bake_day_id"
     t.index ["customer_id"], name: "index_orders_on_customer_id"
     t.index ["order_number"], name: "index_orders_on_order_number"
     t.index ["payment_intent_id"], name: "index_orders_on_payment_intent_id", unique: true, where: "(payment_intent_id IS NOT NULL)"
     t.index ["payment_status"], name: "index_orders_on_payment_status"
+    t.index ["pickup_location_id"], name: "index_orders_on_pickup_location_id"
     t.index ["public_token"], name: "index_orders_on_public_token", unique: true
     t.index ["source"], name: "index_orders_on_source"
     t.index ["status"], name: "index_orders_on_status"
@@ -301,6 +313,18 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_03_120000) do
     t.index ["code"], name: "index_phone_verifications_on_code"
     t.index ["email"], name: "index_phone_verifications_on_email"
     t.index ["phone_e164"], name: "index_phone_verifications_on_phone_e164"
+  end
+
+  create_table "pickup_locations", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.boolean "default", default: false, null: false
+    t.integer "position", default: 0, null: false
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["default"], name: "index_pickup_locations_on_single_default", unique: true, where: "((\"default\" = true) AND (deleted_at IS NULL))"
+    t.index ["deleted_at"], name: "index_pickup_locations_on_deleted_at"
   end
 
   create_table "product_availabilities", force: :cascade do |t|
@@ -371,7 +395,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_03_120000) do
     t.string "channel", default: "store", null: false
     t.datetime "deleted_at"
     t.integer "internal_category", default: 0, null: false
-    t.boolean "pizza_party", default: false, null: false
     t.integer "pizza_party_role", default: 0, null: false
     t.index ["category", "position", "name"], name: "index_products_on_category_and_position_and_name"
     t.index ["category"], name: "index_products_on_category"
@@ -611,6 +634,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_03_120000) do
   add_foreign_key "artisan_revenue_shares", "artisans"
   add_foreign_key "bake_day_artisans", "artisans"
   add_foreign_key "bake_day_artisans", "bake_days"
+  add_foreign_key "bake_day_pickup_locations", "bake_days"
+  add_foreign_key "bake_day_pickup_locations", "pickup_locations"
   add_foreign_key "customer_groups", "customers"
   add_foreign_key "customer_groups", "groups"
   add_foreign_key "group_product_discounts", "groups"
@@ -623,6 +648,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_03_120000) do
   add_foreign_key "order_items", "product_variants"
   add_foreign_key "orders", "bake_days"
   add_foreign_key "orders", "customers"
+  add_foreign_key "orders", "pickup_locations"
   add_foreign_key "payments", "orders"
   add_foreign_key "product_availabilities", "product_variants"
   add_foreign_key "product_flours", "flours"

--- a/spec/factories/bake_days.rb
+++ b/spec/factories/bake_days.rb
@@ -4,6 +4,14 @@ FactoryBot.define do
     baked_on { Date.current.next_occurring(:tuesday) }
     cut_off_at { BakeDay.calculate_cut_off_for(baked_on) || 2.days.ago }
 
+    # Toute fournée ouvre au moins le lieu de retrait par défaut (#148) — comme
+    # en production, où « Les 4 Sources » est créé par migration et coché
+    # automatiquement sur chaque nouvelle fournée. Sans lui, les commandes n'ont
+    # aucun lieu où retomber.
+    before(:create) do
+      PickupLocation.default_location || FactoryBot.create(:pickup_location, :default)
+    end
+
     trait :tuesday do
       baked_on { Date.current.next_occurring(:tuesday) }
       cut_off_at { BakeDay.calculate_cut_off_for(baked_on) }

--- a/spec/factories/pickup_locations.rb
+++ b/spec/factories/pickup_locations.rb
@@ -1,0 +1,21 @@
+FactoryBot.define do
+  factory :pickup_location do
+    sequence(:name) { |n| "Point de retrait #{n}" }
+    description { "Description affichée au client." }
+    default { false }
+    sequence(:position) { |n| n }
+
+    # Le lieu par défaut (« Les 4 Sources » en production). Un seul à la fois :
+    # `PickupLocation.default_location` doit rester libre avant de l'utiliser.
+    trait :default do
+      name { "Les 4 Sources" }
+      description { "Retrait à la boulangerie des 4 Sources, sur le site de Bauche." }
+      default { true }
+      position { 0 }
+    end
+
+    trait :deleted do
+      deleted_at { Time.current }
+    end
+  end
+end

--- a/spec/models/bake_day_pickup_location_spec.rb
+++ b/spec/models/bake_day_pickup_location_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+# Cochage lieu de retrait ↔ fournée (#148), côté fournée.
+RSpec.describe BakeDay, type: :model do
+  let!(:default_location) { create(:pickup_location, :default) }
+  let(:anhee) { create(:pickup_location, name: "Marché d'Anhée") }
+
+  describe "lieu par défaut à la création" do
+    it "coche automatiquement le lieu par défaut sur une nouvelle fournée" do
+      bake_day = BakeDay.create!(
+        baked_on: Date.current.next_occurring(:tuesday),
+        cut_off_at: 2.days.from_now
+      )
+
+      expect(bake_day.open_pickup_locations).to eq([ default_location ])
+    end
+
+    it "coche le lieu par défaut même si l'admin ne coche rien" do
+      bake_day = BakeDay.new(
+        baked_on: Date.current.next_occurring(:friday),
+        cut_off_at: 2.days.from_now
+      )
+      bake_day.pickup_location_ids = []
+      bake_day.save!
+
+      expect(bake_day.open_pickup_locations).to include(default_location)
+    end
+  end
+
+  describe "décochage d'un lieu utilisé par des commandes" do
+    let(:bake_day) { create(:bake_day, :can_order) }
+
+    before do
+      bake_day.pickup_location_ids = [ default_location.id, anhee.id ]
+      bake_day.save!
+    end
+
+    it "refuse le décochage et indique le nombre de commandes concernées" do
+      create(:order, bake_day: bake_day, pickup_location: anhee)
+      create(:order, bake_day: bake_day, pickup_location: anhee)
+
+      bake_day.pickup_location_ids = [ default_location.id ]
+
+      expect(bake_day.save).to be false
+      expect(bake_day.errors[:pickup_locations].join).to include("Marché d'Anhée")
+      expect(bake_day.errors[:pickup_locations].join).to include("2 commandes")
+    end
+
+    it "accorde le message au singulier pour une seule commande" do
+      create(:order, bake_day: bake_day, pickup_location: anhee)
+
+      bake_day.pickup_location_ids = [ default_location.id ]
+      bake_day.save
+
+      expect(bake_day.errors[:pickup_locations].join).to include("1 commande y est rattachée")
+    end
+
+    it "ne supprime PAS la jointure quand la validation échoue" do
+      create(:order, bake_day: bake_day, pickup_location: anhee)
+
+      bake_day.pickup_location_ids = [ default_location.id ]
+      bake_day.save
+
+      expect(bake_day.reload.open_pickup_locations).to include(anhee)
+    end
+
+    it "autorise le décochage d'un lieu sans commande" do
+      bake_day.pickup_location_ids = [ default_location.id ]
+
+      expect(bake_day.save).to be true
+      expect(bake_day.reload.open_pickup_locations).to eq([ default_location ])
+    end
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -464,6 +464,32 @@ RSpec.describe Order, type: :model do
     end
   end
 
+  describe 'point de retrait (#148)' do
+    let!(:default_location) { create(:pickup_location, :default) }
+    let(:anhee) { create(:pickup_location, name: "Marché d'Anhée") }
+    let(:bake_day) { create(:bake_day, :can_order) }
+
+    it "rejette un lieu qui n'est pas ouvert sur la fournée de la commande" do
+      order = build(:order, bake_day: bake_day, pickup_location: anhee)
+
+      expect(order).not_to be_valid
+      expect(order.errors[:pickup_location].join).to include("n'est pas disponible pour cette fournée")
+    end
+
+    it 'accepte un lieu ouvert sur la fournée' do
+      bake_day.pickup_location_ids = [ default_location.id, anhee.id ]
+      bake_day.save!
+
+      expect(build(:order, bake_day: bake_day, pickup_location: anhee)).to be_valid
+    end
+
+    it 'retombe sur le lieu par défaut de la fournée quand aucun lieu n\'est fourni' do
+      order = create(:order, bake_day: bake_day)
+
+      expect(order.pickup_location).to eq(default_location)
+    end
+  end
+
   describe '#bread_bags_cost_cents (#52)' do
     let(:bread) { create(:product_variant, product: create(:product, category: :breads, internal_category: :boulangerie)) }
 

--- a/spec/models/pickup_location_spec.rb
+++ b/spec/models/pickup_location_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+RSpec.describe PickupLocation, type: :model do
+  describe "lieu par défaut" do
+    it "n'autorise qu'un seul lieu par défaut" do
+      create(:pickup_location, :default)
+
+      other = build(:pickup_location, name: "Marché d'Anhée", default: true)
+
+      expect(other).not_to be_valid
+      expect(other.errors[:default]).to be_present
+    end
+
+    it "autorise autant de lieux non-défaut que voulu" do
+      create(:pickup_location, :default)
+
+      expect(build(:pickup_location, name: "Marché d'Anhée")).to be_valid
+      expect(build(:pickup_location, name: "Marché de Dinant")).to be_valid
+    end
+
+    it "expose le lieu par défaut via .default_location" do
+      default = create(:pickup_location, :default)
+      create(:pickup_location, name: "Marché d'Anhée")
+
+      expect(described_class.default_location).to eq(default)
+    end
+
+    it "ignore un lieu par défaut supprimé" do
+      create(:pickup_location, :default, :deleted)
+
+      expect(described_class.default_location).to be_nil
+    end
+  end
+
+  describe "soft delete" do
+    it "retire le lieu des sélecteurs sans casser les commandes qui le référencent" do
+      location = create(:pickup_location, name: "Marché d'Anhée")
+      bake_day = create(:bake_day)
+      bake_day.pickup_location_ids = bake_day.pickup_location_ids + [ location.id ]
+      bake_day.save!
+      order = create(:order, bake_day: bake_day, pickup_location: location)
+
+      location.soft_delete!
+
+      expect(described_class.not_deleted).not_to include(location)
+      # La commande reste lisible et affiche toujours le nom du lieu.
+      expect(order.reload.pickup_location.name).to eq("Marché d'Anhée")
+    end
+  end
+
+  describe "ordre d'affichage" do
+    it "trie par position puis par nom" do
+      create(:pickup_location, :default, position: 0)
+      anhee = create(:pickup_location, name: "Marché d'Anhée", position: 2)
+      dinant = create(:pickup_location, name: "Marché de Dinant", position: 1)
+
+      expect(described_class.not_deleted.ordered.map(&:name))
+        .to eq([ "Les 4 Sources", dinant.name, anhee.name ])
+    end
+  end
+
+  describe "cochage des fournées depuis la fiche du lieu" do
+    let!(:default_location) { create(:pickup_location, :default) }
+    let(:location) { create(:pickup_location, name: "Marché d'Anhée") }
+    let(:bake_day) { create(:bake_day, :can_order) }
+
+    it "ouvre le lieu sur les fournées cochées" do
+      location.update!(bake_day_ids: [ bake_day.id ])
+
+      expect(bake_day.reload.open_pickup_locations).to include(location)
+    end
+
+    it "refuse de fermer une fournée dont des commandes utilisent ce lieu" do
+      location.update!(bake_day_ids: [ bake_day.id ])
+      create(:order, bake_day: bake_day, pickup_location: location)
+
+      location.bake_day_ids = []
+
+      expect(location.save).to be false
+      expect(location.errors[:bake_days].join).to include("1 commande")
+      # La jointure n'a PAS été supprimée : la validation a bien bloqué en amont.
+      expect(bake_day.reload.open_pickup_locations).to include(location)
+    end
+
+    it "conserve le rattachement aux fournées passées, absentes du formulaire" do
+      past_bake_day = create(:bake_day, :past)
+      BakeDayPickupLocation.create!(bake_day: past_bake_day, pickup_location: location)
+
+      # Le formulaire ne liste que les fournées à venir : il ne renvoie donc
+      # jamais l'id d'une fournée passée. Elle ne doit pas être détachée pour autant.
+      location.update!(bake_day_ids: [ bake_day.id ])
+
+      expect(past_bake_day.reload.open_pickup_locations).to include(location)
+    end
+  end
+end

--- a/spec/requests/admin/pickup_locations_spec.rb
+++ b/spec/requests/admin/pickup_locations_spec.rb
@@ -1,0 +1,125 @@
+require "rails_helper"
+
+# Admin des points de retrait (#148) : CRUD, cochage bidirectionnel lieu ↔ fournée,
+# onglet « Par point de retrait » du tableau de bord et feuille de retrait PDF.
+RSpec.describe "Admin — points de retrait", type: :request do
+  let!(:default_location) { create(:pickup_location, :default) }
+  let!(:anhee) { create(:pickup_location, name: "Marché d'Anhée", description: "Sur notre étal.") }
+
+  before do
+    ENV["ADMIN_PASSWORD"] = "test-admin-pw"
+    post admin_login_path, params: { password: "test-admin-pw" }
+  end
+
+  describe "CRUD" do
+    it "liste les points de retrait" do
+      get admin_pickup_locations_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Les 4 Sources")
+      expect(response.body).to include(CGI.escapeHTML("Marché d'Anhée"))
+    end
+
+    it "crée un point de retrait" do
+      expect {
+        post admin_pickup_locations_path, params: {
+          pickup_location: { name: "Marché de Dinant", description: "Place Reine Astrid.", position: 3 }
+        }
+      }.to change(PickupLocation, :count).by(1)
+
+      expect(PickupLocation.last.name).to eq("Marché de Dinant")
+    end
+
+    it "supprime un lieu en soft delete, sans casser les commandes qui le référencent" do
+      bake_day = create(:bake_day, :can_order)
+      bake_day.pickup_location_ids = [ default_location.id, anhee.id ]
+      bake_day.save!
+      order = create(:order, bake_day: bake_day, pickup_location: anhee)
+
+      delete admin_pickup_location_path(anhee)
+
+      expect(anhee.reload.deleted_at).to be_present
+      expect(PickupLocation.not_deleted).not_to include(anhee)
+      expect(order.reload.pickup_location).to eq(anhee) # toujours lisible
+    end
+
+    it "refuse de supprimer le lieu par défaut" do
+      delete admin_pickup_location_path(default_location)
+
+      expect(default_location.reload.deleted_at).to be_nil
+    end
+  end
+
+  describe "cochage des fournées depuis la fiche du lieu" do
+    let(:bake_day) { create(:bake_day, :can_order) }
+
+    it "ouvre le lieu sur les fournées cochées" do
+      patch admin_pickup_location_path(anhee), params: {
+        pickup_location: { name: anhee.name, bake_day_ids: [ bake_day.id ] }
+      }
+
+      expect(bake_day.reload.open_pickup_locations).to include(anhee)
+    end
+  end
+
+  describe "cochage des lieux depuis la fiche de la fournée" do
+    let(:bake_day) { create(:bake_day, :can_order) }
+
+    it "ouvre les lieux cochés" do
+      patch admin_bake_day_path(bake_day), params: {
+        bake_day: { baked_on: bake_day.baked_on, cut_off_at: bake_day.cut_off_at,
+                    pickup_location_ids: [ default_location.id, anhee.id ] }
+      }
+
+      expect(bake_day.reload.open_pickup_locations).to contain_exactly(default_location, anhee)
+    end
+
+    it "REFUSE de décocher un lieu utilisé par des commandes de cette fournée" do
+      bake_day.pickup_location_ids = [ default_location.id, anhee.id ]
+      bake_day.save!
+      create(:order, bake_day: bake_day, pickup_location: anhee)
+      create(:order, bake_day: bake_day, pickup_location: anhee)
+
+      patch admin_bake_day_path(bake_day), params: {
+        bake_day: { baked_on: bake_day.baked_on, cut_off_at: bake_day.cut_off_at,
+                    pickup_location_ids: [ default_location.id ] }
+      }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("2 commandes")
+      # Le lieu est toujours ouvert : rien n'a été supprimé.
+      expect(bake_day.reload.open_pickup_locations).to include(anhee)
+    end
+  end
+
+  describe "tableau de bord de fournée" do
+    let(:bake_day) { create(:bake_day, :can_order) }
+    let(:product) { create(:product, :bread, name: "Pain froment") }
+    let(:variant) { create(:product_variant, product: product, name: "Grand 1 kg", price_cents: 700) }
+
+    before do
+      bake_day.pickup_location_ids = [ default_location.id, anhee.id ]
+      bake_day.save!
+
+      order = create(:order, :paid, bake_day: bake_day, pickup_location: anhee, total_cents: 1400)
+      create(:order_item, order: order, product_variant: variant, qty: 2, unit_price_cents: 700)
+    end
+
+    it "affiche l'onglet « Par point de retrait » avec le récapitulatif du lieu" do
+      get admin_bake_day_path(bake_day)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Par point de retrait")
+      expect(response.body).to include("Articles à préparer pour ce lieu")
+      expect(response.body).to include(CGI.escapeHTML("Marché d'Anhée"))
+    end
+
+    it "propose le téléchargement de la feuille de retrait PDF" do
+      get pickup_sheet_admin_bake_day_path(bake_day, pickup_location_id: anhee.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("application/pdf")
+      expect(response.body).to start_with("%PDF")
+    end
+  end
+end

--- a/spec/requests/api/v1/pickup_locations_spec.rb
+++ b/spec/requests/api/v1/pickup_locations_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+# Ressource « points de retrait » exposée à l'API agent (#148).
+RSpec.describe "Api::V1 pickup_locations", type: :request do
+  let(:api_key) { "test-secret-key" }
+  let(:auth) { { "Authorization" => "Bearer #{api_key}" } }
+
+  around do |example|
+    original = ENV["TRANCHESDEVIE_API_KEY"]
+    ENV["TRANCHESDEVIE_API_KEY"] = api_key
+    example.run
+    ENV["TRANCHESDEVIE_API_KEY"] = original
+  end
+
+  let!(:default_location) { create(:pickup_location, :default) }
+  let!(:anhee) { create(:pickup_location, name: "Marché d'Anhée", description: "Sur notre étal.") }
+
+  it "exige un token" do
+    get "/api/v1/pickup_locations"
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it "liste les points de retrait non supprimés" do
+    deleted = create(:pickup_location, name: "Ancien marché", deleted_at: Time.current)
+
+    get "/api/v1/pickup_locations", headers: auth
+
+    expect(response).to have_http_status(:ok)
+    names = JSON.parse(response.body)["data"].map { |l| l["name"] }
+    expect(names).to contain_exactly("Les 4 Sources", "Marché d'Anhée")
+    expect(names).not_to include(deleted.name)
+  end
+
+  it "expose le drapeau « par défaut »" do
+    get "/api/v1/pickup_locations/#{default_location.id}", headers: auth
+
+    data = JSON.parse(response.body)["data"]
+    expect(data["name"]).to eq("Les 4 Sources")
+    expect(data["default"]).to be true
+    expect(data["deleted"]).to be false
+  end
+
+  it "laisse consultable un lieu supprimé (des commandes le référencent encore)" do
+    anhee.soft_delete!
+
+    get "/api/v1/pickup_locations/#{anhee.id}", headers: auth
+
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body).dig("data", "deleted")).to be true
+  end
+
+  describe "champ point de retrait sur une commande" do
+    it "expose le lieu de retrait de la commande" do
+      bake_day = create(:bake_day, :can_order)
+      bake_day.pickup_location_ids = [ default_location.id, anhee.id ]
+      bake_day.save!
+      order = create(:order, bake_day: bake_day, pickup_location: anhee)
+
+      get "/api/v1/orders/#{order.id}", headers: auth
+
+      data = JSON.parse(response.body)["data"]
+      expect(data["pickup_location_id"]).to eq(anhee.id)
+      expect(data.dig("pickup_location", "name")).to eq("Marché d'Anhée")
+      expect(data.dig("_links", "pickup_location")).to include("pickup_locations")
+    end
+  end
+
+  describe "découvrabilité" do
+    it "apparaît dans l'index de découverte" do
+      get "/api/v1", headers: auth
+
+      expect(response.body).to include("pickup_locations")
+    end
+
+    # Les 3 surfaces de doc sont générées depuis ResourceCatalog : les y voir
+    # toutes prouve que le catalogue est bien la source de vérité.
+    it "apparaît dans le spec OpenAPI (chemins relatifs au basePath)" do
+      get "/api/v1/openapi", headers: auth
+
+      paths = JSON.parse(response.body)["paths"]
+      expect(paths).to have_key("/pickup_locations")
+      expect(paths).to have_key("/pickup_locations/{id}")
+    end
+
+    it "apparaît dans le guide markdown" do
+      get "/api/v1/docs", headers: auth
+
+      expect(response.body).to include("pickup_locations")
+    end
+  end
+end

--- a/spec/requests/checkout_pickup_location_spec.rb
+++ b/spec/requests/checkout_pickup_location_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+# Le point de retrait (#148) circule de bout en bout sur les TROIS chemins de
+# paiement : Stripe, espèces, portefeuille.
+RSpec.describe 'Checkout — point de retrait', type: :request do
+  let!(:default_location) { create(:pickup_location, :default) }
+  let!(:anhee) { create(:pickup_location, name: "Marché d'Anhée", description: "Sur notre étal.") }
+  let!(:dinant) { create(:pickup_location, name: "Marché de Dinant") }
+
+  let(:bake_day) { create(:bake_day, :can_order) }
+  let!(:product) { create(:product, channel: 'store') }
+  let!(:variant) { create(:product_variant, product: product, channel: 'store', price_cents: 550) }
+  let(:customer) { create(:customer, first_name: 'Léa') }
+
+  before do
+    allow(OrderNotificationService).to receive(:send_confirmation)
+    allow(OtpService).to receive(:send_code).and_return({ success: true, channel: :sms })
+    allow(OtpService).to receive(:verify_code).and_return({ success: true })
+
+    # « Marché d'Anhée » est ouvert sur cette fournée ; « Marché de Dinant » non.
+    bake_day.pickup_location_ids = [ default_location.id, anhee.id ]
+    bake_day.save!
+
+    post '/connexion', params: { identifier: customer.phone_e164 }
+    post '/connexion', params: { identifier: customer.phone_e164, otp_code: '123456' }
+    post '/cart/add', params: { product_variant_id: variant.id, bake_day_id: bake_day.id, quantity: 1 }
+  end
+
+  def post_json(path, body)
+    post path, params: body.to_json, headers: { 'CONTENT_TYPE' => 'application/json' }
+  end
+
+  describe "l'écran de checkout" do
+    it "n'affiche que les lieux ouverts sur la fournée choisie" do
+      get '/checkout/new'
+
+      # Les apostrophes sont échappées par ERB (« d&#39;Anhée ») : on compare donc
+      # à la version échappée du nom.
+      expect(response.body).to include(CGI.escapeHTML(anhee.name))
+      expect(response.body).to include("Sur notre étal.")       # description affichée
+      expect(response.body).to include("Les 4 Sources")
+      expect(response.body).not_to include("Marché de Dinant")  # non ouvert sur cette fournée
+    end
+
+    it 'pré-sélectionne le lieu par défaut' do
+      get '/checkout/new'
+
+      expect(response.body).to match(/value="#{default_location.id}"[^>]*checked/)
+    end
+  end
+
+  describe 'chemin Stripe (create_payment_intent)' do
+    before { stub_stripe_payment_intent_create(amount: 550) }
+
+    it 'persiste le point de retrait choisi' do
+      post_json '/checkout/create_payment_intent', { first_name: 'Léa', pickup_location_id: anhee.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(Order.order(:created_at).last.pickup_location).to eq(anhee)
+    end
+
+    it 'rejette un lieu non ouvert sur la fournée' do
+      post_json '/checkout/create_payment_intent', { first_name: 'Léa', pickup_location_id: dinant.id }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(Order.count).to eq(0)
+    end
+
+    it 'rejette un lieu inconnu' do
+      post_json '/checkout/create_payment_intent', { first_name: 'Léa', pickup_location_id: 999_999 }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(Order.count).to eq(0)
+    end
+
+    it 'retombe sur le lieu par défaut si aucun lieu n\'est transmis' do
+      post_json '/checkout/create_payment_intent', { first_name: 'Léa' }
+
+      expect(Order.order(:created_at).last.pickup_location).to eq(default_location)
+    end
+  end
+
+  describe 'chemin espèces (create_cash_order)' do
+    before { customer.update!(cash_payment_allowed: true) }
+
+    it 'persiste le point de retrait choisi' do
+      post_json '/checkout/create_cash_order', { first_name: 'Léa', pickup_location_id: anhee.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(Order.order(:created_at).last.pickup_location).to eq(anhee)
+    end
+
+    it 'rejette un lieu non ouvert sur la fournée' do
+      post_json '/checkout/create_cash_order', { first_name: 'Léa', pickup_location_id: dinant.id }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(Order.count).to eq(0)
+    end
+  end
+
+  describe 'chemin portefeuille (create_wallet_order)' do
+    before { create(:wallet, customer: customer, balance_cents: 10_000) }
+
+    it 'persiste le point de retrait choisi' do
+      post_json '/checkout/create_wallet_order', { first_name: 'Léa', pickup_location_id: anhee.id }
+
+      expect(response).to have_http_status(:ok)
+      expect(Order.order(:created_at).last.pickup_location).to eq(anhee)
+    end
+
+    it 'rejette un lieu non ouvert sur la fournée' do
+      post_json '/checkout/create_wallet_order', { first_name: 'Léa', pickup_location_id: dinant.id }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(Order.count).to eq(0)
+    end
+  end
+end

--- a/spec/requests/customers/calendar_pickup_location_spec.rb
+++ b/spec/requests/customers/calendar_pickup_location_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+# Point de retrait dans le calendrier (#148) : choisi date par date.
+RSpec.describe 'Calendrier — point de retrait', type: :request do
+  let!(:default_location) { create(:pickup_location, :default) }
+  let!(:anhee) { create(:pickup_location, name: "Marché d'Anhée") }
+
+  let(:customer) { create(:customer) }
+  let(:bake_day) { create(:bake_day, :can_order) }
+  let!(:variant) { create(:product_variant, price_cents: 700) }
+
+  before do
+    allow(OtpService).to receive(:send_code).and_return({ success: true, channel: :sms })
+    allow(OtpService).to receive(:verify_code).and_return({ success: true })
+
+    bake_day.pickup_location_ids = [ default_location.id, anhee.id ]
+    bake_day.save!
+
+    create(:wallet, customer: customer, balance_cents: 50_000)
+
+    post '/connexion', params: { identifier: customer.phone_e164 }
+    post '/connexion', params: { identifier: customer.phone_e164, otp_code: '123456' }
+  end
+
+  def update_day(params)
+    patch '/calendrier/update_day', params: params.to_json,
+          headers: { 'CONTENT_TYPE' => 'application/json' }
+  end
+
+  it 'persiste le point de retrait transmis' do
+    update_day(
+      bake_day_id: bake_day.id,
+      items: [ { product_variant_id: variant.id, qty: 2 } ],
+      pickup_location_id: anhee.id
+    )
+
+    expect(response).to have_http_status(:ok)
+    expect(customer.orders.last.pickup_location).to eq(anhee)
+  end
+
+  it 'conserve le lieu quand une mise à jour ne touche que les articles' do
+    update_day(
+      bake_day_id: bake_day.id,
+      items: [ { product_variant_id: variant.id, qty: 2 } ],
+      pickup_location_id: anhee.id
+    )
+
+    update_day(
+      bake_day_id: bake_day.id,
+      items: [ { product_variant_id: variant.id, qty: 4 } ]
+    )
+
+    order = customer.orders.last
+    expect(order.pickup_location).to eq(anhee)
+    expect(order.order_items.sum(&:qty)).to eq(4)
+  end
+
+  it "rejette un lieu non ouvert sur la fournée" do
+    closed = create(:pickup_location, name: "Marché de Dinant")
+
+    update_day(
+      bake_day_id: bake_day.id,
+      items: [ { product_variant_id: variant.id, qty: 1 } ],
+      pickup_location_id: closed.id
+    )
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(customer.orders.count).to eq(0)
+  end
+
+  it "retombe sur le lieu par défaut si aucun lieu n'est transmis" do
+    update_day(
+      bake_day_id: bake_day.id,
+      items: [ { product_variant_id: variant.id, qty: 1 } ]
+    )
+
+    expect(customer.orders.last.pickup_location).to eq(default_location)
+  end
+
+  describe 'affichage du calendrier' do
+    it 'expose les lieux ouverts par fournée et le lieu pré-rempli' do
+      # Le dernier lieu choisi par le client sert de pré-remplissage.
+      create(:order, customer: customer, bake_day: bake_day, pickup_location: anhee)
+
+      get '/calendrier'
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('data-calendar-pickup-locations-value')
+      expect(response.body).to include("data-calendar-preferred-pickup-location-value=\"#{anhee.id}\"")
+    end
+  end
+end

--- a/spec/services/pickup_location_orders_spec.rb
+++ b/spec/services/pickup_location_orders_spec.rb
@@ -1,0 +1,126 @@
+require "rails_helper"
+
+# Circulation du point de retrait (#148) à travers les services de création de
+# commande : checkout (OrderCreationService) et calendrier (PlannedOrderService).
+RSpec.describe "Point de retrait dans les services de commande", type: :service do
+  let!(:default_location) { create(:pickup_location, :default) }
+  let(:anhee) { create(:pickup_location, name: "Marché d'Anhée") }
+
+  let(:customer) { create(:customer) }
+  let(:bake_day) { create(:bake_day, :can_order) }
+  let(:variant) { create(:product_variant, price_cents: 700) }
+  let(:cart_items) { [ { "product_variant_id" => variant.id, "qty" => 2 } ] }
+
+  describe OrderCreationService do
+    def build_service(pickup_location:)
+      described_class.new(
+        customer: customer,
+        bake_day: bake_day,
+        cart_items: cart_items,
+        payment_method: "cash",
+        pickup_location: pickup_location
+      )
+    end
+
+    it "persiste le point de retrait choisi" do
+      bake_day.pickup_location_ids = [ default_location.id, anhee.id ]
+      bake_day.save!
+
+      order = build_service(pickup_location: anhee).call
+
+      expect(order).to be_a(Order)
+      expect(order.pickup_location).to eq(anhee)
+    end
+
+    it "retombe sur le lieu par défaut quand aucun lieu n'est fourni" do
+      order = build_service(pickup_location: nil).call
+
+      expect(order.pickup_location).to eq(default_location)
+    end
+
+    it "rejette un lieu non ouvert sur la fournée" do
+      # `anhee` n'est PAS coché sur cette fournée.
+      service = build_service(pickup_location: anhee)
+
+      expect(service.call).to be false
+      expect(service.errors.join).to include("n'est pas disponible pour cette fournée")
+      expect(Order.count).to eq(0)
+    end
+  end
+
+  describe PlannedOrderService do
+    let(:items) { [ { product_variant_id: variant.id, qty: 2 } ] }
+
+    before do
+      bake_day.pickup_location_ids = [ default_location.id, anhee.id ]
+      bake_day.save!
+    end
+
+    it "persiste le point de retrait à l'upsert" do
+      result = described_class.upsert(
+        customer: customer, bake_day: bake_day, items: items, pickup_location: anhee
+      )
+
+      expect(result[:order].pickup_location).to eq(anhee)
+    end
+
+    it "CONSERVE le lieu quand seuls les articles changent" do
+      described_class.upsert(customer: customer, bake_day: bake_day, items: items, pickup_location: anhee)
+
+      # 2e passage sans lieu (le client ne modifie que ses articles).
+      result = described_class.upsert(
+        customer: customer,
+        bake_day: bake_day,
+        items: [ { product_variant_id: variant.id, qty: 5 } ]
+      )
+
+      expect(result[:order].pickup_location).to eq(anhee)
+      expect(result[:order].order_items.sum(&:qty)).to eq(5)
+    end
+
+    it "permet de changer de lieu date par date" do
+      described_class.upsert(customer: customer, bake_day: bake_day, items: items, pickup_location: anhee)
+
+      result = described_class.upsert(
+        customer: customer, bake_day: bake_day, items: items, pickup_location: default_location
+      )
+
+      expect(result[:order].pickup_location).to eq(default_location)
+    end
+
+    it "rejette un lieu non ouvert sur la fournée" do
+      closed = create(:pickup_location, name: "Marché de Dinant")
+
+      result = described_class.upsert(
+        customer: customer, bake_day: bake_day, items: items, pickup_location: closed
+      )
+
+      expect(result[:error]).to include("n'est pas disponible pour cette fournée")
+    end
+  end
+
+  describe "dernier lieu choisi par le client" do
+    before do
+      bake_day.pickup_location_ids = [ default_location.id, anhee.id ]
+      bake_day.save!
+    end
+
+    it "renvoie le lieu de la dernière commande non annulée" do
+      create(:order, customer: customer, bake_day: bake_day, pickup_location: default_location)
+      create(:order, customer: customer, bake_day: bake_day, pickup_location: anhee)
+
+      expect(customer.last_pickup_location).to eq(anhee)
+    end
+
+    it "ignore les commandes annulées" do
+      create(:order, customer: customer, bake_day: bake_day, pickup_location: default_location)
+      create(:order, :cancelled, customer: customer, bake_day: bake_day, pickup_location: anhee)
+
+      expect(customer.last_pickup_location).to eq(default_location)
+    end
+
+    it "renvoie nil pour un client sans commande" do
+      expect(create(:customer).last_pickup_location).to be_nil
+    end
+  end
+end

--- a/spec/services/pickup_sheet_pdf_service_spec.rb
+++ b/spec/services/pickup_sheet_pdf_service_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+require "pdf/reader"
+
+# Feuille d'émargement d'un point de retrait (#148) : une ligne par client, avec
+# une case à cocher AU STYLO. Aucun pointage en ligne, aucun changement de statut.
+RSpec.describe PickupSheetPdfService, type: :service do
+  let!(:default_location) { create(:pickup_location, :default) }
+  let(:anhee) { create(:pickup_location, name: "Marché d'Anhée", description: "Sur notre étal, place d'Anhée.") }
+  let(:bake_day) { create(:bake_day, :can_order, baked_on: Date.new(2026, 8, 4)) }
+
+  let(:product) { create(:product, name: "Pain froment") }
+  let(:variant) { create(:product_variant, product: product, name: "Grand 1 kg", price_cents: 700) }
+
+  before do
+    bake_day.pickup_location_ids = [ default_location.id, anhee.id ]
+    bake_day.save!
+  end
+
+  def pdf_text(binary)
+    PDF::Reader.new(StringIO.new(binary)).pages.map(&:text).join("\n")
+  end
+
+  def order_for(customer, location, qty: 2)
+    create(:order, customer: customer, bake_day: bake_day, pickup_location: location, total_cents: qty * 700).tap do |order|
+      create(:order_item, order: order, product_variant: variant, qty: qty, unit_price_cents: 700)
+    end
+  end
+
+  let(:zoe) { create(:customer, first_name: "Zoé", last_name: "Zimmer", phone_e164: "+32470000003") }
+  let(:alice) { create(:customer, first_name: "Alice", last_name: "Adam", phone_e164: "+32470000001") }
+  let(:bruno) { create(:customer, first_name: "Bruno", last_name: "Bernard", phone_e164: "+32470000002") }
+
+  subject(:service) { described_class.new(bake_day, anhee) }
+
+  it "porte en en-tête le nom du lieu, sa description et la date de la fournée" do
+    order_for(alice, anhee)
+
+    text = pdf_text(service.render)
+
+    expect(text).to include("Marché d'Anhée")
+    expect(text).to include("Sur notre étal, place d'Anhée.")
+    expect(text).to include(I18n.l(bake_day.baked_on))
+  end
+
+  it "liste les clients du lieu avec téléphone, détail et total" do
+    order_for(alice, anhee, qty: 2)
+
+    text = pdf_text(service.render)
+
+    expect(text).to include("Alice Adam")
+    expect(text).to include("+32470000001")
+    expect(text).to include("2 × Pain froment (Grand 1 kg)")
+    expect(text).to include("14,00 €")
+  end
+
+  it "trie les lignes par nom de client" do
+    order_for(zoe, anhee)
+    order_for(alice, anhee)
+    order_for(bruno, anhee)
+
+    text = pdf_text(service.render)
+
+    expect(text.index("Alice Adam")).to be < text.index("Bruno Bernard")
+    expect(text.index("Bruno Bernard")).to be < text.index("Zoé Zimmer")
+  end
+
+  it "ne contient QUE les commandes de ce lieu pour cette fournée" do
+    order_for(alice, anhee)
+    order_for(bruno, default_location) # autre lieu, même fournée
+
+    other_bake_day = create(:bake_day, :friday)
+    create(:order, customer: zoe, bake_day: other_bake_day, pickup_location: default_location)
+
+    text = pdf_text(service.render)
+
+    expect(text).to include("Alice Adam")
+    expect(text).not_to include("Bruno Bernard")
+    expect(text).not_to include("Zoé Zimmer")
+  end
+
+  it "exclut les commandes annulées (mêmes statuts que le tableau de bord)" do
+    order_for(alice, anhee)
+    create(:order, :cancelled, customer: bruno, bake_day: bake_day, pickup_location: anhee)
+
+    text = pdf_text(service.render)
+
+    expect(text).to include("Alice Adam")
+    expect(text).not_to include("Bruno Bernard")
+  end
+
+  it "produit un PDF lisible même sans aucune commande" do
+    text = pdf_text(service.render)
+
+    expect(text).to include("Marché d'Anhée")
+    expect(text).to include("Aucune commande à retirer")
+  end
+
+  it "propose un nom de fichier parlant" do
+    expect(service.filename).to eq("retrait-marche-d-anhee-2026-08-04.pdf")
+  end
+end


### PR DESCRIPTION
Closes #148

## Résumé

Introduit les **points de retrait** : le client choisit où récupérer sa commande (checkout et calendrier), l'admin déclare les lieux et coche lesquels sont ouverts sur chaque fournée (dans les deux sens), et les boulangers voient les commandes regroupées par lieu avec une feuille d'émargement PDF à imprimer.

**Modèle** — `PickupLocation` (nom, description client, `default`, `position`, soft delete) + jointure `bake_day_pickup_locations` + `orders.pickup_location_id`. Migration en deux temps : création des lieux (« Les 4 Sources » par défaut, « Marché d'Anhée »), ouverture du lieu par défaut sur **toutes** les fournées, backfill de **toutes** les commandes, puis seulement `NOT NULL`.

**Client** — sélecteur au checkout (les 3 chemins de paiement : Stripe, espèces, portefeuille) et dans la modale de chaque date du calendrier, pré-rempli avec le dernier lieu choisi. Le lieu s'affiche sur la page publique de commande et dans « Mon compte ».

**Admin** — CRUD des lieux (Paramètres → Points de retrait), cochage bidirectionnel lieu ↔ fournée, lieu éditable sur une commande, onglet « Par point de retrait » sur le tableau de bord de fournée avec récapitulatif agrégé des articles et bouton PDF par lieu.

**API** — ressource `pickup_locations` + champ sur `order` et sur `bake_day` (détail), via le catalogue `resource_catalog.rb` (les 3 surfaces de doc suivent automatiquement).

### Trois pièges rencontrés, et ce que j'en ai fait

1. **`pickup_location_ids=` écrit les jointures avant la validation.** Le setter d'ActiveRecord persiste immédiatement sur un enregistrement existant : la règle « on ne décoche pas un lieu déjà commandé » aurait été inapplicable (le lieu serait déjà supprimé en base). J'ai remplacé le setter par une mise en attente → validation → application en `after_save`, des deux côtés (`BakeDay` et `PickupLocation`).

2. **Le formulaire d'un lieu ne liste que les fournées à venir.** Un `bake_day_ids=` naïf aurait donc **détaché toutes les fournées passées** (et fait perdre son lieu à l'historique des commandes). La réconciliation est restreinte au périmètre cochable ; les fournées passées sont préservées. Couvert par un spec dédié.

3. **`pluralize` n'accorde pas en locale `fr`** (aucune règle d'inflexion française n'est définie dans le projet) : `pluralize(2, "commande")` rend « 2 commande ». Repéré **sur la capture d'écran**, corrigé en passant le pluriel explicitement. À noter : le même bug existe ailleurs dans le dashboard (« 5 variante »), non corrigé ici — hors périmètre.

## 📸 Aperçu

![Tableau de bord de fournée — onglet « Par point de retrait » (récapitulatif agrégé + PDF par lieu)](https://github.com/les4sources/tranchesdevie2/raw/agent-screenshots/screenshots/20260714-042239-tableau-de-bord-de-fourne--onglet--par-point-de-.png)

![Admin — CRUD des points de retrait](https://github.com/les4sources/tranchesdevie2/raw/agent-screenshots/screenshots/20260714-042248-admin--crud-des-points-de-retrait.png)

![Admin — cochage des lieux ouverts sur une fournée](https://github.com/les4sources/tranchesdevie2/raw/agent-screenshots/screenshots/20260714-042256-admin--cochage-des-lieux-ouverts-sur-une-fourne.png)

## Testé

**67 nouveaux exemples, tous verts** (suite complète : 701 exemples).

- **Modèles** — unicité du lieu par défaut ; soft delete (le lieu sort des sélecteurs mais reste lisible sur les commandes) ; ordre d'affichage ; auto-cochage du lieu par défaut à la création d'une fournée ; **refus bloquant du décochage** d'un lieu utilisé, avec le nombre de commandes et l'accord singulier/pluriel, et vérification que **la jointure n'est pas supprimée** quand la validation échoue ; conservation des fournées passées ; rejet d'un lieu non ouvert sur la fournée d'une commande.
- **Services** — `OrderCreationService` persiste le lieu, retombe sur le défaut, rejette un lieu non ouvert ; `PlannedOrderService` persiste le lieu **et le conserve quand seuls les articles changent** ; `Customer#last_pickup_location` ignore les commandes annulées.
- **PDF** (`pdf-reader`) — en-tête (nom, description, date), une ligne par client avec téléphone/détail/total, **tri par nom**, et **isolation stricte** : un client d'un autre lieu ou d'une autre fournée n'y figure pas ; commandes annulées exclues ; PDF lisible même sans commande.
- **Requêtes** — checkout : seuls les lieux ouverts sont affichés, défaut pré-sélectionné, lieu persisté et **lieu non ouvert / inconnu rejeté côté serveur (422)** sur les **3** chemins de paiement ; calendrier : `PATCH update_day` persiste le lieu, le conserve sur modification d'articles, rejette un lieu fermé ; admin : CRUD, soft delete, refus de supprimer le lieu par défaut, cochage des deux côtés, refus de décochage (422 + « 2 commandes »), onglet dashboard, **téléchargement PDF (200 + `application/pdf`)** ; API : liste, lieu supprimé toujours consultable, champ sur `order`, présence dans l'index/OpenAPI/guide.
- **Backfill vérifié sur les données de dev réelles** : 897/897 commandes et 78/78 fournées rattachées, **zéro orpheline**.
- `bin/rubocop` vert sur le code ajouté · `bin/brakeman` : **0 warning de sécurité**.
- Captures ci-dessus produites via un test système Capybara (Chrome headless), supprimé depuis.

## NON testé

- **Le sélecteur client n'a pas de capture d'écran.** Le checkout est derrière l'OTP, dont le formulaire est piloté en JS (fetch) : le connecter de façon fiable en headless s'est révélé trop fragile. Il est en revanche couvert par des specs de requêtes qui assertent le HTML rendu (lieux ouverts présents, lieu fermé absent, défaut `checked`). **Les captures jointes sont celles de l'admin.** À valider visuellement à la relecture.
- **Aucun test JavaScript.** Le rendu du sélecteur dans la modale du calendrier et l'ajout de `pickup_location_id` aux payloads du checkout et du calendrier n'ont pas de couverture automatisée (le projet n'a pas de suite JS). Les specs de requêtes valident le contrat serveur, pas le code Stimulus qui l'appelle.
- **Changement de fournée en admin sur une commande** : le sélecteur de lieu ne se met pas à jour dynamiquement si l'admin change la fournée dans le même formulaire. La validation du modèle refuse alors un lieu incohérent à l'enregistrement (message d'erreur, pas de corruption), mais l'UX n'est pas idéale.
- **Migration jouée uniquement sur ma base de dev** (qui contenait 897 commandes réelles). Non rejouée sur une copie de la base de production.
- Aucune vérification sur l'environnement déployé (run nocturne, pas d'accès Hatchbox).

## Hors périmètre (conforme à l'issue)

Pas de pointage en ligne des retraits (les cases du PDF se cochent au stylo, aucun changement de statut), pas de mention du lieu dans les SMS, pas de capacité par lieu.

## Note sur `main`

Trois échecs **pré-existants** subsistent, vérifiés sur `main` via un worktree et **non corrigés ici** (hors périmètre) :
- `spec/models/email_message_spec.rb:16` — `EmailMessage.kinds` contient `ready`, que le spec n'attend pas.
- 2 offenses rubocop dans `spec/services/order_notification_service_ready_spec.rb`.
- `bin/importmap audit` remonte 6 vulnérabilités (trix, moderate/low) — identiques sur `main`.
