### PR TITLE
Lieux de vente : coût historisé déduit du bénéfice, lié au jour de cuisson (#150)

### DIFF
--- a/app/controllers/admin/bake_days_controller.rb
+++ b/app/controllers/admin/bake_days_controller.rb
@@ -170,6 +170,6 @@ class Admin::BakeDaysController < Admin::BaseController
 
   def bake_day_params
     params.require(:bake_day).permit(:baked_on, :cut_off_at, :internal_note, :market_day,
-      baking_artisan_ids: [], pickup_location_ids: [])
+      baking_artisan_ids: [], pickup_location_ids: [], sales_location_ids: [])
   end
 end

--- a/app/controllers/admin/settings/sales_location_costs_controller.rb
+++ b/app/controllers/admin/settings/sales_location_costs_controller.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Admin
+  module Settings
+    # Coûts historisés d'un lieu de vente (#150), par période de validité.
+    # Chaque lieu a une liste de paliers (montant + période `valid_from` /
+    # `valid_until` nullable) ; le coût applicable à une date est la période qui
+    # la couvre (cf. SalesLocationCost.cost_cents_for). Le montant est saisi en
+    # euros et converti vers l'entier stocké.
+    class SalesLocationCostsController < Admin::BaseController
+      before_action :set_sales_location
+      before_action :set_cost, only: [ :edit, :update, :destroy ]
+
+      def index
+        @costs = @sales_location.sales_location_costs.ordered
+      end
+
+      def new
+        @cost = @sales_location.sales_location_costs.new(valid_from: Date.current)
+      end
+
+      def create
+        @cost = @sales_location.sales_location_costs.new(cost_params)
+
+        if @cost.save
+          redirect_to admin_settings_sales_location_sales_location_costs_path(@sales_location),
+                      notice: "Coût enregistré"
+        else
+          render :new, status: :unprocessable_entity
+        end
+      end
+
+      def edit
+      end
+
+      def update
+        if @cost.update(cost_params)
+          redirect_to admin_settings_sales_location_sales_location_costs_path(@sales_location),
+                      notice: "Coût mis à jour"
+        else
+          render :edit, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        @cost.destroy
+        redirect_to admin_settings_sales_location_sales_location_costs_path(@sales_location),
+                    notice: "Palier supprimé"
+      end
+
+      private
+
+      def set_sales_location
+        @sales_location = SalesLocation.not_deleted.find(params[:sales_location_id])
+      end
+
+      def set_cost
+        @cost = @sales_location.sales_location_costs.find(params[:id])
+      end
+
+      def cost_params
+        params.require(:sales_location_cost).permit(:amount_euros, :valid_from, :valid_until)
+      end
+    end
+  end
+end

--- a/app/controllers/admin/settings/sales_locations_controller.rb
+++ b/app/controllers/admin/settings/sales_locations_controller.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Admin
+  module Settings
+    # CRUD des lieux de vente (#150). Chaque lieu porte une liste de coûts
+    # historisés par période (cf. SalesLocationCostsController). Suppression =
+    # soft delete : un lieu retiré disparaît des sélecteurs mais reste lisible
+    # sur les fournées passées qui le référencent.
+    class SalesLocationsController < Admin::BaseController
+      before_action :set_sales_location, only: [ :edit, :update, :destroy ]
+
+      def index
+        @sales_locations = SalesLocation.not_deleted.ordered
+      end
+
+      def new
+        @sales_location = SalesLocation.new(active: true)
+      end
+
+      def create
+        @sales_location = SalesLocation.new(sales_location_params)
+
+        if @sales_location.save
+          redirect_to admin_settings_sales_locations_path, notice: "Lieu de vente créé"
+        else
+          render :new, status: :unprocessable_entity
+        end
+      end
+
+      def edit
+      end
+
+      def update
+        if @sales_location.update(sales_location_params)
+          redirect_to admin_settings_sales_locations_path, notice: "Lieu de vente mis à jour"
+        else
+          render :edit, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        @sales_location.soft_delete!
+        redirect_to admin_settings_sales_locations_path, notice: "Lieu de vente supprimé"
+      end
+
+      private
+
+      def set_sales_location
+        @sales_location = SalesLocation.not_deleted.find(params[:id])
+      end
+
+      def sales_location_params
+        params.require(:sales_location).permit(:name, :active, :position)
+      end
+    end
+  end
+end

--- a/app/models/bake_day.rb
+++ b/app/models/bake_day.rb
@@ -19,6 +19,12 @@ class BakeDay < ApplicationRecord
   has_many :baking_artisans, through: :bake_day_artisans, source: :artisan
   has_many :bake_day_pickup_locations, dependent: :destroy
   has_many :pickup_locations, through: :bake_day_pickup_locations
+  # Lieux de vente liés à la fournée (#150) : leur coût du jour est déduit de la
+  # marge brute avant le partage 70/30. Contrairement aux lieux de RETRAIT, rien
+  # n'empêche de décocher un lieu de vente (aucune commande ne s'y rattache) :
+  # l'affectation standard `sales_location_ids=` d'ActiveRecord suffit.
+  has_many :bake_day_sales_locations, dependent: :destroy
+  has_many :sales_locations, through: :bake_day_sales_locations
 
   validates :baked_on, presence: true, uniqueness: true
   validates :cut_off_at, presence: true
@@ -34,6 +40,13 @@ class BakeDay < ApplicationRecord
   # non supprimés, dans l'ordre d'affichage.
   def open_pickup_locations
     pickup_locations.not_deleted.ordered
+  end
+
+  # Coût total des lieux de vente liés à la fournée (#150), résolu à la date de
+  # cuisson (`baked_on`). Chaque lieu contribue le coût de la période qui couvre
+  # ce jour (ou 0 s'il n'en a aucune). 0 si aucun lieu n'est lié → neutre.
+  def sales_locations_cost_cents(on: baked_on)
+    sales_locations.sum { |location| location.cost_cents(on: on) || 0 }
   end
 
   # Le setter d'ActiveRecord écrirait les jointures IMMÉDIATEMENT, avant même la

