### PR TITLE
Fix du double crédit du portefeuille lors d'une recharge (#159)

### DIFF
--- a/app/controllers/customers/wallets_controller.rb
+++ b/app/controllers/customers/wallets_controller.rb
@@ -78,12 +78,15 @@ module Customers
         redirect_to customers_wallet_reload_path, alert: message and return
       end
 
-      WalletService.top_up(
+      # `top_up` est idempotent : si le webhook Stripe a gagné la course entre le
+      # check ci-dessus et ici, il rend la transaction existante sans recréditer.
+      wallet_transaction = WalletService.top_up(
         wallet: @wallet,
         amount_cents: payment_intent.amount,
         stripe_payment_intent_id: @payment_intent_id
       )
-      @amount_cents = payment_intent.amount
+      @amount_cents = wallet_transaction&.amount_cents || payment_intent.amount
+      @wallet.reload
     rescue Stripe::StripeError => e
       Rails.logger.error("Stripe error on reload_success: #{e.message}")
       redirect_to customers_wallet_reload_path, alert: "Une erreur est survenue. Veuillez réessayer."

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -5,9 +5,10 @@ class Wallet < ApplicationRecord
   validates :balance_cents, numericality: { only_integer: true }
   validates :low_balance_threshold_cents, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
+  # Retourne la WalletTransaction créée.
   def credit!(amount_cents, type:, order: nil, stripe_payment_intent_id: nil, description: nil)
     transaction do
-      wallet_transactions.create!(
+      wallet_transaction = wallet_transactions.create!(
         amount_cents: amount_cents,
         transaction_type: type,
         order: order,
@@ -15,6 +16,7 @@ class Wallet < ApplicationRecord
         description: description
       )
       increment!(:balance_cents, amount_cents)
+      wallet_transaction
     end
   end
 

--- a/app/services/wallet_service.rb
+++ b/app/services/wallet_service.rb
@@ -1,12 +1,45 @@
 class WalletService
   class << self
+    # Crédite le portefeuille pour une recharge Stripe.
+    #
+    # Deux chemins indépendants appellent cette méthode pour un même
+    # PaymentIntent — le webhook Stripe et la page de retour Bancontact — et ils
+    # arrivent souvent quasi simultanément. Sans sérialisation, leurs deux checks
+    # d'idempotence passaient tous les deux et le client était crédité deux fois
+    # (#159).
+    #
+    # Trois garde-fous, du plus rapide au plus solide :
+    #   1. le verrou sur le portefeuille sérialise les deux chemins ;
+    #   2. le check d'idempotence est refait *à l'intérieur* du verrou ;
+    #   3. l'index unique partiel en base rattrape tout le reste (autre process,
+    #      autre portefeuille), auquel cas on traite le `RecordNotUnique` comme
+    #      un « déjà traité » plutôt que comme une erreur.
+    #
+    # Retourne la WalletTransaction — celle qui vient d'être créée, ou celle qui
+    # existait déjà si la recharge avait déjà été encaissée.
     def top_up(wallet:, amount_cents:, stripe_payment_intent_id:)
-      wallet.credit!(
-        amount_cents,
-        type: :top_up,
-        stripe_payment_intent_id: stripe_payment_intent_id,
-        description: "Recharge de #{amount_cents / 100.0}€"
-      )
+      description = "Recharge de #{amount_cents / 100.0}€"
+
+      # Une recharge sans PaymentIntent (crédit manuel) n'a rien à dédupliquer.
+      if stripe_payment_intent_id.blank?
+        return wallet.credit!(amount_cents, type: :top_up, description: description)
+      end
+
+      wallet.with_lock do
+        existing = existing_top_up(stripe_payment_intent_id)
+        next log_already_processed(stripe_payment_intent_id, existing) if existing
+
+        wallet.credit!(
+          amount_cents,
+          type: :top_up,
+          stripe_payment_intent_id: stripe_payment_intent_id,
+          description: description
+        )
+      end
+    rescue ActiveRecord::RecordNotUnique
+      # La transaction vient d'être annulée : le crédit concurrent a gagné et il
+      # est bien committé, donc la ligne existe maintenant.
+      log_already_processed(stripe_payment_intent_id, existing_top_up(stripe_payment_intent_id))
     end
 
     def debit_for_order(wallet:, order:)
@@ -25,6 +58,19 @@ class WalletService
         order: order,
         description: "Remboursement commande #{order.order_number}"
       )
+    end
+
+    private
+
+    # L'index unique est global (et un identifiant Stripe l'est aussi), donc on
+    # cherche sans se limiter au portefeuille courant.
+    def existing_top_up(stripe_payment_intent_id)
+      WalletTransaction.find_by(stripe_payment_intent_id: stripe_payment_intent_id)
+    end
+
+    def log_already_processed(stripe_payment_intent_id, transaction)
+      Rails.logger.info("Recharge déjà créditée pour #{stripe_payment_intent_id} : aucun crédit supplémentaire.")
+      transaction
     end
   end
 end

--- a/db/migrate/20260727013551_add_unique_index_on_stripe_payment_intent_id_to_wallet_transactions.rb
+++ b/db/migrate/20260727013551_add_unique_index_on_stripe_payment_intent_id_to_wallet_transactions.rb
@@ -1,0 +1,64 @@
+class AddUniqueIndexOnStripePaymentIntentIdToWalletTransactions < ActiveRecord::Migration[8.0]
+  INDEX_NAME = "index_wallet_transactions_on_stripe_payment_intent_id".freeze
+
+  # Filet de sécurité en base contre le double crédit du portefeuille (#159) :
+  # le webhook Stripe et la page de retour Bancontact créditent tous deux la
+  # même recharge. L'index est *partiel* : seules les recharges portent un
+  # `stripe_payment_intent_id`, les débits/remboursements de commande le
+  # laissent à NULL et peuvent donc rester nombreux.
+  def up
+    guard_against_duplicates!
+
+    add_index :wallet_transactions, :stripe_payment_intent_id,
+              unique: true,
+              where: "stripe_payment_intent_id IS NOT NULL",
+              name: INDEX_NAME
+  end
+
+  def down
+    remove_index :wallet_transactions, name: INDEX_NAME
+  end
+
+  private
+
+  # Volontairement : aucune réparation automatique des données. Un doublon
+  # signifie qu'un client a été crédité deux fois — ça se répare à la main,
+  # en console, en connaissance de cause. On échoue donc tôt et clairement
+  # plutôt que de toucher automatiquement à des lignes qui portent de l'argent.
+  def guard_against_duplicates!
+    duplicates = select_rows(<<~SQL.squish)
+      SELECT stripe_payment_intent_id, COUNT(*)
+      FROM wallet_transactions
+      WHERE stripe_payment_intent_id IS NOT NULL
+      GROUP BY stripe_payment_intent_id
+      HAVING COUNT(*) > 1
+      ORDER BY stripe_payment_intent_id
+    SQL
+
+    return if duplicates.empty?
+
+    listing = duplicates.map { |pi_id, count| "  - #{pi_id} (#{count} lignes)" }.join("\n")
+
+    raise <<~MESSAGE
+      Impossible de poser l'index unique : des recharges en double existent déjà.
+
+      PaymentIntents concernés :
+      #{listing}
+
+      Ces doublons correspondent à des clients crédités deux fois. Il faut les
+      corriger à la main en console AVANT de rejouer cette migration, par ex. :
+
+        WalletTransaction.where.not(stripe_payment_intent_id: nil)
+                         .group(:stripe_payment_intent_id)
+                         .having("count(*) > 1")
+                         .count
+                         .each_key do |pi_id|
+          txs = WalletTransaction.where(stripe_payment_intent_id: pi_id).order(:created_at).to_a
+          txs.drop(1).each do |tx|
+            tx.wallet.decrement!(:balance_cents, tx.amount_cents)
+            tx.destroy!
+          end
+        end
+    MESSAGE
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_24_064642) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_27_013551) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -712,6 +712,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_24_064642) do
     t.datetime "updated_at", null: false
     t.index ["created_at"], name: "index_wallet_transactions_on_created_at"
     t.index ["order_id"], name: "index_wallet_transactions_on_order_id"
