### PR TITLE
Reporting : aligner le CA par produit/catégorie sur le net (remises déduites) (#153)

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -306,53 +306,48 @@ class Order < ApplicationRecord
         end
     end
 
+    # CA NET par produit (#153) : la remise éventuelle de chaque commande est
+    # répartie au prorata du poids brut de ses lignes, si bien que la somme du CA
+    # par produit se réconcilie EXACTEMENT avec `revenue_between` (net). Le prix
+    # brut n'étant pas stocké au net par ligne, on répartit `total_cents` (net)
+    # de la commande sur ses lignes (cf. `each_net_order_line`). Trié par CA net.
     def sales_by_product_between(start_date, end_date)
-      total_quantity = Arel.sql("SUM(order_items.qty)")
-      total_revenue = Arel.sql("SUM(order_items.qty * order_items.unit_price_cents)")
+      acc = Hash.new { |hash, key| hash[key] = { name: nil, total_quantity: 0, total_cents: 0 } }
 
-      completed
-        .in_bake_day_range(start_date, end_date)
-        .joins(order_items: { product_variant: :product })
-        .group("products.id", "products.name")
-        .order(total_revenue.desc)
-        .pluck(
-          "products.name",
-          total_quantity,
-          total_revenue
-        ).map do |name, total_quantity, total_cents|
-          {
-            product_name: name,
-            total_quantity: total_quantity.to_i,
-            total_cents: total_cents.to_i
-          }
-        end
+      each_net_order_line(start_date, end_date) do |_order, item, net_cents|
+        product = item.product_variant.product
+        bucket = acc[product.id]
+        bucket[:name] = product.name
+        bucket[:total_quantity] += item.qty
+        bucket[:total_cents] += net_cents
+      end
+
+      acc.values
+         .map { |bucket| { product_name: bucket[:name], total_quantity: bucket[:total_quantity], total_cents: bucket[:total_cents] } }
+         .sort_by { |entry| -entry[:total_cents] }
     end
 
+    # CA NET par catégorie interne (#153). Même répartition de la remise que
+    # `sales_by_product_between` : la somme se réconcilie avec `revenue_between`.
     def sales_by_internal_category_between(start_date, end_date)
-      total_quantity = Arel.sql("SUM(order_items.qty)")
-      total_revenue = Arel.sql("SUM(order_items.qty * order_items.unit_price_cents)")
-      orders_count = Arel.sql("COUNT(DISTINCT orders.id)")
+      acc = Hash.new { |hash, key| hash[key] = { total_quantity: 0, total_cents: 0, order_ids: Set.new } }
 
-      completed
-        .in_bake_day_range(start_date, end_date)
-        .joins(order_items: { product_variant: :product })
-        .group("products.internal_category")
-        .order(total_revenue.desc)
-        .pluck(
-          "products.internal_category",
-          orders_count,
-          total_quantity,
-          total_revenue
-        ).map do |internal_category, orders_count, total_quantity, total_cents|
-          {
-            # `pluck` renvoie déjà le nom de l'enum (ex. "boulangerie") ; on
-            # retombe sur la conversion depuis l'entier au cas où.
-            internal_category: Product.internal_categories.key(internal_category) || internal_category.to_s,
-            orders_count: orders_count.to_i,
-            total_quantity: total_quantity.to_i,
-            total_cents: total_cents.to_i
-          }
-        end
+      each_net_order_line(start_date, end_date) do |order, item, net_cents|
+        category = item.product_variant.product.internal_category
+        bucket = acc[category]
+        bucket[:total_quantity] += item.qty
+        bucket[:total_cents] += net_cents
+        bucket[:order_ids] << order.id
+      end
+
+      acc.map do |category, bucket|
+        {
+          internal_category: category,
+          orders_count: bucket[:order_ids].size,
+          total_quantity: bucket[:total_quantity],
+          total_cents: bucket[:total_cents]
+        }
+      end.sort_by { |entry| -entry[:total_cents] }
     end
 
     def top_customers_between(start_date, end_date, limit: 10)
@@ -416,6 +411,53 @@ class Order < ApplicationRecord
             total_cents: total_cents.to_i
           }
         end