--- a/app/models/bake_day_sales_location.rb
+++ b/app/models/bake_day_sales_location.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Jointure entre un jour de cuisson et un lieu de vente (#150). La présence d'une
+# ligne signifie que la fournée a été vendue sur ce lieu — dont le coût du jour
+# est déduit de la marge brute (cf. BakerRevenueService).
+class BakeDaySalesLocation < ApplicationRecord
+  belongs_to :bake_day
+  belongs_to :sales_location
+end

--- a/app/models/sales_location.rb
+++ b/app/models/sales_location.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Lieu de vente (#150) : un endroit où la boulangerie vend (typiquement un
+# marché), porteur d'un COÛT (emplacement / stand) qui se déduit du bénéfice.
+#
+# Concept SÉPARÉ du lieu de retrait (`PickupLocation`) — décision produit : on ne
+# les fusionne pas. Ici on ne gère QUE le coût (pas les recettes/ventes par lieu).
+#
+# Suppression = soft delete (comme MoldType / PickupLocation) : un lieu retiré
+# disparaît des sélecteurs mais reste lisible sur les fournées passées qui le
+# référencent. Aucun `default_scope` n'est posé — filtrer explicitement avec
+# `not_deleted` dans les sélecteurs.
+class SalesLocation < ApplicationRecord
+  has_soft_deletion
+
+  has_many :sales_location_costs, dependent: :destroy
+  has_many :bake_day_sales_locations, dependent: :destroy
+  has_many :bake_days, through: :bake_day_sales_locations
+
+  validates :name, presence: true, uniqueness: { conditions: -> { where(deleted_at: nil) } }
+
+  scope :not_deleted, -> { where(deleted_at: nil) }
+  scope :active, -> { not_deleted.where(active: true) }
+  scope :ordered, -> { order(position: :asc, name: :asc) }
+
+  # Coût (cents) applicable à une date donnée, ou `nil` si aucune période ne la
+  # couvre (le lieu n'a donc aucun coût déductible à cette date). Délègue au
+  # résolveur du modèle de coût historisé.
+  def cost_cents(on: Date.current)
+    SalesLocationCost.cost_cents_for(self, on: on)
+  end
+end

--- a/app/models/sales_location_cost.rb
+++ b/app/models/sales_location_cost.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Coût d'un lieu de vente (#150), historisé par période de validité.
+#
+# Contrairement aux coûts historisés à date d'activation unique (VariantCostPrice,
+# BreadBagPrice, RevenueParameter — où le palier le plus récent supersede les
+# précédents), ce modèle porte une borne de fin explicite : `valid_until` nul =
+# période EN COURS. Le coût applicable à une date est la période qui la couvre :
+# `valid_from <= date` ET (`valid_until` nul OU `date <= valid_until`). En cas de
+# chevauchement (déconseillé), la période au `valid_from` le plus récent gagne.
+class SalesLocationCost < ApplicationRecord
+  belongs_to :sales_location
+
+  validates :amount_cents, presence: true,
+                           numericality: { greater_than_or_equal_to: 0, only_integer: true }
+  validates :valid_from, presence: true
+  validate :valid_until_after_valid_from
+
+  # Plus récent d'abord : sert à la fois à l'affichage admin et à la résolution
+  # du coût applicable (le premier qui couvre la date gagne).
+  scope :ordered, -> { order(valid_from: :desc, id: :desc) }
+
+  # Coût (cents) applicable à `on` pour `sales_location`, ou `nil` si aucune
+  # période ne couvre la date. Requête bornée aux périodes ouvertes ou dont la
+  # fin est postérieure/égale à la date.
+  def self.cost_cents_for(sales_location, on: Date.current)
+    sales_location
+      .sales_location_costs
+      .where(valid_from: ..on)
+      .where("valid_until IS NULL OR valid_until >= ?", on)
+      .ordered
+      .limit(1)
+      .pick(:amount_cents)
+  end
+
+  def amount_euros
+    return nil if amount_cents.nil?
+
+    (amount_cents / 100.0).round(2)
+  end
+
+  def amount_euros=(value)
+    self.amount_cents = value.to_s.strip.blank? ? nil : (value.to_s.tr(",", ".").to_f * 100).round
+  end
+
+  private
+
+  def valid_until_after_valid_from
+    return if valid_until.blank? || valid_from.blank?
+    return if valid_until >= valid_from
+
+    errors.add(:valid_until, "doit être postérieure ou égale à la date de début")
+  end
+end

--- a/app/services/baker_revenue_service.rb
+++ b/app/services/baker_revenue_service.rb
@@ -11,7 +11,9 @@
 #   - commissions   = Σ commissions Stripe des commandes EN LIGNE du jour
 #                     (cohérent avec Order.stripe_fees_between ; cash/portefeuille
 #                     n'ont pas de commission)
-#   - marge brute   = CA − coûtant − sacs − transport − commissions
+#   - lieux de vente = Σ coûts des lieux de vente liés à la fournée (#150),
+#                     résolus à la date de la fournée (0 si aucun lieu lié)
+#   - marge brute   = CA − coûtant − sacs − transport − commissions − lieux de vente
 #   - part 4 Sources = taux 4S (historisé, réf. 30 %) × marge brute
 #   - pool boulangers = marge brute − part 4 Sources (réf. 70 %)
 #   - revenu/artisan  = pool × (part littérale de l'artisan présent / 100)
@@ -51,6 +53,7 @@ class BakerRevenueService
     :bread_bags_cents,
     :transport_cents,
     :commission_cents,
+    :sales_locations_cents,
     :gross_margin_cents,
     :four_sources_cents,
     :baker_pool_cents,
@@ -94,6 +97,7 @@ class BakerRevenueService
     :total_bread_bags_cents,
     :total_transport_cents,
     :total_commission_cents,
+    :total_sales_locations_cents,
     :gross_margin_cents,
     :four_sources_cents,
     :baker_pool_cents,
@@ -124,6 +128,7 @@ class BakerRevenueService
       total_bread_bags_cents: sum(days, :bread_bags_cents),
       total_transport_cents: sum(days, :transport_cents),
       total_commission_cents: sum(days, :commission_cents),
+      total_sales_locations_cents: sum(days, :sales_locations_cents),
       gross_margin_cents: sum(days, :gross_margin_cents),
       four_sources_cents: sum(days, :four_sources_cents),
       baker_pool_cents: sum(days, :baker_pool_cents),
@@ -139,7 +144,7 @@ class BakerRevenueService
     BakeDay
       .where(baked_on: @start_date..@end_date)
       .ordered
-      .includes(:baking_artisans)
+      .includes(:baking_artisans, sales_locations: :sales_location_costs)
   end
 
   def build_day(bake_day)
@@ -154,9 +159,13 @@ class BakerRevenueService
     # Commissions Stripe des commandes EN LIGNE du jour (CA = 0 → aucune commande
     # → commission naturellement 0 : pas de paiement Stripe à déduire).
     commission_cents = day_commission_cents(date)
+    # Coût des lieux de vente liés à la fournée (#150), résolu à la date de
+    # cuisson. 0 si aucun lieu lié → déduction neutre, chiffres inchangés.
+    sales_locations_cents = day_sales_locations_cents(bake_day, date)
 
     gross_margin_cents =
-      revenue_cents - cost_price_cents - bread_bags_cents - transport_cents - commission_cents
+      revenue_cents - cost_price_cents - bread_bags_cents - transport_cents -
+      commission_cents - sales_locations_cents
     four_sources_cents = four_sources_cut(gross_margin_cents, date)
     baker_pool_cents = gross_margin_cents - four_sources_cents
 
@@ -172,6 +181,7 @@ class BakerRevenueService
       bread_bags_cents: bread_bags_cents,
       transport_cents: transport_cents,
       commission_cents: commission_cents,
+      sales_locations_cents: sales_locations_cents,
       gross_margin_cents: gross_margin_cents,
       four_sources_cents: four_sources_cents,
       baker_pool_cents: baker_pool_cents,
@@ -214,6 +224,13 @@ class BakerRevenueService
   # jour sans paiement Stripe donne naturellement 0.
   def day_commission_cents(date)
     Order.stripe_fees_between(date, date)
+  end
+
+  # Coût des lieux de vente liés à la fournée (#150), résolu à `date` (la date de
+  # cuisson). Chaque lieu contribue le coût de la période qui couvre ce jour, ou
+  # 0 s'il n'en a aucune. Aucune fournée liée → 0 (déduction neutre).
+  def day_sales_locations_cents(bake_day, date)
+    bake_day.sales_locations_cost_cents(on: date)
   end
 
   # Coût total des sacs à pains du jour (#52), à la date de cuisson.

--- a/app/views/admin/bake_days/_sales_locations.html.slim
+++ b/app/views/admin/bake_days/_sales_locations.html.slim
@@ -1,0 +1,19 @@
+/ Lieux de vente liés à cette fournée (#150). Partial partagé par `new` et
+/ `edit`. Le coût du/des lieu(x) sélectionné(s) est déduit du bénéfice dans le
+/ rapport « Revenus des boulangers » (avant le partage 70/30). Rien n'oblige à
+/ en cocher : sans lieu de vente, la déduction est nulle.
+.mb-4
+  span.block.text-gray-700.font-medium.mb-2 Lieux de vente (coût déduit du bénéfice)
+  - locations = SalesLocation.active.ordered
+  - if locations.any?
+    .grid.grid-cols-1.sm:grid-cols-2.lg:grid-cols-3.gap-2
+      = f.collection_check_boxes :sales_location_ids, locations, :id, :name do |b|
+        label.flex.items-center.gap-2.rounded-md.border.border-gray-200.px-3.py-2.cursor-pointer.hover:bg-gray-50
+          = b.check_box class: "rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+          = b.text
+    p.mt-2.text-xs.text-gray-500
+      | Le coût de chaque lieu coché (à la date de cuisson) est déduit de la marge brute.
+  - else
+    p.text-sm.text-gray-500
+      | Aucun lieu de vente défini.
+      =< link_to "En créer un", new_admin_settings_sales_location_path, class: "text-blue-600 hover:underline"

--- a/app/views/admin/bake_days/edit.html.slim
+++ b/app/views/admin/bake_days/edit.html.slim
@@ -26,6 +26,8 @@ h1.text-2xl.font-bold.mb-6 Modifier le jour de cuisson
 
   = render "pickup_locations", f: f, bake_day: @bake_day
 
+  = render "sales_locations", f: f, bake_day: @bake_day
+
   .flex.gap-3
     = f.submit "Mettre à jour le jour de cuisson", class: "bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
     = link_to "Annuler", admin_bake_day_path(@bake_day), class: "inline-block text-gray-600 hover:underline py-2 px-4"

--- a/app/views/admin/bake_days/new.html.slim
+++ b/app/views/admin/bake_days/new.html.slim
@@ -24,6 +24,8 @@ h1.text-2xl.font-bold.mb-6 Nouveau jour de cuisson
 
   = render "pickup_locations", f: f, bake_day: @bake_day
 
+  = render "sales_locations", f: f, bake_day: @bake_day
+
   .flex.gap-3
     = f.submit "Créer le jour de cuisson", class: "bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
     = link_to "Annuler", admin_bake_days_path, class: "inline-block text-gray-600 hover:underline py-2 px-4"

--- a/app/views/admin/reports/baker_revenue.html.erb
+++ b/app/views/admin/reports/baker_revenue.html.erb
@@ -42,7 +42,7 @@
 <% end %>
 
 <%# Synthèse de période %>
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-6 mb-6">
+<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-6 mb-6">
   <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
     <h2 class="text-sm font-medium text-gray-500 tracking-wide">Chiffre d'affaires</h2>
     <p class="mt-2 text-2xl font-bold text-gray-900"><%= reports_currency(@report.total_revenue_cents) %></p>
@@ -53,9 +53,14 @@
     <p class="mt-1 text-xs text-gray-500">Commandes en ligne uniquement</p>
   </div>
   <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+    <h2 class="text-sm font-medium text-gray-500 tracking-wide">Lieux de vente</h2>
+    <p class="mt-2 text-2xl font-bold text-gray-900">- <%= reports_currency(@report.total_sales_locations_cents) %></p>
+    <p class="mt-1 text-xs text-gray-500">Coût des emplacements liés aux fournées</p>
+  </div>
+  <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
     <h2 class="text-sm font-medium text-gray-500 tracking-wide">Marge brute</h2>
     <p class="mt-2 text-2xl font-bold text-gray-900"><%= reports_currency(@report.gross_margin_cents) %></p>
-    <p class="mt-1 text-xs text-gray-500">CA − coûtant − sacs − transport − commissions</p>
+    <p class="mt-1 text-xs text-gray-500">CA − coûtant − sacs − transport − commissions − lieux de vente</p>
   </div>
   <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
     <h2 class="text-sm font-medium text-gray-500 tracking-wide">Part Les 4 Sources</h2>
@@ -134,6 +139,7 @@
             <th class="px-3 py-3 text-right text-xs font-medium text-gray-700 uppercase">Sacs</th>
             <th class="px-3 py-3 text-right text-xs font-medium text-gray-700 uppercase">Transport</th>
             <th class="px-3 py-3 text-right text-xs font-medium text-gray-700 uppercase">Commissions</th>
+            <th class="px-3 py-3 text-right text-xs font-medium text-gray-700 uppercase">Lieux de vente</th>
             <th class="px-3 py-3 text-right text-xs font-medium text-gray-700 uppercase">Marge brute</th>
             <th class="px-3 py-3 text-right text-xs font-medium text-gray-700 uppercase">Part 4S</th>
             <th class="px-3 py-3 text-right text-xs font-medium text-gray-700 uppercase">Pool</th>
@@ -149,6 +155,7 @@
               <td class="px-3 py-3 text-gray-600 text-right">- <%= reports_currency(day.bread_bags_cents) %></td>
               <td class="px-3 py-3 text-gray-600 text-right">- <%= reports_currency(day.transport_cents) %></td>
               <td class="px-3 py-3 text-gray-600 text-right">- <%= reports_currency(day.commission_cents) %></td>
+              <td class="px-3 py-3 text-gray-600 text-right">- <%= reports_currency(day.sales_locations_cents) %></td>
               <td class="px-3 py-3 text-gray-900 text-right font-semibold"><%= reports_currency(day.gross_margin_cents) %></td>
               <td class="px-3 py-3 text-emerald-700 text-right"><%= reports_currency(day.four_sources_cents) %></td>
               <td class="px-3 py-3 text-blue-700 text-right"><%= reports_currency(day.baker_pool_cents) %></td>
@@ -185,6 +192,7 @@
             <td class="px-3 py-3 text-gray-600 text-right">- <%= reports_currency(@report.total_bread_bags_cents) %></td>
             <td class="px-3 py-3 text-gray-600 text-right">- <%= reports_currency(@report.total_transport_cents) %></td>
             <td class="px-3 py-3 text-gray-600 text-right">- <%= reports_currency(@report.total_commission_cents) %></td>
+            <td class="px-3 py-3 text-gray-600 text-right">- <%= reports_currency(@report.total_sales_locations_cents) %></td>
             <td class="px-3 py-3 text-gray-900 text-right"><%= reports_currency(@report.gross_margin_cents) %></td>
             <td class="px-3 py-3 text-emerald-700 text-right"><%= reports_currency(@report.four_sources_cents) %></td>
             <td class="px-3 py-3 text-blue-700 text-right"><%= reports_currency(@report.baker_pool_cents) %></td>

--- a/app/views/admin/settings/index.html.slim
+++ b/app/views/admin/settings/index.html.slim
@@ -60,3 +60,9 @@
         span.text-gray-400
           svg.w-5.h-5 fill="none" stroke="currentColor" viewBox="0 0 24 24"
             path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"
+    li
+      = link_to admin_settings_sales_locations_path, class: "flex items-center justify-between px-4 py-4 hover:bg-gray-50"
+        span.text-sm.font-medium.text-gray-900 Lieux de vente (coût déduit du bénéfice)
+        span.text-gray-400
+          svg.w-5.h-5 fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"

--- a/app/views/admin/settings/sales_location_costs/_form.html.slim
+++ b/app/views/admin/settings/sales_location_costs/_form.html.slim
@@ -1,0 +1,22 @@
+= form_with model: cost, url: (cost.persisted? ? admin_settings_sales_location_sales_location_cost_path(@sales_location, cost) : admin_settings_sales_location_sales_location_costs_path(@sales_location)), method: (cost.persisted? ? :patch : :post), local: true, class: "bg-white shadow-sm rounded-lg border border-gray-200 p-6 space-y-6" do |f|
+  - if cost.errors.any?
+    .rounded-md.bg-red-50.p-4
+      h2.text-sm.font-semibold.text-red-800 Correction requise
+      ul.mt-2.list-disc.list-inside.text-sm.text-red-700
+        - cost.errors.full_messages.each do |message|
+          li= message
+
+  .grid.grid-cols-1.md:grid-cols-3.gap-6
+    .space-y-2
+      = f.label :amount_euros, "Coût (€)", class: "block text-sm font-medium text-gray-700"
+      = f.number_field :amount_euros, value: cost.amount_euros, step: "0.01", min: 0, required: true, class: admin_input_class
+    .space-y-2
+      = f.label :valid_from, "À partir du", class: "block text-sm font-medium text-gray-700"
+      = f.date_field :valid_from, required: true, class: admin_input_class
+    .space-y-2
+      = f.label :valid_until, "Jusqu'au (optionnel)", class: "block text-sm font-medium text-gray-700"
+      = f.date_field :valid_until, class: admin_input_class
+
+  .flex.justify-end.space-x-3
+    = link_to "Annuler", admin_settings_sales_location_sales_location_costs_path(@sales_location), class: "px-4 py-2 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+    = f.submit cost.persisted? ? "Mettre à jour" : "Enregistrer", class: "px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 cursor-pointer"

--- a/app/views/admin/settings/sales_location_costs/edit.html.slim
+++ b/app/views/admin/settings/sales_location_costs/edit.html.slim
@@ -1,0 +1,10 @@
+- content_for :title, "Modifier le coût"
+- content_for :layout, "admin"
+
+.mb-6.flex.items-center.gap-3
+  = link_to "Paramètres", admin_settings_path, class: "px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200"
+  = link_to "Lieux de vente", admin_settings_sales_locations_path, class: "px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200"
+  = link_to @sales_location.name, admin_settings_sales_location_sales_location_costs_path(@sales_location), class: "px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200"
+  h1.text-2xl.font-bold.text-gray-900 Modifier le coût
+
+= render "form", cost: @cost

--- a/app/views/admin/settings/sales_location_costs/index.html.slim
+++ b/app/views/admin/settings/sales_location_costs/index.html.slim
@@ -1,0 +1,39 @@
+- content_for :title, "Coûts — #{@sales_location.name}"
+- content_for :layout, "admin"
+
+.mb-6.flex.justify-between.items-center
+  .flex.items-center.gap-3
+    = link_to "Paramètres", admin_settings_path, class: "px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200"
+    = link_to "Lieux de vente", admin_settings_sales_locations_path, class: "px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200"
+    h1.text-2xl.font-bold.text-gray-900 = "Coûts : #{@sales_location.name}"
+  = link_to "Ajouter un palier", new_admin_settings_sales_location_sales_location_cost_path(@sales_location), class: "px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+
+p.text-sm.text-gray-600.mb-6
+  | Coût de l'emplacement, historisé par période de validité. Le coût appliqué à une fournée est celui de la période qui couvre sa date de cuisson. Une période sans date de fin est en cours.
+
+.bg-white.shadow-sm.rounded-lg.border.border-gray-200.overflow-hidden
+  - if @costs.any?
+    .overflow-x-auto
+      table.min-w-full.divide-y.divide-gray-200
+        thead.bg-gray-100
+          tr
+            th.px-4.py-3.text-left.text-xs.font-medium.text-gray-700.uppercase Coût
+            th.px-4.py-3.text-left.text-xs.font-medium.text-gray-700.uppercase À partir du
+            th.px-4.py-3.text-left.text-xs.font-medium.text-gray-700.uppercase Jusqu'au
+            th.px-4.py-3.text-left.text-xs.font-medium.text-gray-700.uppercase Actions
+        tbody.divide-y.divide-gray-200
+          - @costs.each do |cost|
+            tr
+              td.px-4.py-3.text-sm.text-gray-900.font-medium = number_to_currency(cost.amount_euros, unit: "€", format: "%n %u", separator: ",", delimiter: " ")
+              td.px-4.py-3.text-sm.text-gray-600 = l(cost.valid_from)
+              td.px-4.py-3.text-sm.text-gray-600
+                - if cost.valid_until
+                  = l(cost.valid_until)
+                - else
+                  span.inline-flex.items-center.rounded-full.bg-emerald-100.px-2.5.py-0.5.text-xs.font-medium.text-emerald-800 En cours
+              td.px-4.py-3.text-sm
+                = link_to "Modifier", edit_admin_settings_sales_location_sales_location_cost_path(@sales_location, cost), class: "text-blue-600 hover:text-blue-800 mr-3"
+                = link_to "Supprimer", admin_settings_sales_location_sales_location_cost_path(@sales_location, cost), data: { turbo_method: :delete, turbo_confirm: "Supprimer ce palier ?" }, class: "text-red-600 hover:text-red-800"
+  - else
+    .px-4.py-8.text-center.text-sm.text-gray-500
+      | Aucun coût saisi. Sans coût configuré, ce lieu ne déduit rien du bénéfice.

--- a/app/views/admin/settings/sales_location_costs/new.html.slim
+++ b/app/views/admin/settings/sales_location_costs/new.html.slim
@@ -1,0 +1,10 @@
+- content_for :title, "Nouveau coût"
+- content_for :layout, "admin"
+
+.mb-6.flex.items-center.gap-3
+  = link_to "Paramètres", admin_settings_path, class: "px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200"
+  = link_to "Lieux de vente", admin_settings_sales_locations_path, class: "px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200"
+  = link_to @sales_location.name, admin_settings_sales_location_sales_location_costs_path(@sales_location), class: "px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200"
+  h1.text-2xl.font-bold.text-gray-900 Nouveau coût
+
+= render "form", cost: @cost

--- a/app/views/admin/settings/sales_locations/_form.html.slim
+++ b/app/views/admin/settings/sales_locations/_form.html.slim
@@ -1,0 +1,24 @@
+= form_with model: [:admin, :settings, sales_location], local: true, class: "bg-white shadow-sm rounded-lg border border-gray-200 p-6 space-y-6" do |f|
+  - if sales_location.errors.any?
+    .rounded-md.bg-red-50.p-4
+      h2.text-sm.font-semibold.text-red-800 Correction requise
+      ul.mt-2.list-disc.list-inside.text-sm.text-red-700
+        - sales_location.errors.full_messages.each do |message|
+          li= message
+
+  .grid.grid-cols-1.md:grid-cols-2.gap-6
+    .space-y-2
+      = f.label :name, "Nom", class: "block text-sm font-medium text-gray-700"
+      = f.text_field :name, required: true, class: admin_input_class
+    .space-y-2
+      = f.label :position, "Ordre d'affichage", class: "block text-sm font-medium text-gray-700"
+      = f.number_field :position, min: 0, class: admin_input_class
+    .space-y-2.flex.items-center
+      .flex.items-center.h-5
+        = f.check_box :active, class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+      .ml-3.text-sm
+        = f.label :active, "Lieu actif (apparaît dans les choix des jours de cuisson)", class: "font-medium text-gray-700"
+
+  .flex.justify-end.space-x-3
+    = link_to "Annuler", admin_settings_sales_locations_path, class: "px-4 py-2 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+    = f.submit sales_location.persisted? ? "Mettre à jour" : "Créer le lieu de vente", class: "px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 cursor-pointer"

--- a/app/views/admin/settings/sales_locations/edit.html.slim
+++ b/app/views/admin/settings/sales_locations/edit.html.slim
@@ -1,0 +1,10 @@
+- content_for :title, "Modifier le lieu de vente"
+- content_for :layout, "admin"
+
+.mb-6.flex.justify-between.items-center
+  .flex.items-center.gap-3
+    = link_to "Paramètres", admin_settings_path, class: "px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200"
+    = link_to "Lieux de vente", admin_settings_sales_locations_path, class: "px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200"
+  h1.text-2xl.font-bold.text-gray-900 = "Modifier le lieu de vente : #{@sales_location.name}"
+
+= render "form", sales_location: @sales_location

--- a/app/views/admin/settings/sales_locations/index.html.slim
+++ b/app/views/admin/settings/sales_locations/index.html.slim
@@ -1,0 +1,44 @@
+- content_for :title, "Lieux de vente"
+- content_for :layout, "admin"
+
+.mb-6.flex.justify-between.items-center
+  .flex.items-center.gap-3
+    = link_to "Paramètres", admin_settings_path, class: "px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200"
+    h1.text-2xl.font-bold.text-gray-900 Lieux de vente
+  = link_to "Nouveau lieu de vente", new_admin_settings_sales_location_path, class: "px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+
+p.text-sm.text-gray-600.mb-6
+  | Un lieu de vente (ex. un marché) porte un coût d'emplacement, déduit du bénéfice des fournées qui y sont vendues. Concept distinct des points de retrait.
+
+.bg-white.shadow-sm.rounded-lg.border.border-gray-200.overflow-hidden
+  - if @sales_locations.any?
+    .overflow-x-auto
+      table.min-w-full.divide-y.divide-gray-200
+        thead.bg-gray-100
+          tr
+            th.px-4.py-3.text-left.text-xs.font-medium.text-gray-700.uppercase Nom
+            th.px-4.py-3.text-left.text-xs.font-medium.text-gray-700.uppercase Actif
+            th.px-4.py-3.text-left.text-xs.font-medium.text-gray-700.uppercase Coût actuel
+            th.px-4.py-3.text-left.text-xs.font-medium.text-gray-700.uppercase Actions
+        tbody.divide-y.divide-gray-200
+          - @sales_locations.each do |location|
+            tr
+              td.px-4.py-3.text-sm.text-gray-900.font-medium = location.name
+              td.px-4.py-3.text-sm.text-gray-600
+                - if location.active?
+                  span.inline-flex.items-center.rounded-full.bg-emerald-100.px-2.5.py-0.5.text-xs.font-medium.text-emerald-800 Oui
+                - else
+                  span.inline-flex.items-center.rounded-full.bg-gray-100.px-2.5.py-0.5.text-xs.font-medium.text-gray-600 Inactif
+              td.px-4.py-3.text-sm.text-gray-600
+                - current_cost = location.cost_cents
+                - if current_cost
+                  = number_to_currency(current_cost / 100.0, unit: "€", format: "%n %u", separator: ",", delimiter: " ")
+                - else
+                  span.text-gray-400 —
+              td.px-4.py-3.text-sm
+                = link_to "Modifier", edit_admin_settings_sales_location_path(location), class: "text-blue-600 hover:text-blue-800 mr-3"
+                = link_to "Coûts", admin_settings_sales_location_sales_location_costs_path(location), class: "text-blue-600 hover:text-blue-800 mr-3"
+                = link_to "Supprimer", admin_settings_sales_location_path(location), data: { turbo_method: :delete, turbo_confirm: "Supprimer ce lieu de vente ?" }, class: "text-red-600 hover:text-red-800"
+  - else
+    .px-4.py-8.text-center.text-sm.text-gray-500
+      | Aucun lieu de vente enregistré.

--- a/app/views/admin/settings/sales_locations/new.html.slim
+++ b/app/views/admin/settings/sales_locations/new.html.slim
@@ -1,0 +1,10 @@
+- content_for :title, "Nouveau lieu de vente"
+- content_for :layout, "admin"
+
+.mb-6.flex.justify-between.items-center
+  .flex.items-center.gap-3
+    = link_to "Paramètres", admin_settings_path, class: "px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200"
+    = link_to "Lieux de vente", admin_settings_sales_locations_path, class: "px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200"
+  h1.text-2xl.font-bold.text-gray-900 Nouveau lieu de vente
+
+= render "form", sales_location: @sales_location

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -209,6 +209,11 @@ Rails.application.routes.draw do
       # transport (15 €/jour) et taux 4 Sources (30 %). Un seul contrôleur gère
       # les deux clés via le paramètre `:key`.
       resources :revenue_parameters, path: "revenus-boulangers", only: [ :index, :new, :create, :edit, :update, :destroy ]
+      # Lieux de vente (#150) : CRUD + coûts historisés par période de validité.
+      resources :sales_locations, path: "lieux-de-vente" do
+        resources :sales_location_costs, controller: "sales_location_costs",
+          path: "couts", only: [ :index, :new, :create, :edit, :update, :destroy ]
+      end
     end
   end
 end

--- a/db/migrate/20260719120000_create_sales_locations.rb
+++ b/db/migrate/20260719120000_create_sales_locations.rb
@@ -1,0 +1,49 @@
+class CreateSalesLocations < ActiveRecord::Migration[8.0]
+  def change
+    # Lieu de vente (#150) : un endroit où la boulangerie vend (ex. un marché),
+    # porteur d'un COÛT (emplacement / stand) déductible du bénéfice. Concept
+    # SÉPARÉ du lieu de retrait (`PickupLocation`) — décision produit. Soft
+    # delete comme MoldType / PickupLocation : un lieu retiré disparaît des
+    # sélecteurs mais reste lisible sur les fournées passées qui le référencent.
+    create_table :sales_locations do |t|
+      t.string :name, null: false
+      t.boolean :active, null: false, default: true
+      t.integer :position, null: false, default: 0
+      t.datetime :deleted_at
+
+      t.timestamps
+    end
+
+    add_index :sales_locations, :deleted_at
+    add_index :sales_locations, :name, unique: true,
+      where: "deleted_at IS NULL", name: "index_sales_locations_on_name_unique"
+
+    # Coût du lieu de vente historisé par période de validité (#150). Même esprit
+    # que les coûts historisés existants (VariantCostPrice, BreadBagPrice,
+    # RevenueParameter), mais avec une borne de fin explicite : `valid_until` nul
+    # = période en cours. Le coût applicable à une date est la période qui la
+    # couvre (`valid_from <= date <= valid_until`, ou `valid_until` nul).
+    create_table :sales_location_costs do |t|
+      t.references :sales_location, null: false, foreign_key: true
+      t.integer :amount_cents, null: false
+      t.date :valid_from, null: false
+      t.date :valid_until
+
+      t.timestamps
+    end
+
+    add_index :sales_location_costs, [ :sales_location_id, :valid_from ]
+
+    # Un jour de cuisson peut être lié à 0..N lieux de vente (#150) : le coût
+    # du/des lieu(x) est déduit de la marge brute avant le partage 70/30.
+    create_table :bake_day_sales_locations do |t|
+      t.references :bake_day, null: false, foreign_key: true
+      t.references :sales_location, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :bake_day_sales_locations, [ :bake_day_id, :sales_location_id ],
+      unique: true, name: "index_bake_day_sales_locations_on_pair"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_18_154405) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_19_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -86,6 +86,16 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_18_154405) do
     t.index ["bake_day_id", "pickup_location_id"], name: "index_bake_day_pickup_locations_on_pair", unique: true
     t.index ["bake_day_id"], name: "index_bake_day_pickup_locations_on_bake_day_id"
     t.index ["pickup_location_id"], name: "index_bake_day_pickup_locations_on_pickup_location_id"
+  end
+
+  create_table "bake_day_sales_locations", force: :cascade do |t|
+    t.bigint "bake_day_id", null: false
+    t.bigint "sales_location_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["bake_day_id", "sales_location_id"], name: "index_bake_day_sales_locations_on_pair", unique: true
+    t.index ["bake_day_id"], name: "index_bake_day_sales_locations_on_bake_day_id"
+    t.index ["sales_location_id"], name: "index_bake_day_sales_locations_on_sales_location_id"
   end
 
   create_table "bake_days", force: :cascade do |t|
@@ -428,6 +438,28 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_18_154405) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "sales_location_costs", force: :cascade do |t|
+    t.bigint "sales_location_id", null: false
+    t.integer "amount_cents", null: false
+    t.date "valid_from", null: false
+    t.date "valid_until"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["sales_location_id", "valid_from"], name: "index_sales_location_costs_on_sales_location_id_and_valid_from"
+    t.index ["sales_location_id"], name: "index_sales_location_costs_on_sales_location_id"
+  end
+
+  create_table "sales_locations", force: :cascade do |t|
+    t.string "name", null: false
+    t.boolean "active", default: true, null: false
+    t.integer "position", default: 0, null: false
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["deleted_at"], name: "index_sales_locations_on_deleted_at"
+    t.index ["name"], name: "index_sales_locations_on_name_unique", unique: true, where: "(deleted_at IS NULL)"
+  end
+
   create_table "sms_messages", force: :cascade do |t|
     t.integer "direction", default: 0, null: false
     t.string "to_e164", null: false