+    t.index ["stripe_payment_intent_id"], name: "index_wallet_transactions_on_stripe_payment_intent_id", unique: true, where: "(stripe_payment_intent_id IS NOT NULL)"
     t.index ["wallet_id"], name: "index_wallet_transactions_on_wallet_id"
   end
 

--- a/spec/models/wallet_transaction_spec.rb
+++ b/spec/models/wallet_transaction_spec.rb
@@ -37,6 +37,28 @@ RSpec.describe WalletTransaction, type: :model do
     end
   end
 
+  # Index unique *partiel* : une recharge Stripe ne peut être encaissée qu'une
+  # fois (#159), mais les débits/remboursements de commande n'ont pas de
+  # PaymentIntent et restent donc nombreux à NULL.
+  describe 'unicité du stripe_payment_intent_id' do
+    let(:wallet) { create(:wallet) }
+
+    it 'refuse deux transactions pour le même PaymentIntent' do
+      create(:wallet_transaction, wallet: wallet, stripe_payment_intent_id: 'pi_unique')
+
+      expect { create(:wallet_transaction, wallet: wallet, stripe_payment_intent_id: 'pi_unique') }
+        .to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it 'accepte plusieurs transactions sans PaymentIntent' do
+      expect {
+        create(:wallet_transaction, :order_debit, wallet: wallet, stripe_payment_intent_id: nil)
+        create(:wallet_transaction, :order_debit, wallet: wallet, stripe_payment_intent_id: nil)
+        create(:wallet_transaction, :order_refund, wallet: wallet, stripe_payment_intent_id: nil)
+      }.to change(described_class, :count).by(3)
+    end
+  end
+
   describe '#amount_euros' do
     it 'returns positive amounts in euros' do
       transaction = build(:wallet_transaction, amount_cents: 1550)