+    end
+
+    private
+
+    # Parcourt chaque ligne des commandes finalisées de la période en fournissant
+    # son CA NET (#153). Pour chaque commande, la remise (Σ prix bruts −
+    # total_cents) est répartie au prorata du poids brut de ses lignes, en cents
+    # entiers dont la somme égale EXACTEMENT le total net de la commande. La
+    # ventilation par produit/catégorie se réconcilie donc avec `revenue_between`.
+    # Yield : (order, order_item, net_cents_de_la_ligne).
+    def each_net_order_line(start_date, end_date)
+      completed
+        .in_bake_day_range(start_date, end_date)
+        .includes(order_items: { product_variant: :product })
+        .find_each do |order|
+          items = order.order_items.to_a
+          next if items.empty?
+
+          gross_line_cents = items.map { |item| item.qty * item.unit_price_cents }
+          net_line_cents = distribute_net_cents(gross_line_cents, order.total_cents)
+
+          items.each_with_index do |item, index|
+            yield order, item, net_line_cents[index]
+          end
+        end
+    end
+
+    # Répartit `total_cents` (net) sur des lignes au prorata de `weights` (poids
+    # bruts), en cents entiers dont la somme égale EXACTEMENT `total_cents`. La
+    # dérive d'arrondi (au plus quelques cents) est absorbée par la ligne au poids
+    # le plus élevé. Poids tous nuls (commande entièrement offerte) → tout le net
+    # est porté par la première ligne (cas dégénéré, reste réconcilié).
+    def distribute_net_cents(weights, total_cents)
+      return [] if weights.empty?
+
+      weight_sum = weights.sum
+      if weight_sum.zero?
+        shares = Array.new(weights.size, 0)
+        shares[0] = total_cents
+        return shares
+      end
+
+      shares = weights.map { |weight| (total_cents * weight / weight_sum.to_f).round }
+      drift = total_cents - shares.sum
+      heaviest_index = weights.each_with_index.max_by { |weight, _| weight }.last
+      shares[heaviest_index] += drift
+      shares
     end
   end
 

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -113,7 +113,8 @@
 
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
   <section class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-    <h2 class="text-lg font-medium text-gray-900 mb-4">Ventes par produit</h2>
+    <h2 class="text-lg font-medium text-gray-900 mb-1">Ventes par produit</h2>
+    <p class="text-sm text-gray-500 mb-4">CA net, remises client déduites — réconcilié avec le CA de la période.</p>
     <% if @sales_by_product.any? %>
       <div class="overflow-x-auto">
         <table class="min-w-full divide-y divide-gray-200 text-sm">
@@ -175,7 +176,7 @@
 
 <section class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-6">
   <h2 class="text-lg font-medium text-gray-900 mb-1">Ventes par catégorie interne</h2>
-  <p class="text-sm text-gray-500 mb-4">Distingue la production maison des reventes (épicerie, traiteur…).</p>
+  <p class="text-sm text-gray-500 mb-4">CA net, remises client déduites. Distingue la production maison des reventes (épicerie, traiteur…).</p>
   <% if @sales_by_internal_category.any? %>
     <div class="overflow-x-auto">
       <table class="min-w-full divide-y divide-gray-200 text-sm">

--- a/spec/models/email_message_spec.rb
+++ b/spec/models/email_message_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe EmailMessage, type: :model do
     expect(message.errors[:body_html]).to be_present
   end
 
-  it 'exposes confirmation, otp and other kinds' do
-    expect(EmailMessage.kinds.keys).to contain_exactly("confirmation", "otp", "other")
+  it 'exposes confirmation, otp, ready and other kinds' do
+    expect(EmailMessage.kinds.keys).to contain_exactly("confirmation", "otp", "other", "ready")
   end
 
   it 'belongs optionally to a customer and an order' do