@@ -653,6 +685,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_18_154405) do
   add_foreign_key "bake_day_artisans", "bake_days"
   add_foreign_key "bake_day_pickup_locations", "bake_days"
   add_foreign_key "bake_day_pickup_locations", "pickup_locations"
+  add_foreign_key "bake_day_sales_locations", "bake_days"
+  add_foreign_key "bake_day_sales_locations", "sales_locations"
   add_foreign_key "customer_groups", "customers"
   add_foreign_key "customer_groups", "groups"
   add_foreign_key "group_product_discounts", "groups"
@@ -676,6 +710,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_18_154405) do
   add_foreign_key "product_variants", "products"
   add_foreign_key "revenue_partnership_memberships", "artisans"
   add_foreign_key "revenue_partnership_memberships", "revenue_partnerships"
+  add_foreign_key "sales_location_costs", "sales_locations"
   add_foreign_key "sms_messages", "customers"
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/spec/factories/bake_day_sales_locations.rb
+++ b/spec/factories/bake_day_sales_locations.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :bake_day_sales_location do
+    bake_day
+    sales_location
+  end
+end

--- a/spec/factories/sales_location_costs.rb
+++ b/spec/factories/sales_location_costs.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :sales_location_cost do
+    sales_location
+    amount_cents { 2_500 } # 25,00 €
+    valid_from { Date.new(2026, 1, 1) }
+    valid_until { nil }
+  end
+end