--- a/spec/requests/customers/wallets_spec.rb
+++ b/spec/requests/customers/wallets_spec.rb
@@ -100,4 +100,52 @@ RSpec.describe 'Customers::Wallets', type: :request do
       end
     end
   end
+
+  # Page de retour Bancontact. Elle crédite le portefeuille, tout comme le
+  # webhook Stripe : les deux ne doivent jamais créditer la même recharge (#159).
+  describe 'GET /customers/portefeuille/success' do
+    let!(:wallet) { create(:wallet, customer: customer, balance_cents: 1000) }
+    let(:pi_id) { 'pi_reload_success_123' }
+
+    before { authenticate_customer }
+
+    def stub_succeeded_reload(amount: 5000, &during_retrieve)
+      pi = double('Stripe::PaymentIntent', id: pi_id, status: 'succeeded', amount: amount,
+                                           metadata: { 'type' => 'wallet_reload' })
+      allow(Stripe::PaymentIntent).to receive(:retrieve).with(pi_id) do
+        during_retrieve&.call
+        pi
+      end
+    end
+
+    it 'credits the wallet and displays the amount' do
+      stub_succeeded_reload
+
+      expect { get '/customers/portefeuille/success', params: { payment_intent: pi_id } }
+        .to change { wallet.reload.balance_cents }.from(1000).to(6000)
+      expect(response.body).to include('50')
+    end
+
+    it 'ne crédite pas une seconde fois quand la recharge est déjà encaissée' do
+      wallet.credit!(5000, type: :top_up, stripe_payment_intent_id: pi_id)
+
+      expect { get '/customers/portefeuille/success', params: { payment_intent: pi_id } }
+        .not_to change { wallet.reload.balance_cents }
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include('50')
+    end
+
+    # Le webhook crédite pile entre le check d'idempotence du contrôleur et
+    # l'appel à WalletService.top_up — c'est la course qui produisait le bug.
+    it 'ne crédite pas deux fois quand le webhook gagne la course pendant la requête' do
+      stub_succeeded_reload do
+        WalletService.top_up(wallet: wallet, amount_cents: 5000, stripe_payment_intent_id: pi_id)
+      end
+
+      expect { get '/customers/portefeuille/success', params: { payment_intent: pi_id } }
+        .to change { wallet.reload.balance_cents }.from(1000).to(6000)
+      expect(WalletTransaction.where(stripe_payment_intent_id: pi_id).count).to eq(1)
+      expect(response.body).to include('50')
+    end
+  end
 end

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -78,6 +78,34 @@ RSpec.describe 'Stripe webhook', type: :request do
     end
   end
 