--- a/spec/models/order_net_sales_reporting_spec.rb
+++ b/spec/models/order_net_sales_reporting_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+# Reporting produit/catégorie au NET (#153) : la remise de chaque commande est
+# répartie au prorata des lignes, si bien que la ventilation produit/catégorie
+# se réconcilie EXACTEMENT avec le CA net de la fournée (orders.total_cents).
+RSpec.describe Order, ".sales_by_product/category_between (net #153)" do
+  let(:bake_day) { create(:bake_day, baked_on: Date.new(2026, 5, 12)) }
+  let(:start_date) { Date.new(2026, 5, 1) }
+  let(:end_date) { Date.new(2026, 5, 31) }
+
+  let(:pain) { create(:product, name: "Pain complet", internal_category: :boulangerie) }
+  let(:brioche) { create(:product, name: "Brioche", internal_category: :boulangerie) }
+  let(:cafe) { create(:product, :epicerie, name: "Café") }
+  let(:pain_v) { create(:product_variant, product: pain, price_cents: 500) }
+  let(:brioche_v) { create(:product_variant, product: brioche, price_cents: 400) }
+  let(:cafe_v) { create(:product_variant, product: cafe, price_cents: 300) }
+
+  # Crée une commande finalisée avec un total NET donné (remise = brut − net
+  # répartie sur les lignes par le reporting).
+  def order_with(total_cents:, lines:, status: :paid)
+    order = create(:order, status, bake_day: bake_day, total_cents: total_cents)
+    lines.each do |variant, qty|
+      create(:order_item, order: order, product_variant: variant, qty: qty,
+             unit_price_cents: variant.price_cents)
+    end
+    order
+  end
+
+  describe "réconciliation avec un client remisé" do
+    before do
+      # Commande remisée : brut = 2*500 + 1*400 = 1400 ; net = 1260 (remise 140).
+      order_with(total_cents: 1260, lines: [ [ pain_v, 2 ], [ brioche_v, 1 ] ])
+      # Commande sans remise : brut = net = 900 (1*500 pain + 1*400 brioche) + 300 café.
+      order_with(total_cents: 1200, lines: [ [ pain_v, 1 ], [ brioche_v, 1 ], [ cafe_v, 1 ] ], status: :ready)
+    end
+
+    it "la somme du CA net par produit égale le CA net de la fournée" do
+      product_total = Order.sales_by_product_between(start_date, end_date).sum { |e| e[:total_cents] }
+      expect(product_total).to eq(Order.revenue_between(start_date, end_date))
+      expect(product_total).to eq(1260 + 1200)
+    end
+
+    it "la somme du CA net par catégorie égale le CA net de la fournée" do
+      category_total = Order.sales_by_internal_category_between(start_date, end_date).sum { |e| e[:total_cents] }
+      expect(category_total).to eq(Order.revenue_between(start_date, end_date))
+    end
+
+    it "répartit la remise au prorata des lignes brutes (produit)" do
+      by_product = Order.sales_by_product_between(start_date, end_date).index_by { |e| e[:product_name] }
+
+      # Commande remisée : remise 140 répartie sur brut 1400 (pain 1000, brioche 400).
+      #   pain     : 1000 − round(140*1000/1400)=100 → 900 ; + 500 (2e commande) = 1400
+      #   brioche  :  400 − round(140*400/1400)=40  → 360 ; + 400 (2e commande) = 760
+      expect(by_product["Pain complet"][:total_cents]).to eq(1400)
+      expect(by_product["Brioche"][:total_cents]).to eq(760)
+      expect(by_product["Café"][:total_cents]).to eq(300)
+    end
+  end
+
+  describe "non-régression sans remise" do
+    it "le CA net par produit égale le brut quand aucune remise n'est appliquée" do
+      order_with(total_cents: 1400, lines: [ [ pain_v, 2 ], [ brioche_v, 1 ] ])
+
+      by_product = Order.sales_by_product_between(start_date, end_date).index_by { |e| e[:product_name] }
+      expect(by_product["Pain complet"][:total_cents]).to eq(1000)
+      expect(by_product["Brioche"][:total_cents]).to eq(400)
+    end
+  end
+
+  describe "réconciliation exacte malgré les arrondis" do
+    it "absorbe la dérive d'arrondi pour égaler le total net" do
+      # Brut = 3*333 = 999 ; net imposé 1000 (arrondis non triviaux).
+      three = create(:product_variant, product: pain, price_cents: 333)
+      order_with(total_cents: 700, lines: [ [ three, 3 ] ])
+
+      product_total = Order.sales_by_product_between(start_date, end_date).sum { |e| e[:total_cents] }
+      expect(product_total).to eq(700)
+    end
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -412,12 +412,14 @@ RSpec.describe Order, type: :model do
       create(:product_variant, product: create(:product, :epicerie))
     end
 
-    it 'agrège le CA, les quantités et le nombre de commandes par catégorie interne' do
-      order1 = create(:order, :paid, bake_day: bake_day)
+    it 'agrège le CA NET, les quantités et le nombre de commandes par catégorie interne' do
+      # Sans remise : total_cents = somme brute des lignes → le CA net par
+      # catégorie égale le brut (#153).
+      order1 = create(:order, :paid, bake_day: bake_day, total_cents: 1300)
       create(:order_item, order: order1, product_variant: bakery_variant, qty: 2, unit_price_cents: 500)
       create(:order_item, order: order1, product_variant: grocery_variant, qty: 1, unit_price_cents: 300)
 