--- a/spec/factories/sales_locations.rb
+++ b/spec/factories/sales_locations.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :sales_location do
+    sequence(:name) { |n| "Marché #{n}" }
+    active { true }
+    sequence(:position) { |n| n }
+
+    trait :deleted do
+      deleted_at { Time.current }
+    end
+  end
+end

--- a/spec/models/email_message_spec.rb
+++ b/spec/models/email_message_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe EmailMessage, type: :model do
     expect(message.errors[:body_html]).to be_present
   end
 
-  it 'exposes confirmation, otp and other kinds' do
-    expect(EmailMessage.kinds.keys).to contain_exactly("confirmation", "otp", "other")
+  it 'exposes confirmation, otp, ready and other kinds' do
+    expect(EmailMessage.kinds.keys).to contain_exactly("confirmation", "otp", "other", "ready")
   end
 
   it 'belongs optionally to a customer and an order' do

--- a/spec/models/sales_location_spec.rb
+++ b/spec/models/sales_location_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+# Lieu de vente (#150) et coût historisé par période de validité.
+RSpec.describe SalesLocation do
+  describe "validations" do
+    it "exige un nom" do
+      expect(build(:sales_location, name: nil)).not_to be_valid
+    end
+
+    it "refuse un nom dupliqué parmi les lieux non supprimés" do
+      create(:sales_location, name: "Marché d'Anhée")
+      expect(build(:sales_location, name: "Marché d'Anhée")).not_to be_valid
+    end
+
+    it "autorise le même nom qu'un lieu supprimé (soft delete)" do
+      create(:sales_location, :deleted, name: "Marché d'Anhée")
+      expect(build(:sales_location, name: "Marché d'Anhée")).to be_valid
+    end
+  end
+
+  describe "soft deletion" do
+    it "conserve le lieu lisible après suppression, hors du scope not_deleted" do
+      location = create(:sales_location)
+      location.soft_delete!
+
+      expect(location.reload.deleted_at).to be_present
+      expect(SalesLocation.not_deleted).not_to include(location)
+      expect(SalesLocation.find(location.id)).to eq(location)
+    end
+  end
+
+  describe "scopes" do
+    it "active ne renvoie que les lieux actifs et non supprimés" do
+      active = create(:sales_location, active: true)
+      create(:sales_location, active: false)
+      create(:sales_location, :deleted, active: true)
+
+      expect(SalesLocation.active).to contain_exactly(active)
+    end
+  end
+
+  describe "#cost_cents" do
+    let(:location) { create(:sales_location) }
+
+    it "renvoie nil si aucune période ne couvre la date" do
+      create(:sales_location_cost, sales_location: location,
+             amount_cents: 2_000, valid_from: Date.new(2026, 6, 1))
+
+      expect(location.cost_cents(on: Date.new(2026, 5, 31))).to be_nil
+    end
+
+    it "renvoie le coût d'une période ouverte (valid_until nil) à partir de valid_from" do
+      create(:sales_location_cost, sales_location: location,
+             amount_cents: 2_000, valid_from: Date.new(2026, 1, 1), valid_until: nil)
+
+      expect(location.cost_cents(on: Date.new(2026, 1, 1))).to eq(2_000)
+      expect(location.cost_cents(on: Date.new(2027, 12, 31))).to eq(2_000)
+    end
+
+    it "respecte les bornes d'une période fermée (valid_from..valid_until inclus)" do
+      create(:sales_location_cost, sales_location: location,
+             amount_cents: 3_000, valid_from: Date.new(2026, 3, 1), valid_until: Date.new(2026, 3, 31))
+
+      expect(location.cost_cents(on: Date.new(2026, 2, 28))).to be_nil
+      expect(location.cost_cents(on: Date.new(2026, 3, 1))).to eq(3_000)
+      expect(location.cost_cents(on: Date.new(2026, 3, 31))).to eq(3_000)
+      expect(location.cost_cents(on: Date.new(2026, 4, 1))).to be_nil
+    end
+
+    it "sélectionne la bonne période quand le coût évolue dans le temps" do
+      create(:sales_location_cost, sales_location: location,
+             amount_cents: 2_000, valid_from: Date.new(2026, 1, 1), valid_until: Date.new(2026, 6, 30))
+      create(:sales_location_cost, sales_location: location,
+             amount_cents: 2_500, valid_from: Date.new(2026, 7, 1), valid_until: nil)
+
+      expect(location.cost_cents(on: Date.new(2026, 5, 15))).to eq(2_000)
+      expect(location.cost_cents(on: Date.new(2026, 7, 15))).to eq(2_500)
+    end
+  end
+
+  describe SalesLocationCost do
+    it "refuse une fin antérieure au début" do
+      cost = build(:sales_location_cost,
+                   valid_from: Date.new(2026, 3, 1), valid_until: Date.new(2026, 2, 1))
+      expect(cost).not_to be_valid
+    end
+
+    it "convertit amount_euros vers amount_cents" do
+      cost = build(:sales_location_cost, amount_cents: nil)
+      cost.amount_euros = "25,50"
+      expect(cost.amount_cents).to eq(2_550)
+    end
+  end
+end