+  # Recharge de portefeuille : le webhook et la page de retour Bancontact
+  # créditent tous deux la même recharge (#159).
+  describe 'wallet reload (payment_intent.succeeded)' do
+    let(:reload_pi_id) { "pi_reload_#{SecureRandom.hex(6)}" }
+    let!(:wallet) { create(:wallet, customer: customer, balance_cents: 1000) }
+
+    def fabricate_reload_event(amount: 5000)
+      pi = double('Stripe::PaymentIntent', id: reload_pi_id, amount: amount,
+                                           metadata: { 'customer_id' => customer.id.to_s, 'type' => 'wallet_reload' })
+      double('Stripe::Event', id: "evt_#{SecureRandom.hex(6)}", type: 'payment_intent.succeeded',
+                              data: double('event_data', object: pi))
+    end
+
+    it 'credits the wallet' do
+      expect { deliver(fabricate_reload_event) }
+        .to change { wallet.reload.balance_cents }.from(1000).to(6000)
+    end
+
+    # Événements distincts (la dédup StripeEvent ne joue pas), même PaymentIntent.
+    it 'ne recrédite pas quand le même PaymentIntent revient dans un autre événement' do
+      deliver(fabricate_reload_event)
+
+      expect { deliver(fabricate_reload_event) }.not_to change { wallet.reload.balance_cents }
+      expect(WalletTransaction.where(stripe_payment_intent_id: reload_pi_id).count).to eq(1)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe 'refund failure (charge.refund.updated)' do
     def fabricate_refund_event(status:, failure_reason: 'expired_or_canceled_card')
       refund = double('Stripe::Refund', status: status, payment_intent: pi_id, failure_reason: failure_reason)

--- a/spec/services/wallet_service_spec.rb
+++ b/spec/services/wallet_service_spec.rb
@@ -23,6 +23,55 @@ RSpec.describe WalletService do
       WalletService.top_up(wallet: wallet, amount_cents: 2000, stripe_payment_intent_id: 'pi_123')
       expect(wallet.wallet_transactions.last.description).to include('20.0')
     end