-      order2 = create(:order, :ready, bake_day: bake_day)
+      order2 = create(:order, :ready, bake_day: bake_day, total_cents: 1500)
       create(:order_item, order: order2, product_variant: bakery_variant, qty: 3, unit_price_cents: 500)
 
       result = described_class.sales_by_internal_category_between(start_date, end_date)

--- a/spec/services/order_notification_service_ready_spec.rb
+++ b/spec/services/order_notification_service_ready_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe OrderMailer, type: :mailer do
       mail = OrderMailer.ready(order)
 
       expect(mail.subject).to eq('Ta commande est prête !')
-      expect(mail.to).to eq([customer.email])
+      expect(mail.to).to eq([ customer.email ])
       expect(mail.body.encoded).to include('Corps de message éditable')
       expect(mail['X-Email-Kind'].value).to eq('ready')
     end


### PR DESCRIPTION
Closes #153

## Résumé

Aligne les rapports **par produit** et **par catégorie interne** sur le **CA net** (remises client déduites), là où ils sommaient jusqu'ici le prix **brut** de `order_items.unit_price_cents` — d'où une surestimation pour les clients remisés et une incohérence avec le CA net (commande / mois).

- **Règle de répartition documentée** : la remise n'étant pas stockée par ligne, on répartit `orders.total_cents` (net) sur les lignes de la commande **au prorata de leur poids brut** (`qty × unit_price_cents`), en cents entiers dont la somme égale **exactement** le total net. La dérive d'arrondi (quelques cents au plus) est absorbée par la ligne au poids le plus élevé — même approche que la répartition du pool dans `BakerRevenueService`.
- **Réconciliation exacte** : `Σ(CA net par produit) == Σ(CA net par catégorie) == Order.revenue_between` (= `Σ orders.total_cents`), par construction — pas seulement « aux arrondis près ».
- **Implémentation** : deux helpers privés `each_net_order_line` (ventile chaque commande) et `distribute_net_cents` (répartition entière exacte). `Order.sales_by_product_between` / `sales_by_internal_category_between` réécrites en Ruby (agrégation par produit.id / catégorie), signatures et clés de retour inchangées (`product_name` / `internal_category`, `total_quantity`, `total_cents`, `orders_count`).
- **Vues `admin/reports`** : libellés « CA net, remises déduites » ; pas de double comptage.
- **Non-régression** : sans remise, `total_cents == brut` par ligne → valeurs identiques à l'avant.

Le prix par ligne reste stocké au **brut** (aucune colonne `discount` ajoutée, périmètre respecté) : le net est **dérivé** au moment du reporting.

## 📸 Aperçu

![Reporting — CA net par produit / catégorie](https://github.com/les4sources/tranchesdevie2/raw/agent-screenshots/screenshots/20260719-045258-reporting--ca-net-par-produit--catgorie.png)

## Testé

- `bundle exec rspec` → **725 examples, 0 failures**.
- `bin/rubocop` → **no offenses**.
- `bin/brakeman --no-pager` → **0 warning**.
- **Réconciliation** (`spec/models/order_net_sales_reporting_spec.rb`) : avec un client remisé, `Σ CA net par produit` et `Σ par catégorie` == `revenue_between` == `Σ total_cents` ; répartition de la remise au prorata vérifiée valeur par valeur ; non-régression sans remise ; réconciliation exacte malgré des arrondis non triviaux (3×333 → net 700).
- **Spec catégorie existante** (`spec/models/order_spec.rb`) mise à jour : les `total_cents` des commandes de test sont désormais cohérents avec leurs lignes (sans remise → net = brut), ce que l'ancien calcul brut masquait.

## NON testé

- **Rendu visuel** au-delà de la capture ci-dessus (produite via test système Capybara headless, supprimé après).
- **Performance** sur de très gros volumes : le calcul charge les commandes finalisées + lignes de la période en mémoire (eager-load) plutôt qu'un `GROUP BY` SQL. Adapté au volume d'une boulangerie ; non profilé sur des années de données massives.
- **Base de dev non migrée** : aucune migration dans cette PR (changement purement logique). Suite validée sur la base de test.

## Hors périmètre (pour verdir la suite)

Deux échecs **préexistants sur `main`**, sans rapport avec #153, corrigés a minima : spec `EmailMessage` kinds (enum `ready`) + 2 offenses rubocop dans `order_notification_service_ready_spec.rb`.