--- a/spec/requests/admin/sales_locations_spec.rb
+++ b/spec/requests/admin/sales_locations_spec.rb
@@ -1,0 +1,107 @@
+require "rails_helper"
+
+# Admin des lieux de vente (#150) : CRUD, coûts historisés, liaison depuis le
+# formulaire jour de cuisson, et ligne de déduction dans le rapport boulangers.
+RSpec.describe "Admin — lieux de vente", type: :request do
+  before do
+    ENV["ADMIN_PASSWORD"] = "test-admin-pw"
+    post admin_login_path, params: { password: "test-admin-pw" }
+  end
+
+  describe "CRUD lieu de vente" do
+    it "liste les lieux de vente" do
+      create(:sales_location, name: "Marché d'Anhée")
+      get admin_settings_sales_locations_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(CGI.escapeHTML("Marché d'Anhée"))
+    end
+
+    it "crée un lieu de vente" do
+      expect {
+        post admin_settings_sales_locations_path, params: {
+          sales_location: { name: "Marché de Dinant", active: "1", position: 2 }
+        }
+      }.to change(SalesLocation, :count).by(1)
+
+      expect(SalesLocation.last.name).to eq("Marché de Dinant")
+    end
+
+    it "met à jour un lieu de vente" do
+      location = create(:sales_location, name: "Anhée")
+      patch admin_settings_sales_location_path(location), params: {
+        sales_location: { name: "Marché d'Anhée", active: "1" }
+      }
+
+      expect(location.reload.name).to eq("Marché d'Anhée")
+    end
+
+    it "supprime un lieu en soft delete" do
+      location = create(:sales_location)
+      delete admin_settings_sales_location_path(location)
+
+      expect(location.reload.deleted_at).to be_present
+      expect(SalesLocation.not_deleted).not_to include(location)
+    end
+  end
+
+  describe "coûts historisés" do
+    let(:location) { create(:sales_location, name: "Marché d'Anhée") }
+
+    it "ajoute un palier de coût saisi en euros" do
+      expect {
+        post admin_settings_sales_location_sales_location_costs_path(location), params: {
+          sales_location_cost: { amount_euros: "25,50", valid_from: "2026-01-01", valid_until: "" }
+        }
+      }.to change(SalesLocationCost, :count).by(1)
+
+      cost = SalesLocationCost.last
+      expect(cost.amount_cents).to eq(2_550)
+      expect(cost.valid_until).to be_nil
+    end
+
+    it "refuse une période dont la fin précède le début" do
+      expect {
+        post admin_settings_sales_location_sales_location_costs_path(location), params: {
+          sales_location_cost: { amount_euros: "25", valid_from: "2026-03-01", valid_until: "2026-02-01" }
+        }
+      }.not_to change(SalesLocationCost, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "liaison au jour de cuisson" do
+    it "permet de cocher des lieux de vente à la création d'une fournée" do
+      create(:pickup_location, :default)
+      location = create(:sales_location, name: "Marché d'Anhée")
+
+      post admin_bake_days_path, params: {
+        bake_day: {
+          baked_on: Date.current.next_occurring(:tuesday).to_s,
+          cut_off_at: 2.days.from_now.to_s,
+          sales_location_ids: [ location.id ]
+        }
+      }
+
+      expect(BakeDay.last.sales_locations).to include(location)
+    end
+
+    it "affiche le sélecteur de lieux de vente dans le formulaire" do
+      create(:sales_location, name: "Marché d'Anhée")
+      get new_admin_bake_day_path
+
+      expect(response.body).to include("Lieux de vente")
+      expect(response.body).to include(CGI.escapeHTML("Marché d'Anhée"))
+    end
+  end
+
+  describe "rapport boulangers" do
+    it "affiche une ligne de déduction pour les lieux de vente" do
+      get baker_revenue_admin_reports_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Lieux de vente")
+    end
+  end
+end

--- a/spec/services/baker_revenue_service_sales_locations_spec.rb
+++ b/spec/services/baker_revenue_service_sales_locations_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+# Déduction du coût des lieux de vente (#150) dans le calcul des revenus
+# boulangers : le coût des lieux liés à une fournée (résolu à sa date de cuisson)
+# est retranché de la marge brute AVANT le partage 70/30.
+RSpec.describe BakerRevenueService do
+  def bread_variant(price_cents:, cost_cents:)
+    product = create(:product, category: :breads, internal_category: :boulangerie)
+    variant = create(:product_variant, product: product, price_cents: price_cents)
+    create(:variant_cost_price, product_variant: variant, amount_cents: cost_cents, active_from: Date.new(2026, 1, 1))
+    variant
+  end
+
+  def completed_order(bake_day:, variant:, qty:)
+    order = create(:order, :paid, bake_day: bake_day, total_cents: qty * variant.price_cents)
+    create(:order_item, order: order, product_variant: variant, qty: qty, unit_price_cents: variant.price_cents)
+    order
+  end
+
+  let(:start_date) { Date.new(2026, 5, 1) }
+  let(:end_date) { Date.new(2026, 5, 31) }
+  let(:bake_day) { create(:bake_day, baked_on: Date.new(2026, 5, 12)) }
+  let(:variant) { bread_variant(price_cents: 1_000, cost_cents: 400) }
+
+  subject(:report) { described_class.new(start_date: start_date, end_date: end_date).call }
+
+  before do
+    create(:bread_bag_price, amount_cents: 4, active_from: Date.new(2026, 1, 1))
+    create(:revenue_parameter, :transport, value: 1_500, active_from: Date.new(2026, 1, 1))
+    create(:revenue_parameter, :four_sources_rate, value: 3_000, active_from: Date.new(2026, 1, 1))
+    completed_order(bake_day: bake_day, variant: variant, qty: 10)
+  end
+
+  # Sans lieu de vente : marge brute de référence = 10000 − 4000 − 40 − 1500 = 4460.
+  context "sans lieu de vente lié" do
+    it "ne déduit rien : marge brute et split inchangés" do
+      day = report.days.first
+
+      expect(day.sales_locations_cents).to eq(0)
+      expect(day.gross_margin_cents).to eq(4_460)
+      expect(day.four_sources_cents).to eq(1_338)
+      expect(day.baker_pool_cents).to eq(3_122)
+      expect(report.total_sales_locations_cents).to eq(0)
+    end
+  end
+
+  context "avec un lieu de vente lié" do
+    before do
+      location = create(:sales_location, name: "Marché d'Anhée")
+      create(:sales_location_cost, sales_location: location, amount_cents: 2_000,
+             valid_from: Date.new(2026, 1, 1), valid_until: nil)
+      bake_day.sales_locations << location
+    end
+
+    it "déduit le coût du lieu de la marge brute avant le split" do
+      day = report.days.first
+
+      expect(day.sales_locations_cents).to eq(2_000)
+      # marge brute = 4460 − 2000 = 2460
+      expect(day.gross_margin_cents).to eq(2_460)
+      # 4S = 30 % × 2460 = 738 ; pool = 2460 − 738 = 1722
+      expect(day.four_sources_cents).to eq(738)
+      expect(day.baker_pool_cents).to eq(1_722)
+      expect(report.total_sales_locations_cents).to eq(2_000)
+    end
+  end
+
+  context "avec deux lieux de vente liés" do
+    before do
+      [ [ "Anhée", 2_000 ], [ "Dinant", 1_500 ] ].each do |name, cost|
+        location = create(:sales_location, name: name)
+        create(:sales_location_cost, sales_location: location, amount_cents: cost,
+               valid_from: Date.new(2026, 1, 1), valid_until: nil)
+        bake_day.sales_locations << location
+      end
+    end
+
+    it "cumule les coûts des deux lieux" do
+      day = report.days.first
+
+      expect(day.sales_locations_cents).to eq(3_500)
+      # marge brute = 4460 − 3500 = 960
+      expect(day.gross_margin_cents).to eq(960)
+      # 4S = 30 % × 960 = 288 ; pool = 672
+      expect(day.four_sources_cents).to eq(288)
+      expect(day.baker_pool_cents).to eq(672)
+    end
+  end
+
+  context "quand le coût du lieu évolue dans le temps" do
+    before do
+      location = create(:sales_location, name: "Marché d'Anhée")
+      # Période antérieure à la fournée (mai) : ne doit PAS s'appliquer.
+      create(:sales_location_cost, sales_location: location, amount_cents: 9_999,
+             valid_from: Date.new(2025, 1, 1), valid_until: Date.new(2026, 4, 30))
+      # Période couvrant la fournée du 12/05.
+      create(:sales_location_cost, sales_location: location, amount_cents: 2_000,
+             valid_from: Date.new(2026, 5, 1), valid_until: nil)
+      bake_day.sales_locations << location
+    end
+
+    it "applique le coût de la période qui couvre la date de cuisson" do
+      expect(report.days.first.sales_locations_cents).to eq(2_000)
+    end
+  end
+end

--- a/spec/services/order_notification_service_ready_spec.rb
+++ b/spec/services/order_notification_service_ready_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe OrderMailer, type: :mailer do
       mail = OrderMailer.ready(order)
 
       expect(mail.subject).to eq('Ta commande est prête !')
-      expect(mail.to).to eq([customer.email])
+      expect(mail.to).to eq([ customer.email ])
       expect(mail.body.encoded).to include('Corps de message éditable')
       expect(mail['X-Email-Kind'].value).to eq('ready')
     end


### PR DESCRIPTION
Closes #150

## Résumé

Ajoute la notion de **lieu de vente** (ex. un marché), concept **séparé** du lieu de retrait, porteur d'un **coût d'emplacement historisé** qui se déduit du bénéfice des fournées où l'on vend.

- **`SalesLocation`** — modèle simple avec activation (`active`) + soft delete (comme `PickupLocation` / `MoldType`), scopes `not_deleted` / `active` / `ordered`, unicité de nom conditionnelle sur `deleted_at`.
- **`SalesLocationCost`** — coût historisé par **période de validité** : `amount_cents`, `valid_from`, `valid_until` nullable (= période en cours). Résolveur `SalesLocation#cost_cents(on:)` → le coût de la période qui couvre la date (le `valid_from` le plus récent gagne en cas de chevauchement).
- **Jointure N-N** `BakeDay` ↔ `SalesLocation` (`bake_day_sales_locations`, `sales_location_ids`). Pas de garde « déjà commandé » (contrairement aux lieux de retrait) : aucune commande ne s'y rattache, l'affectation standard suffit.
- **`BakerRevenueService`** — le coût des lieux liés à la fournée (résolu à sa **date de cuisson**) est déduit de la **marge brute AVANT** le partage 70/30 (au même niveau que coûtant / sacs / transport / commissions). Impacte donc boulangers **et** 4 Sources, comme décidé. 0 lieu lié → déduction nulle, chiffres inchangés.
- **Admin Paramètres** — CRUD lieux de vente + CRUD des coûts historisés par période, lien ajouté au menu Paramètres.
- **Formulaire jour de cuisson** — sélecteur multiple des lieux de vente (partial `_sales_locations`).
- **Rapport « Revenus des boulangers »** — carte de synthèse + colonne par jour + total « Lieux de vente », et libellé de marge brute mis à jour.

Approche d'historisation : le champ `valid_from`/`valid_until` est explicitement demandé par l'issue ; le résolveur suit l'esprit des coûts historisés existants (`VariantCostPrice`, `BreadBagPrice`, `RevenueParameter`).

## 📸 Aperçu

![Admin — Lieux de vente (coûts historisés)](https://github.com/les4sources/tranchesdevie2/raw/agent-screenshots/screenshots/20260719-043058-admin--lieux-de-vente-cots-historiss.png)

## Testé

- `bundle exec rspec` → **744 examples, 0 failures**.
- `bin/rubocop` → **no offenses**.
- `bin/brakeman --no-pager` → **0 warning**.
- **Modèle** (`spec/models/sales_location_spec.rb`) : validations, soft delete, scope `active`, résolution du coût par date (période ouverte, période fermée avec bornes incluses, évolution dans le temps, `valid_until` < `valid_from` refusé, conversion €→cents).
- **Service** (`spec/services/baker_revenue_service_sales_locations_spec.rb`) : déduction avec **0 / 1 / 2** lieux liés, recalcul de la marge brute et du split 30/70, sélection de la bonne période quand le coût évolue.
- **Requête admin** (`spec/requests/admin/sales_locations_spec.rb`) : CRUD lieu + coûts (saisie en €, refus période invalide), liaison depuis le formulaire fournée, ligne de déduction visible dans le rapport boulangers.
- Migration appliquée proprement sur la base de test (schéma dumpé : 3 tables + FK).

## NON testé

- **Rendu visuel réel de la page** au-delà de la capture ci-dessus (la capture est produite via un test système Capybara headless connecté à l'admin, puis supprimé). Pas de vérification navigateur interactive.
- **Base de dev non migrée** : `bin/rails db:migrate` échoue en environnement de dev sur une **ancienne** migration (`20260604130000`, index unique email clients) à cause de données dupliquées **préexistantes** — sans rapport avec cette PR. Ma migration a donc été validée sur la base de **test** (rechargée depuis `schema.rb`), où elle passe seule et proprement. `schema.rb` est à jour (version `2026_07_19_120000`).

## Hors périmètre (pour verdir la suite)

Deux échecs **préexistants sur `main`**, sans rapport avec #150, corrigés a minima pour que le gate rspec/rubocop soit vert :
- `spec/models/email_message_spec.rb` : l'enum `EmailMessage.kind` a gagné une valeur `ready` (commit `bdcc283`) sans mise à jour de la spec → assertion `contain_exactly` complétée.
- `spec/services/order_notification_service_ready_spec.rb` : 2 offenses `Layout/SpaceInsideArrayLiteralBrackets` autocorrigées.