+
+    it 'returns the created transaction' do
+      result = WalletService.top_up(wallet: wallet, amount_cents: 2000, stripe_payment_intent_id: 'pi_123')
+      expect(result).to eq(wallet.wallet_transactions.last)
+    end
+
+    # Le webhook Stripe et la page de retour Bancontact créditent tous deux la
+    # même recharge : le service doit rester idempotent (#159).
+    describe 'idempotence sur le stripe_payment_intent_id' do
+      def top_up!(pi_id = 'pi_dup')
+        WalletService.top_up(wallet: wallet, amount_cents: 2000, stripe_payment_intent_id: pi_id)
+      end
+
+      it 'ne crédite le portefeuille qu\'une seule fois' do
+        expect { 2.times { top_up! } }.to change { wallet.reload.balance_cents }.from(1000).to(3000)
+      end
+
+      it 'ne crée qu\'une seule transaction' do
+        expect { 2.times { top_up! } }.to change(WalletTransaction, :count).by(1)
+      end
+
+      it 'retourne la transaction déjà existante au second appel' do
+        expect(top_up!).to eq(top_up!)
+      end
+
+      # Course réelle : le check à l'intérieur du verrou ne voit pas encore la
+      # ligne concurrente, c'est l'index unique en base qui tranche.
+      it 'traite un ActiveRecord::RecordNotUnique comme « déjà traité »' do
+        existing = wallet.credit!(2000, type: :top_up, stripe_payment_intent_id: 'pi_race')
+        allow(WalletService).to receive(:existing_top_up).and_return(nil, existing)
+
+        expect { top_up!('pi_race') }.not_to change { wallet.reload.balance_cents }
+        expect(WalletTransaction.where(stripe_payment_intent_id: 'pi_race').count).to eq(1)
+      end
+
+      it 'retourne la transaction existante après un RecordNotUnique' do
+        existing = wallet.credit!(2000, type: :top_up, stripe_payment_intent_id: 'pi_race')
+        allow(WalletService).to receive(:existing_top_up).and_return(nil, existing)
+
+        expect(top_up!('pi_race')).to eq(existing)
+      end
+    end
+
+    context 'without a stripe_payment_intent_id' do
+      it 'credits the wallet without deduplicating' do
+        expect { 2.times { WalletService.top_up(wallet: wallet, amount_cents: 500, stripe_payment_intent_id: nil) } }
+          .to change { wallet.reload.balance_cents }.from(1000).to(2000)
+      end
+    end
   end
 
   describe '.debit_for_order' do


### PR DESCRIPTION
Closes #159

## ⚠️ À faire AVANT de merger

**La base de prod contient probablement encore des doublons — la migration refusera de tourner tant qu'ils sont là** (c'est volontaire : voir plus bas). Nettoyer d'abord en console de prod, sinon le déploiement Hatchbox échouera sur la migration.

Le message d'erreur de la migration liste les PaymentIntents concernés et donne le snippet de réparation à copier-coller. Sur ma base de dev (dump récent), la garde a bien détecté 2 doublons réels :

```
  - pi_3TqIwWPr7x6Essmf0luzlO9O (2 lignes)
  - pi_3TZWiKPr7x6Essmf1XKs9OGR (2 lignes)
```

## Résumé

Le webhook Stripe et la page de retour Bancontact créditent tous deux la même recharge. Chacun faisait son check d'idempotence **avant** d'écrire, sans verrou ni contrainte en base : quand les deux arrivaient quasi simultanément, les deux checks passaient et le client était crédité deux fois.

Trois garde-fous, du plus rapide au plus solide :

1. **`WalletService.top_up` verrouille le portefeuille** (`wallet.with_lock`) — ça sérialise les deux chemins.
2. **Le check d'idempotence est refait à l'intérieur du verrou** — le second chemin voit la ligne du premier et ressort sans recréditer.
3. **Index unique partiel** sur `wallet_transactions.stripe_payment_intent_id` (`WHERE ... IS NOT NULL`) — filet de sécurité en base. Un `ActiveRecord::RecordNotUnique` est rattrapé et traité comme « déjà traité » (pas d'erreur, pas de 500).

`top_up` retourne désormais la `WalletTransaction` — celle qui vient d'être créée, ou celle qui existait déjà. `Wallet#credit!` retourne la transaction créée (au lieu du wallet) ; aucun appelant ne s'appuyait sur l'ancienne valeur de retour. `reload_success` s'appuie sur cette transaction pour afficher le bon montant même quand le webhook a gagné la course.

**Choix assumé — la migration ne répare pas les données.** L'issue demandait explicitement de ne pas écrire de migration de données. Elle contient donc une garde qui échoue tôt, avec la liste des PaymentIntents en double et le snippet de réparation, plutôt que de supprimer automatiquement des lignes qui portent de l'argent. Conséquence à connaître : tant que les doublons sont là, le déploiement échoue sur la migration.

**Écart avec la Definition of Done de l'issue** : elle demandait des commits sur `main`. Le run nocturne ne pousse jamais sur la branche par défaut (un push sur `main` déclenche un déploiement Hatchbox en prod) — d'où cette PR.

## 📸 Aperçu

Page de retour Bancontact dans **le scénario exact du bug** : le webhook a déjà crédité les 50 €, puis le client arrive sur la page de succès. Solde affiché **60 €** (10 + 50) — avant le fix, il aurait affiché 110 €.

![Page de retour Bancontact — 50 € crédités une seule fois (solde 60 €, pas 110 €)](https://github.com/les4sources/tranchesdevie2/raw/agent-screenshots/screenshots/20260727-034131-page-de-retour-bancontact--50--crdits-une-seule-.png)

## Testé

- **Suite complète** : `bundle exec rspec` → **952 exemples, 0 échec**.
- `bin/rubocop` → 463 fichiers, 0 offense.
- Brakeman → 1 avertissement, **préexistant et hors périmètre** (`app/services/party_reservation_service.rb:86`, advisory lock du parcours pizza party). Rien de neuf introduit. À noter : `bin/brakeman` ne scanne rien en l'état — le binstub injecte `--ensure-latest` et sort immédiatement parce que la version installée (7.1.0) n'est plus la dernière (8.0.5). J'ai donc lancé `bundle exec brakeman`. Ça vaut sans doute un bump du gem à part.
- **Service** : deux `top_up` avec le même PaymentIntent → un seul crédit, une seule transaction, la seconde retourne la transaction existante.
- **Service, chemin `RecordNotUnique`** : le check dans le verrou est stubbé pour rater, l'insert touche réellement l'index unique en base → pas de crédit, pas d'erreur, transaction existante retournée.
- **Webhook** : deux événements Stripe distincts portant le même PaymentIntent (la dédup `StripeEvent` ne joue donc pas) → un seul crédit, HTTP 200.
- **`reload_success`** : recharge normale ; recharge déjà encaissée ; et la course réelle — le webhook crédite pile entre le check du contrôleur et l'appel au service (simulé dans le stub de `Stripe::PaymentIntent.retrieve`) → un seul crédit, montant affiché correct.
- **Index partiel** : plusieurs transactions à `stripe_payment_intent_id` NULL coexistent (débits/remboursements de commande) ; deux transactions au même PI non-NULL lèvent `RecordNotUnique`.
- **Migration** : jouée sur la base de test (propre) → index posé, `db/schema.rb` commité. Garde vérifiée pour de vrai sur la base de dev, qui contient 2 doublons réels → elle refuse et affiche la liste + le remède.

## NON testé

- **`bin/rails db:migrate` n'a pas pu tourner sur ma base de dev** : elle contient les 2 doublons réels ci-dessus, et la garde l'a (correctement) bloquée. Je ne les ai pas supprimés — `tranchesdevie_development` est la base partagée avec ton repo de travail local, ce n'est pas à un run nocturne de trancher sur des lignes qui touchent à de l'argent. Le schéma vient donc de la base de test, structurellement identique.
- **Aucune vraie concurrence testée.** Les specs sérialisent les deux chemins ; RSpec tourne dans une transaction, donc on ne peut pas y observer deux connexions se disputer le verrou. Ce sont le verrou et l'index unique qui portent la garantie en prod — la logique est vérifiée, pas le parallélisme réel.
- **Aucun appel Stripe réel** : `PaymentIntent.retrieve` et les événements webhook sont des doubles.
- **Pas de test du parcours Bancontact de bout en bout** (redirection banque → retour), impossible sans compte Stripe de test piloté.
- **Rien vérifié en prod** : la migration n'y a pas été jouée, les doublons existants n'ont pas été réparés.
